### PR TITLE
[Bugfix] Sørger for at søketreff ivaretas når bruker går ut av en annonseside

### DIFF
--- a/src/search/Search.js
+++ b/src/search/Search.js
@@ -12,7 +12,7 @@ import EngagementType from './facets/engagement/Engagement';
 import Sector from './facets/sector/Sector';
 import Published from './facets/published/Published';
 import SearchBox from './searchBox/SearchBox';
-import { INITIAL_SEARCH, KEEP_SCROLL_POSITION, SEARCH } from './searchReducer';
+import { RESTORE_STATE_FROM_URL, INITIAL_SEARCH, KEEP_SCROLL_POSITION, SEARCH } from './searchReducer';
 import BackToTop from './backToTopButton/BackToTop';
 import Disclaimer from '../discalimer/Disclaimer';
 import './Search.less';
@@ -20,6 +20,7 @@ import './Search.less';
 class Search extends React.Component {
     constructor(props) {
         super(props);
+        this.props.restoreStateFromUrl();
         this.props.initialSearch();
     }
 
@@ -99,6 +100,7 @@ Search.defaultProps = {
 };
 
 Search.propTypes = {
+    restoreStateFromUrl: PropTypes.func.isRequired,
     initialSearch: PropTypes.func.isRequired,
     search: PropTypes.func.isRequired,
     hasError: PropTypes.bool.isRequired,
@@ -112,6 +114,7 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
+    restoreStateFromUrl: () => dispatch({ type: RESTORE_STATE_FROM_URL }),
     initialSearch: () => dispatch({ type: INITIAL_SEARCH }),
     search: () => dispatch({ type: SEARCH }),
     keepScrollPosition: (scrollPosition) => dispatch({ type: KEEP_SCROLL_POSITION, scrollPosition })

--- a/src/search/searchResults/SearchResults.js
+++ b/src/search/searchResults/SearchResults.js
@@ -5,11 +5,12 @@ import SearchResultItem from './SearchResultsItem';
 import SearchResultsCount from './SearchResultsCount';
 import Pagination from '../pagination/Pagination';
 import NoResults from '../noResults/NoResults';
-import { PAGE_SIZE } from '../searchReducer';
+import { PAGE_SIZE, toUrlQuery } from '../searchReducer';
+import { toUrl } from '../url';
 import './SearchResults.less';
 
 function SearchResults({
-    searchResult, isSearching, restoreFocusToUuid, page, total
+    searchResult, isSearching, restoreFocusToUuid, page, total, urlQuery
 }) {
     const { stillinger } = searchResult;
     const totalPages = total / PAGE_SIZE;
@@ -25,6 +26,7 @@ function SearchResults({
                 <SearchResultItem
                     key={stilling.uuid}
                     stilling={stilling}
+                    urlQuery={urlQuery}
                     shouldFocus={stilling.uuid === restoreFocusToUuid}
                 />
             ))}
@@ -65,7 +67,8 @@ SearchResults.propTypes = {
     isSearching: PropTypes.bool.isRequired,
     restoreFocusToUuid: PropTypes.string,
     page: PropTypes.number.isRequired,
-    total: PropTypes.number.isRequired
+    total: PropTypes.number.isRequired,
+    urlQuery: PropTypes.string.isRequired
 };
 
 const mapStateToProps = (state) => ({
@@ -73,7 +76,8 @@ const mapStateToProps = (state) => ({
     searchResult: state.search.searchResult,
     restoreFocusToUuid: state.focus.restoreFocusToUuid,
     page: state.search.page,
-    total: state.search.searchResult.total
+    total: state.search.searchResult.total,
+    urlQuery: toUrl(toUrlQuery(state))
 });
 
 export default connect(mapStateToProps)(SearchResults);

--- a/src/search/searchResults/SearchResultsItem.js
+++ b/src/search/searchResults/SearchResultsItem.js
@@ -15,14 +15,14 @@ export default class SearchResultItem extends React.Component {
     }
 
     render() {
-        const { stilling } = this.props;
+        const { stilling, urlQuery } = this.props;
         return (
             <Link
                 innerRef={(link) => {
                     this.link = link;
                 }}
                 className="SearchResultItem"
-                to={`${STILLING}${stilling.uuid}`}
+                to={`${STILLING}${stilling.uuid}${urlQuery}`}
             >
                 <Row className="SearchResultItem__row">
                     <Column xs="12" md="4">
@@ -62,7 +62,8 @@ export default class SearchResultItem extends React.Component {
 }
 
 SearchResultItem.defaultProps = {
-    shouldFocus: false
+    shouldFocus: false,
+    urlQuery: ''
 };
 
 SearchResultItem.propTypes = {
@@ -76,5 +77,6 @@ SearchResultItem.propTypes = {
             updated: PropTypes.string
         })
     }).isRequired,
-    shouldFocus: PropTypes.bool
+    shouldFocus: PropTypes.bool,
+    urlQuery: PropTypes.string
 };

--- a/src/stilling/Stilling.js
+++ b/src/stilling/Stilling.js
@@ -12,7 +12,7 @@ import NotFound from './NotFound';
 import SearchError from '../search/error/SearchError';
 import Expired from './Expired';
 import BackToSearch from './backToSearch/BackToSearch';
-import { toUrlQuery } from "../search/searchReducer";
+import { RESTORE_STATE_FROM_URL, toUrlQuery } from '../search/searchReducer';
 import Disclaimer from '../discalimer/Disclaimer';
 import Loading from './loading/Loading';
 import { toUrl } from '../search/url';
@@ -27,13 +27,15 @@ class Stilling extends React.Component {
     constructor(props) {
         super(props);
         this.hasSetTitle = false;
+        this.props.restoreStateFromUrl();
     }
 
     componentDidMount() {
         window.scrollTo(0, 0);
         this.props.getStilling(this.props.match.params.uuid);
     }
-componentDidUpdate() {
+
+    componentDidUpdate() {
         if (!this.hasSetTitle
             && this.props.stilling
             && this.props.stilling._source
@@ -43,13 +45,15 @@ componentDidUpdate() {
         }
     }
     render() {
-        const { stilling, cachedStilling, isFetchingStilling, error, state } = this.props;
+        const {
+            stilling, cachedStilling, isFetchingStilling, error, urlQuery
+        } = this.props;
         return (
             <div>
                 <Disclaimer />
                 <div className="background--light-green">
                     <Container>
-                        <BackToSearch urlQuery={toUrl(toUrlQuery(state))} />
+                        <BackToSearch urlQuery={urlQuery} />
                     </Container>
                 </div>
                 {error && error.statusCode === 404 ? (
@@ -161,7 +165,8 @@ componentDidUpdate() {
 Stilling.defaultProps = {
     stilling: undefined,
     cachedStilling: undefined,
-    isFetchingStilling: false
+    isFetchingStilling: false,
+    urlQuery: ''
 };
 
 Stilling.propTypes = {
@@ -177,8 +182,10 @@ Stilling.propTypes = {
     cachedStilling: PropTypes.shape({
         title: PropTypes.string
     }),
+    restoreStateFromUrl: PropTypes.func.isRequired,
     getStilling: PropTypes.func.isRequired,
-    isFetchingStilling: PropTypes.bool
+    isFetchingStilling: PropTypes.bool,
+    urlQuery: PropTypes.string
 };
 
 const mapStateToProps = (state) => ({
@@ -186,10 +193,11 @@ const mapStateToProps = (state) => ({
     stilling: state.stilling.stilling,
     cachedStilling: state.stilling.cachedStilling,
     error: state.stilling.error,
-    state: state
+    urlQuery: toUrl(toUrlQuery(state))
 });
 
 const mapDispatchToProps = (dispatch) => ({
+    restoreStateFromUrl: () => dispatch({ type: RESTORE_STATE_FROM_URL }),
     getStilling: (uuid) => dispatch({ type: FETCH_STILLING_BEGIN, uuid })
 });
 

--- a/src/stilling/backToSearch/BackToSearch.js
+++ b/src/stilling/backToSearch/BackToSearch.js
@@ -65,7 +65,7 @@ export default class BackToSearch extends React.Component {
     };
 
     render() {
-        return this.props.urlQuery ? (
+        return (
             <div className="BackToSearch">
                 <div
                     ref={(inlineBackButton) => { this.inlineBackButton = inlineBackButton; }}
@@ -81,7 +81,7 @@ export default class BackToSearch extends React.Component {
                     </div>
                 )}
             </div>
-        ) : null;
+        );
     }
 }
 


### PR DESCRIPTION
Nå forsvinner søketreffene når man går ut av annonsesiden, feks inn på Send søknad. Når man trykker tilbake, så må man da krysse av og søke på nytt. Legger derfor til url query (?q=java&sector=Offentlig) også på selve annonse siden, slik at søket kan gjenskapes når bruker kommer tilbake.