### PR TITLE
[PAM-1360] Fikser bool filter for fylke og kommune

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -101,7 +101,8 @@ export async function fetchSearch(query = {}) {
             key: county.key,
             count: county.doc_count,
             municipals: county.municipals.buckets.map((municipal) => ({
-                key: municipal.key,
+                key: `${county.key}.${municipal.key}`,
+                label: municipal.key,
                 count: municipal.doc_count
             }))
         })),
@@ -109,7 +110,8 @@ export async function fetchSearch(query = {}) {
             key: firstLevel.key,
             count: firstLevel.doc_count,
             occupationSecondLevels: firstLevel.occupationSecondLevels.buckets.map((secondLevel) => ({
-                key: secondLevel.key,
+                key: `${firstLevel.key}.${secondLevel.key}`,
+                label: secondLevel.key,
                 count: secondLevel.doc_count
             }))
         })),

--- a/src/api/templates/searchTemplate.js
+++ b/src/api/templates/searchTemplate.js
@@ -51,63 +51,58 @@ export function filterEngagementType(engagementTypes) {
     return filters;
 }
 
+/**
+ * Lager filter for fasetter med flere nivå, feks fylke og kommune. Kobinerer AND og OR.
+ * Feks (Akershus) OR (Buskerud) hvis man bare har valgt disse to fylkene.
+ * Feks (Akershus AND Asker) OR (Buskerud AND Drammen) om man ser etter jobb i Asker og Drammen
+ * Feks (Akershus) OR (Buskerud AND Drammen) om man ser etter jobb i hele Akershus fylke, men også i Drammen kommune.
+ */
+export function filterNestedFacets(parents, children = [], parentKey, childKey) {
+    let allMusts = [];
+    if (parents && parents.length > 0) {
+        parents.forEach((parent) => {
+            let must = [{
+                match: {
+                    [parentKey]: parent
+                }
+            }];
+
+            const childrenOfCurrentParent = children.filter((m) => (m.split('.')[0] === parent));
+            if (childrenOfCurrentParent.length > 0) {
+                must = [...must, {
+                    bool: {
+                        should: childrenOfCurrentParent.map((child) => ({
+                            term: {
+                                [childKey]: child.split('.')[1] // child kan feks være AKERSHUS.ASKER
+                            }
+                        }))
+                    }
+                }];
+            }
+
+            allMusts = [...allMusts, must];
+        });
+    }
+
+    return {
+        bool: {
+            should: allMusts.map((must) => ({
+                bool: {
+                    must
+                }
+            }))
+        }
+    };
+}
+
 export function filterLocation(counties, municipals) {
-    const filters = {
-        bool: {
-            should: []
-        }
-    };
-    if (counties && counties.length > 0) {
-        counties.forEach((county) => {
-            filters.bool.should.push({
-                term: {
-                    county_facet: county
-                }
-            });
-        });
-    }
-
-    if (municipals && municipals.length > 0) {
-        municipals.forEach((municipal) => {
-            filters.bool.should.push({
-                term: {
-                    municipal_facet: municipal
-                }
-            });
-        });
-    }
-
-    return filters;
+    return filterNestedFacets(counties, municipals, 'county_facet', 'municipal_facet');
 }
 
