### PR TITLE
Fikser kontrast på grønn tekst

### DIFF
--- a/src/search/searchResults/SearchResultsCount.less
+++ b/src/search/searchResults/SearchResultsCount.less
@@ -1,7 +1,6 @@
 @import '../../variables';
 
 .SearchResultsCount {
-  color: @color-green;
   margin: 0 0 1rem 0;
   line-height: 1.75rem;
 }

--- a/src/styles.less
+++ b/src/styles.less
@@ -20,6 +20,7 @@ body {
   min-height: 100%;
   overflow-y: scroll;
   background: #F6F5F5;
+  color: @navMorkGra;
 }
 
 #topbar {


### PR DESCRIPTION
Grønn tekstfarge på lysegrønn eller lysegrå bakgrunn har ikke nok kontrast.
Gjør derfor om teksen "340 treff" til standard tekstfarge.