### PR TITLE
[Feature] Dynamisk sidetittel

### DIFF
--- a/src/search/Search.js
+++ b/src/search/Search.js
@@ -24,6 +24,7 @@ class Search extends React.Component {
     }
 
     componentDidMount() {
+        document.title = 'Ledige stillinger';
         const top = this.props.scrollPosition;
         setTimeout(() => {
             window.scrollTo(0, top);

--- a/src/stilling/Stilling.js
+++ b/src/stilling/Stilling.js
@@ -21,8 +21,23 @@ import './Stilling.less';
 const arrayHasData = (array) => array && array[0].hasOwnProperty('punkt');
 
 class Stilling extends React.Component {
+    constructor(props) {
+        super(props);
+        this.hasSetTitle = false;
+    }
+
     componentDidMount() {
         this.props.getStilling(this.props.match.params.uuid);
+    }
+
+    componentDidUpdate() {
+        if (!this.hasSetTitle
+            && this.props.stilling
+            && this.props.stilling._source
+            && this.props.stilling._source.title) {
+            document.title = this.props.stilling._source.title;
+            this.hasSetTitle = true;
+        }
     }
 
     render() {


### PR DESCRIPTION
Har fått tilbakemelding fra bruker om at alle sider har samme sidetittel (navnet som vises i browserfanen). Det er et problem at alle stillinger får tittelen "Ledige stillinger" når man feks bookmarker en stilling. Har derfor gjort det slik at er bare søkesiden som har "Ledige stillinger", mens selve stillingssiden bruker annonseoverskrift som sidetittel