### PR TITLE
[PAM-1567] Legge til skjemagruppe ved opprettelse av nytt søk fra et …

### DIFF
--- a/src/savedSearches/form/AddOrReplaceForm.js
+++ b/src/savedSearches/form/AddOrReplaceForm.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { Checkbox, Fieldset, Input, Radio, SkjemaGruppe } from 'nav-frontend-skjema';
+import NotifyTypeEnum from '../enums/NotifyTypeEnum';
+import {
+    SET_SAVED_SEARCH_DURATION,
+    SET_SAVED_SEARCH_NOTIFY_TYPE,
+    SET_SAVED_SEARCH_TITLE
+} from './savedSearchFormReducer';
+import './SavedSearchForm.less';
+
+class AddOrReplaceForm extends React.Component {
+    onTitleChange = (e) => {
+        this.props.setTitle(e.target.value);
+    };
+
+    onSubscribeChange = (e) => {
+        if (e.target.checked) {
+            this.props.setNotifyType(NotifyTypeEnum.EMAIL);
+        } else {
+            this.props.setNotifyType(NotifyTypeEnum.NONE);
+        }
+    };
+
+    onDurationChange = (e) => {
+        this.props.setDuration(e.target.value);
+    };
+
+    render() {
+        const { formData, validation } = this.props;
+        return (
+            <div>
+                <Input
+                    className="SavedSearchModal__body__name"
+                    label="Navn*"
+                    onChange={this.onTitleChange}
+                    value={formData.title}
+                    feil={!validation.titleIsValid ?
+                        { feilmelding: 'Du må gi et navn på søket' } :
+                        undefined
+                    }
+                />
+                <Checkbox
+                    className="SavedSearchModal__body__notify"
+                    label="Ja, jeg ønsker å motta varsler om nye treff på e-post"
+                    onChange={this.onSubscribeChange}
+                    checked={formData.notifyType === NotifyTypeEnum.EMAIL}
+                />
+                {formData.notifyType === NotifyTypeEnum.EMAIL && (
+                    <SkjemaGruppe>
+                        <Fieldset legend="Varighet på varsel:">
+                            <Radio
+                                label="30 dager"
+                                className="SavedSearchModal__body__duration"
+                                name="duration"
+                                key="30dager"
+                                value="30"
+                                onChange={this.onDurationChange}
+                                checked={formData.duration === 30}
+                            />
+                            <Radio
+                                label="60 dager"
+                                className="SavedSearchModal__body__duration"
+                                name="duration"
+                                key="60dager"
+                                value="60"
+                                onChange={this.onDurationChange}
+                                checked={formData.duration === 60}
+                            />
+                            <Radio
+                                label="90 dager"
+                                className="SavedSearchModal__body__duration"
+                                name="duration"
+                                key="90dager"
+                                value="90"
+                                onChange={this.onDurationChange}
+                                checked={formData.duration === 90}
+                            />
+                        </Fieldset>
+                    </SkjemaGruppe>
+                )}
+            </div>
+        );
+    }
+}
+
+AddOrReplaceForm.defaultProps = {
+    formData: undefined
+};
+
+AddOrReplaceForm.propTypes = {
+    setTitle: PropTypes.func.isRequired,
+    setNotifyType: PropTypes.func.isRequired,
+    setDuration: PropTypes.func.isRequired,
+    formData: PropTypes.shape({
+        title: PropTypes.string
+    }),
+    validation: PropTypes.shape({
+        titleIsValid: PropTypes.bool
+    }).isRequired
+};
+
+const mapStateToProps = (state) => ({
+    formData: state.savedSearchForm.formData,
+    validation: state.savedSearchForm.validation
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    setTitle: (title) => dispatch({ type: SET_SAVED_SEARCH_TITLE, title }),
+    setNotifyType: (notifyType) => dispatch({ type: SET_SAVED_SEARCH_NOTIFY_TYPE, notifyType }),
+    setDuration: (duration) => dispatch({ type: SET_SAVED_SEARCH_DURATION, duration })
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(AddOrReplaceForm);

--- a/src/savedSearches/form/SavedSearchForm.js
+++ b/src/savedSearches/form/SavedSearchForm.js
@@ -1,40 +1,21 @@
 import { Hovedknapp } from 'nav-frontend-knapper';
 import Modal from 'nav-frontend-modal';
-import { Checkbox, Fieldset, Input, Radio, SkjemaGruppe } from 'nav-frontend-skjema';
+import { Fieldset, Radio, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Undertittel } from 'nav-frontend-typografi';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import Lenkeknapp from '../../common/Lenkeknapp';
-import NotifyTypeEnum from '../enums/NotifyTypeEnum';
 import { ADD_SAVED_SEARCH, UPDATE_SAVED_SEARCH } from '../savedSearchesReducer';
 import './SavedSearchForm.less';
 import {
     HIDE_SAVED_SEARCH_FORM,
     SavedSearchFormMode,
-    SET_SAVED_SEARCH_DURATION,
-    SET_SAVED_SEARCH_FORM_MODE,
-    SET_SAVED_SEARCH_NOTIFY_TYPE,
-    SET_SAVED_SEARCH_TITLE
+    SET_SAVED_SEARCH_FORM_MODE
 } from './savedSearchFormReducer';
+import AddOrReplaceForm from './AddOrReplaceForm';
 
 class SavedSearchForm extends React.Component {
-    onTitleChange = (e) => {
-        this.props.setTitle(e.target.value);
-    };
-
-    onSubscribeChange = (e) => {
-        if (e.target.checked) {
-            this.props.setNotifyType(NotifyTypeEnum.EMAIL);
-        } else {
-            this.props.setNotifyType(NotifyTypeEnum.NONE);
-        }
-    };
-
-    onDurationChange = (e) => {
-        this.props.setDuration(e.target.value);
-    };
-
     onFormModeChange = (e) => {
         this.props.setFormMode(e.target.value);
     };
@@ -53,7 +34,7 @@ class SavedSearchForm extends React.Component {
 
     render() {
         const {
-            showSavedSearchForm, formData, validation, isSaving, formMode, cancelButtonText, currentSavedSearch, showAddOrReplace
+            showSavedSearchForm, isSaving, formMode, cancelButtonText, currentSavedSearch, showAddOrReplace
         } = this.props;
 
         if (showSavedSearchForm) {
@@ -105,51 +86,14 @@ class SavedSearchForm extends React.Component {
                         )}
                         {!(showAddOrReplace && formMode === SavedSearchFormMode.EDIT) && (
                             <div className="SavedSearchModal__body">
-                                <Input
-                                    className="SavedSearchModal__body__name"
-                                    label="Navn*"
-                                    onChange={this.onTitleChange}
-                                    value={formData.title}
-                                    feil={!validation.titleIsValid ?
-                                        { feilmelding: 'Du må gi et navn på søket' } :
-                                        undefined
-                                    }
-                                />
-                                <Checkbox
-                                    className="SavedSearchModal__body__notify"
-                                    label="Ja, jeg ønsker å motta varsler om nye treff på e-post"
-                                    onChange={this.onSubscribeChange}
-                                    checked={formData.notifyType === NotifyTypeEnum.EMAIL}
-                                />
-                                {formData.notifyType === NotifyTypeEnum.EMAIL && (
+                                {showAddOrReplace ? (
                                     <SkjemaGruppe>
-                                        <Fieldset legend="Varighet på varsel:">
-                                            <Radio
-                                                label="30 dager"
-                                                name="duration"
-                                                key="30dager"
-                                                value="30"
-                                                onChange={this.onDurationChange}
-                                                checked={formData.duration === 30}
-                                            />
-                                            <Radio
-                                                label="60 dager"
-                                                name="duration"
-                                                key="60dager"
-                                                value="60"
-                                                onChange={this.onDurationChange}
-                                                checked={formData.duration === 60}
-                                            />
-                                            <Radio
-                                                label="90 dager"
-                                                name="duration"
-                                                key="90dager"
-                                                value="90"
-                                                onChange={this.onDurationChange}
-                                                checked={formData.duration === 90}
-                                            />
+                                        <Fieldset legend="Lagre nytt søk">
+                                            <AddOrReplaceForm />
                                         </Fieldset>
                                     </SkjemaGruppe>
+                                ) : (
+                                    <AddOrReplaceForm />
                                 )}
                             </div>
                         )}
@@ -173,7 +117,6 @@ class SavedSearchForm extends React.Component {
 }
 
 SavedSearchForm.defaultProps = {
-    formData: undefined,
     currentSavedSearch: undefined
 };
 
@@ -183,29 +126,18 @@ SavedSearchForm.propTypes = {
     showSavedSearchForm: PropTypes.bool.isRequired,
     addSavedSearch: PropTypes.func.isRequired,
     updateSavedSearch: PropTypes.func.isRequired,
-    setTitle: PropTypes.func.isRequired,
-    setNotifyType: PropTypes.func.isRequired,
-    setDuration: PropTypes.func.isRequired,
     setFormMode: PropTypes.func.isRequired,
     hideForm: PropTypes.func.isRequired,
     formMode: PropTypes.string.isRequired,
     cancelButtonText: PropTypes.string.isRequired,
     currentSavedSearch: PropTypes.shape({
         title: PropTypes.string
-    }),
-    formData: PropTypes.shape({
-        title: PropTypes.string
-    }),
-    validation: PropTypes.shape({
-        titleIsValid: PropTypes.bool
-    }).isRequired
+    })
 };
 
 const mapStateToProps = (state) => ({
     showSavedSearchForm: state.savedSearchForm.showSavedSearchForm,
     formMode: state.savedSearchForm.formMode,
-    formData: state.savedSearchForm.formData,
-    validation: state.savedSearchForm.validation,
     cancelButtonText: state.savedSearchForm.cancelButtonText,
     showAddOrReplace: state.savedSearchForm.showAddOrReplace,
     currentSavedSearch: state.savedSearches.currentSavedSearch,
@@ -215,9 +147,6 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
     addSavedSearch: () => dispatch({ type: ADD_SAVED_SEARCH }),
     updateSavedSearch: () => dispatch({ type: UPDATE_SAVED_SEARCH }),
-    setTitle: (title) => dispatch({ type: SET_SAVED_SEARCH_TITLE, title }),
-    setNotifyType: (notifyType) => dispatch({ type: SET_SAVED_SEARCH_NOTIFY_TYPE, notifyType }),
-    setDuration: (duration) => dispatch({ type: SET_SAVED_SEARCH_DURATION, duration }),
     setFormMode: (formMode) => dispatch({ type: SET_SAVED_SEARCH_FORM_MODE, formMode }),
     hideForm: () => dispatch({ type: HIDE_SAVED_SEARCH_FORM })
 });

--- a/src/savedSearches/form/SavedSearchForm.less
+++ b/src/savedSearches/form/SavedSearchForm.less
@@ -52,3 +52,13 @@
     margin-right: 2rem;
   }
 }
+
+@media (min-width: 450px) {
+  .SavedSearchModal__body__duration {
+    display: inline;
+
+    &:not(:last-child) {
+      margin-right: 2rem;
+    }
+  }
+}

--- a/src/savedSearches/form/savedSearchFormReducer.js
+++ b/src/savedSearches/form/savedSearchFormReducer.js
@@ -18,6 +18,7 @@ export const SET_SAVED_SEARCH_TITLE = 'SET_SAVED_SEARCH_TITLE';
 export const SET_SAVED_SEARCH_NOTIFY_TYPE = 'SET_SAVED_SEARCH_NOTIFY_TYPE';
 export const SET_SAVED_SEARCH_DURATION = 'SET_SAVED_SEARCH_DURATION';
 export const SET_SAVED_SEARCH_QUERY = 'SET_SAVED_SEARCH_QUERY';
+export const SET_TITLE_VALIDATION = 'SET_TITLE_VALIDATION';
 
 export const SavedSearchFormMode = {
     ADD: 'ADD',
@@ -72,10 +73,6 @@ export default function savedSearchFormReducer(state = initialState, action) {
                 formData: {
                     ...state.formData,
                     title: action.title
-                },
-                validation: {
-                    ...state.validation,
-                    titleIsValid: action.title.trim().length > 0
                 }
             };
         }
@@ -106,9 +103,27 @@ export default function savedSearchFormReducer(state = initialState, action) {
                 }
             };
         }
+        case SET_TITLE_VALIDATION:
+            return {
+                ...state,
+                validation: {
+                    ...state.validation,
+                    titleIsValid: action.titleIsValid
+                }
+            };
         default:
             return state;
     }
