### PR TITLE
[PAM-595] Set default sorting to 'updated' when query is missing or b…

### DIFF
--- a/src/sok/search/templates/searchTemplate.js
+++ b/src/sok/search/templates/searchTemplate.js
@@ -82,7 +82,16 @@ export function filterLocation(counties, municipals) {
 }
 
 export default function searchTemplate(query) {
-    const { q, from, sort, counties, municipals, heltidDeltid, engagementType } = query;
+    const { from, counties, municipals, heltidDeltid, engagementType } = query;
+    let { sort, q } = query;
+
+    /**
+     *  To ensure consistent search results across multiple shards in elasticsearch when query is blank
+     */
+    if (!q || q.trim().length === 0) {
+        sort = 'updated';
+        q = '';
+    }
 
     let template = {
         from: from || 0,
@@ -91,7 +100,7 @@ export default function searchTemplate(query) {
             bool: {
                 must: {
                     multi_match: {
-                        query: q || '',
+                        query: q,
                         fields: [
                             'title_no^2',
                             'category_no^2',
@@ -107,7 +116,7 @@ export default function searchTemplate(query) {
                 should: {
                     match_phrase: {
                         title: {
-                            query: q || '',
+                            query: q,
                             slop: 3
                         }
                     }
@@ -155,7 +164,7 @@ export default function searchTemplate(query) {
                 },
                 aggs: {
                     values: {
-                        terms: {field: 'extent_facet'}
+                        terms: { field: 'extent_facet' }
                     }
                 }
             },
@@ -235,4 +244,3 @@ export default function searchTemplate(query) {
 
     return template;
 }
-


### PR DESCRIPTION
…lank (full search).

This will ensure a consistent set of results, across multiple shards in elasticsearch,
see https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-is-broken.html