### PR TITLE
[PAM-924]: Små bokstaver i fylke og kommune

### DIFF
--- a/src/search/facets/counties/Counties.js
+++ b/src/search/facets/counties/Counties.js
@@ -37,7 +37,7 @@ class Counties extends React.Component {
         const separators = [
             ' ', // NORDRE LAND skal bli Nordre Land
             '-', // AUST-AGDER skal bli Aust-Agder
-            '(' // HERØY (MØRE OG ROMSDAL) skal bli Herøy (Møre og Romsdal)
+            '(' // BØ (TELEMARK) skal bli Bø (Telemark)
         ];
 
         const ignore = [


### PR DESCRIPTION
Fylke og kommune i fasettlisten er i store bokstaver. Det mest optimale fix'en ville vært å endre kildedataene, men har ikke gjort det i denne løsningen, da det er uklart om dette kan gjøres. Derfor transformerer vi heller til små bokstaver i front-endkoden.