+}
+
+function* validateTitle() {
+    const state = yield select();
+    const titleIsValid = state.savedSearchForm.formData.title.trim().length > 0;
+    yield put({ type: SET_TITLE_VALIDATION, titleIsValid });
+}
+
+export function* validateAll() {
+    yield validateTitle();
 }
 
 function toQuery(state) {
@@ -179,6 +194,7 @@ function* setDefaultFormData(action) {
 }
 
 export const savedSearchFormSaga = function* saga() {
+    yield takeLatest(SET_SAVED_SEARCH_TITLE, validateAll);
     yield takeLatest(SHOW_SAVED_SEARCH_FORM, setDefaultFormData);
     yield takeLatest(SET_SAVED_SEARCH_FORM_MODE, setDefaultFormData);
 };

--- a/src/savedSearches/savedSearchesReducer.js
+++ b/src/savedSearches/savedSearchesReducer.js
@@ -5,6 +5,7 @@ import { USER_UUID_HACK } from '../favourites/favouritesReducer';
 import { RESET_SEARCH } from '../search/searchReducer';
 import { fromUrl } from '../search/url';
 import { RESTORE_STATE_FROM_URL, SEARCH_PARAMETERS_DEFINITION } from '../urlReducer';
+import { validateAll } from './form/savedSearchFormReducer';
 
 export const FETCH_SAVED_SEARCHES = 'FETCH_SAVED_SEARCHES';
 export const FETCH_SAVED_SEARCHES_BEGIN = 'FETCH_SAVED_SEARCHES_BEGIN';
@@ -178,6 +179,7 @@ function* removeSavedSearch(action) {
 }
 
 function* updateSavedSearch() {
+    yield validateAll();
     const state = yield select();
     if (state.savedSearchForm.validation.titleIsValid) {
         try {
@@ -201,6 +203,7 @@ function* updateSavedSearch() {
 }
 
 function* addSavedSearch() {
+    yield validateAll();
     const state = yield select();
     if (state.savedSearchForm.validation.titleIsValid) {
         try {


### PR DESCRIPTION
…allerede lagret

[PAM-1567] Oppdatere validering

Brukerhistorie/beskrivelse og skisser
- Lagre et søk,
- gjør endringer på søkekriterier, legg feks til et fylke
- trykk Lagre søk på nytt
- nå skal man få valg om å Lagre endringer eller Lagre nytt søk i modal som vises

Når man velger radiobutton lagre nytt søk, så skal den delen av skjemet som da kommer opp være wrappet i en skjemagruppe (legend = "Lagre nytt søk")

Men denne skjemagruppen/legend skal ikke være der om man oppretter en nytt søk fra scratch

Se https://app.zeplin.io/project/598323bd8e79174fbfc9a5be/screen/5b7c0616a29fbb5ecf99d24c