### PR TITLE
[Feature] Flytter arbeidsgiver inn i egen kolonne i trefflisten

### DIFF
--- a/src/search/searchResults/SearchResultsItem.js
+++ b/src/search/searchResults/SearchResultsItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Row, Column } from 'nav-frontend-grid';
-import { Undertittel, Normaltekst } from 'nav-frontend-typografi';
+import { Undertittel, Normaltekst, Undertekst } from 'nav-frontend-typografi';
 import { formatISOString } from '../../utils';
 import { STILLING } from '../../fasitProperties';
 import './SearchResultsItem.less';
@@ -24,23 +24,28 @@ export default class SearchResultItem extends React.Component {
                 className="SearchResultItem"
                 to={`${STILLING}${stilling.uuid}`}
             >
-                <Row>
-                    <Column xs="12">
-                        {stilling.updated && (
-                            <Normaltekst className="SearchResultItem__updated">
-                                {formatISOString(stilling.updated, 'D. MMMM YYYY')}
+                <Row className="SearchResultItem__row">
+                    <Column xs="12" md="4">
+                        {stilling.properties.employer && (
+                            <Normaltekst className="SearchResultItem__employer">
+                                {stilling.properties.employer}
                             </Normaltekst>
+                        )}
+                    </Column>
+                    <Column xs="12" md="8">
+                        {stilling.updated && (
+                            <Undertekst className="SearchResultItem__updated">
+                                {formatISOString(stilling.updated, 'D. MMMM YYYY')}
+                            </Undertekst>
                         )}
 
                         <Undertittel tag="h3" className="SearchResultItem__title">{stilling.title}</Undertittel>
 
                         {stilling.properties.jobtitle && stilling.title !== stilling.properties.jobtitle && (
-                            <Normaltekst className="SearchResultItem__jobtitle">{stilling.properties.jobtitle}</Normaltekst>
-                        )}
-
-                        {stilling.properties.employer && (
-                            <Normaltekst className="SearchResultItem__employer">
-                                {stilling.properties.employer}
+                            <Normaltekst
+                                className="SearchResultItem__jobtitle"
+                            >
+                                {stilling.properties.jobtitle}
                             </Normaltekst>
                         )}
 

--- a/src/search/searchResults/SearchResultsItem.less
+++ b/src/search/searchResults/SearchResultsItem.less
@@ -2,7 +2,7 @@
 
 .SearchResultItem {
   background-color: #fff;
-  padding: 1rem 2rem 1.5rem 2rem;
+  padding: 1rem 2rem;
   display: block;
   text-decoration: none;
   color: @navMorkGra;
@@ -19,6 +19,10 @@
     color: @navGronn;
     border-color: transparent;
   }
+}
+
+.SearchResultItem__employer {
+  padding-right: 1rem;
 }
 
 .SearchResultItem__updated {
@@ -45,7 +49,19 @@
   }
 
   .SearchResultItem__updated,
-  .SearchResultItem__title {
-    margin-bottom: 0.5rem;
+  .SearchResultItem__employer {
+    margin-bottom: 1rem;
+  }
+
+  .SearchResultItem__updated {
+    margin-bottom: 0;
+
+  }
+}
+
+@media (min-width: @screen-md-min) {
+  .SearchResultItem__row {
+    display: flex;
+    align-items: center;
   }
 }


### PR DESCRIPTION
lere tilbakemeldinger på at det er vanskleig å scanne trefflisten. Gjør derfor om til slik det var opprinnelig med arbeidsgivernavn i en egen kolonne på venstre side i treff listen.