-export function filterOccupation(occupationFirstLevels, occupationSecondLevels) {
-    const filters = {
-        bool: {
-            should: []
-        }
-    };
-    if (occupationFirstLevels && occupationFirstLevels.length > 0) {
-        occupationFirstLevels.forEach((occupationFirstLevel) => {
-            filters.bool.should.push({
-                term: {
-                    occupation_level1_facet: occupationFirstLevel
-                }
-            });
-        });
-    }
-
-    if (occupationSecondLevels && occupationSecondLevels.length > 0) {
-        occupationSecondLevels.forEach((occupationSecondLevel) => {
-            filters.bool.should.push({
-                term: {
-                    occupation_level2_facet: occupationSecondLevel
-                }
-            });
-        });
-    }
-
-    return filters;
+export function filterOccupation(occupationLevel1, occupationLevel2) {
+    return filterNestedFacets(occupationLevel1, occupationLevel2, 'occupation_level1_facet', 'occupation_level2_facet');
 }
+
 
 export function filterSector(sector) {
     const filters = {

--- a/src/api/templates/searchTemplate.js
+++ b/src/api/templates/searchTemplate.js
@@ -52,9 +52,9 @@ export function filterEngagementType(engagementTypes) {
 }
 
 /**
- * Lager filter for fasetter med flere nivå, feks fylke og kommune. Kobinerer AND og OR.
+ * Lager filter for fasetter med flere nivå, feks fylke og kommune. Kombinerer AND og OR.
  * Feks (Akershus) OR (Buskerud) hvis man bare har valgt disse to fylkene.
- * Feks (Akershus AND Asker) OR (Buskerud AND Drammen) om man ser etter jobb i Asker og Drammen
+ * Feks (Akershus AND (Asker OR Bærum)) OR (Buskerud AND Drammen) om man ser etter jobb i Asker, Bærum eller Drammen
  * Feks (Akershus) OR (Buskerud AND Drammen) om man ser etter jobb i hele Akershus fylke, men også i Drammen kommune.
  */
 export function filterNestedFacets(parents, children = [], parentKey, childKey) {

--- a/src/savedSearches/form/savedSearchFormReducer.js
+++ b/src/savedSearches/form/savedSearchFormReducer.js
@@ -170,9 +170,9 @@ function toTitle(state) {
 
     if (state.searchBox.q) title.push(state.searchBox.q);
     if (occupationFirstLevels.length > 0) title.push(occupationFirstLevels.join(', '));
-    if (state.occupations.checkedSecondLevels.length > 0) title.push(state.occupations.checkedSecondLevels.join(', '));
+    if (state.occupations.checkedSecondLevels.length > 0) title.push(state.occupations.checkedSecondLevels.map((o) => (o.split('.')[1])).join(', '));
     if (counties.length > 0) title.push(counties.map((c) => (capitalizeLocation(c))).join(', '));
-    if (state.counties.checkedMunicipals.length > 0) title.push(state.counties.checkedMunicipals.map((m) => (capitalizeLocation(m))).join(', '));
+    if (state.counties.checkedMunicipals.length > 0) title.push(state.counties.checkedMunicipals.map((m) => (capitalizeLocation(m.split('.')[1]))).join(', '));
     if (state.extent.checkedExtent.length > 0) title.push(state.extent.checkedExtent.join(', '));
     if (state.engagement.checkedEngagementType.length > 0) title.push(state.engagement.checkedEngagementType.join(', '));
     if (state.sector.checkedSector.length > 0) title.push(state.sector.checkedSector.join(', '));

--- a/src/search/facets/counties/Counties.js
+++ b/src/search/facets/counties/Counties.js
@@ -72,7 +72,7 @@ class Counties extends React.Component {
                                         <Checkbox
                                             name="location"
                                             key={municipal.key}
-                                            label={`${capitalizeLocation(municipal.key)} (${municipal.count})`}
+                                            label={`${capitalizeLocation(municipal.label)} (${municipal.count})`}
                                             value={municipal.key}
                                             onChange={this.onMunicipalClick}
                                             checked={checkedMunicipals.includes(municipal.key)}

--- a/src/search/facets/occupations/Occupations.js
+++ b/src/search/facets/occupations/Occupations.js
@@ -74,7 +74,7 @@ class Occupations extends React.Component {
                                         <Checkbox
                                             name="occupation"
                                             key={secondLevel.key}
-                                            label={`${secondLevel.key} (${secondLevel.count})`}
+                                            label={`${secondLevel.label} (${secondLevel.count})`}
                                             value={secondLevel.key}
                                             onChange={this.onSecondLevelClick}
                                             checked={checkedSecondLevels.includes(secondLevel.key)}

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -119,27 +119,13 @@ export function toSearchQuery(state) {
     if (state.search.from > 0) query.from = state.search.from;
     if (state.search.to > PAGE_SIZE) query.size = state.search.to - state.search.from;
     if (state.sorting.sort.length > 0) query.sort = state.sorting.sort;
-
-    // Hvis man filtrerer på en kommune, må man droppe fylket når man søker.
-    // Altså om man krysser av på Bergen, skal man ikke ha med Hordaland i søket.
-    const counties = state.counties.checkedCounties.filter((county) => {
-        const countyObject = state.counties.counties.find((c) => c.key === county);
-        const found = countyObject.municipals.find((m) => state.counties.checkedMunicipals.includes(m.key));
-        return !found;
-    });
-    if (counties.length > 0) query.counties = counties;
+    if (state.counties.checkedCounties.length > 0) query.counties = state.counties.checkedCounties;
     if (state.counties.checkedMunicipals.length > 0) query.municipals = state.counties.checkedMunicipals;
     if (state.published.checkedPublished.length > 0) query.published = state.published.checkedPublished;
     if (state.engagement.checkedEngagementType.length > 0) query.engagementType = state.engagement.checkedEngagementType;
     if (state.sector.checkedSector.length > 0) query.sector = state.sector.checkedSector;
     if (state.extent.checkedExtent.length > 0) query.extent = state.extent.checkedExtent;
-    // Hvis man filtrerer på en yrke på andre nivå, må man droppe yrkeskategorien på første nivå.
-    const occupationFirstLevels = state.occupations.checkedFirstLevels.filter((firstLevel) => {
-        const firstLevelObject = state.occupations.occupationFirstLevels.find((c) => c.key === firstLevel);
-        const found = firstLevelObject.occupationSecondLevels.find((m) => state.occupations.checkedSecondLevels.includes(m.key));
-        return !found;
-    });
-    if (occupationFirstLevels.length > 0) query.occupationFirstLevels = occupationFirstLevels;
+    if (state.occupations.checkedFirstLevels.length > 0) query.occupationFirstLevels = state.occupations.checkedFirstLevels;
     if (state.occupations.checkedSecondLevels.length > 0) query.occupationSecondLevels = state.occupations.checkedSecondLevels;
     return query;
 }


### PR DESCRIPTION
Når man søker på jobb i Asker, har man både krysset av på Akershus + Asker. Men for at resultatene kun skal vise Asker, og ikke alle treff fra hele fylket har vi hittil droppet å ta med fylket i spørringen mot elastic search, hvis en kommune i samme fylke er avkrysset. 

Å fjerne fylket er en workaround som heller kan løses med å legge til flere bool nivåer.