### PR TITLE
Fjerner dokumentasjon om gammelt søkegrensesnitt fra readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,6 @@ Jenkins       | http://a34apvl00015.devillo.no:8080/
 Fasit         | https://fasit.adeo.no/applications/edit?1&application=2372388
 Kibana        | https://logs.adeo.no/app/kibana
 
-## Søk grensesnitt
-
-Beskrivelse   | URL
---------------|------------------------------------------------------------------
-Søkeresultat  | http://localhost:1337/rest/stillingsok/stillinger
-neste side    | http://localhost:1337/rest/stillingsok/stillinger?p=1
-antall treff per side | http://localhost:1337/rest/stillingsok/stillinger?p=1&rpp=25
-sortering | &sort=frist, &sort=akt, &sort=tittel
-visning |  http://localhost:1337/rest/stillingsok/stillinger/{annonseid}
-arbeidsgiver | http://localhost:1337/rest/stillingsok/stillinger/{annonseid}/arbeidsgiver
-stillingstype yrker | http://localhost:1337/rest/stillingsok/yrker/stillingstype
-geografi steder | http://localhost:1337/rest/stillingsok/steder/geografi
 
 
 


### PR DESCRIPTION
Dette er gammel dokumentasjon som beskriver hvordan man kan søke mot nåværende stillingsbase på nav.no