### PR TITLE
[Bugfix] Fjerner duplikate annonser når man trykker "Se flere"

### DIFF
--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -1,6 +1,9 @@
-import { call, put, select, takeLatest, throttle } from 'redux-saga/effects';
-import { fetchSearch, SearchApiError } from '../api/api';
-import { fromUrl, ParameterType, toUrl } from './url';
+import { select, call, put, takeLatest, throttle } from 'redux-saga/effects';
+import {
+    SearchApiError,
+    fetchSearch
+} from '../api/api';
+import { fromUrl, toUrl, ParameterType } from './url';
 
 export const SET_INITIAL_STATE = 'SET_INITIAL_STATE';
 export const INITIAL_SEARCH = 'INITIAL_SEARCH';


### PR DESCRIPTION
Det har vært et issue at det dukker opp treff fra feks Oslo når man deretter velger feks Bamle. Dette skyldes at man har trykket "Se flere" på Oslo, og det har blitt lastet inn duplikate annonser. Man kan få duplkate annonser når man pager, siden backend returnerer treff fra flere søkeindexer. Duplikate annonser skaper trøbbel for react, og duplikater fjernes ikke fra DOM. Fix'en er derfor å droppe eventuelle duplikater i frontend'en.