### PR TITLE
[Pam-2035] Endre format på lagrede queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2510,11 +2510,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2527,15 +2529,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2638,7 +2643,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2648,6 +2654,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2660,17 +2667,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2687,6 +2697,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2759,7 +2770,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2769,6 +2781,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2874,6 +2887,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,5 +1,5 @@
 import SearchApiError from './SearchApiError';
-import { objectToQueryString } from "../utils";
+import { toQueryString } from "../search/url";
 
 /* eslint-disable no-underscore-dangle */
 import { SEARCH_API } from '../fasitProperties';
@@ -90,7 +90,7 @@ function fixStilling(stilling) {
 }
 
 export async function fetchSearch(query = {}) {
-    const queryString = '?' + objectToQueryString(query);
+    const queryString = toQueryString(query);
     const result = await get('/pam-stillingsok/search' + queryString);
     return {
         stillinger: result.hits.hits.map((stilling) => (
@@ -135,7 +135,7 @@ export async function fetchSearch(query = {}) {
 }
 
 export async function fetchCategoryAndSearchTagsSuggestions(match, minLength) {
-    const queryString = '?' + objectToQueryString({ match: match, minLength: minLength });
+    const queryString = toQueryString({ match: match, minLength: minLength });
     const result = await get('/pam-stillingsok/suggestions' + queryString);
 
     return {

--- a/src/savedSearches/form/savedSearchFormReducer.js
+++ b/src/savedSearches/form/savedSearchFormReducer.js
@@ -1,6 +1,6 @@
 import { put, select, takeLatest } from 'redux-saga/es/effects';
 import capitalizeLocation from '../../common/capitalizeLocation';
-import { toUrl } from '../../search/url';
+import { toQueryString } from "../../search/url";
 import NotifyTypeEnum from '../enums/NotifyTypeEnum';
 import SavedSearchStatusEnum from '../enums/SavedSearchStatusEnum';
 import {
@@ -189,7 +189,7 @@ function* setDefaultFormData(action) {
             type: SET_FORM_DATA,
             formData: {
                 title: toTitle(state),
-                searchQuery: toUrl(toQuery(state)),
+                searchQuery: toQueryString(toQuery(state)),
                 notifyType: NotifyTypeEnum.NONE,
                 status: SavedSearchStatusEnum.INACTIVE
             }
@@ -204,7 +204,7 @@ function* setDefaultFormData(action) {
             type: SET_FORM_DATA,
             formData: {
                 ...state.savedSearches.currentSavedSearch,
-                searchQuery: toUrl(toQuery(state))
+                searchQuery: toQueryString(toQuery(state))
             }
         });
     }
@@ -216,4 +216,3 @@ export const savedSearchFormSaga = function* saga() {
     yield takeLatest(SHOW_SAVED_SEARCH_FORM, setDefaultFormData);
     yield takeLatest(SET_SAVED_SEARCH_FORM_MODE, setDefaultFormData);
 };
-

--- a/src/savedSearches/form/savedSearchFormReducer.js
+++ b/src/savedSearches/form/savedSearchFormReducer.js
@@ -1,6 +1,7 @@
 import { put, select, takeLatest } from 'redux-saga/es/effects';
 import capitalizeLocation from '../../common/capitalizeLocation';
-import { toQueryString } from "../../search/url";
+import { toQueryString } from '../../search/url';
+import { removeUndefinedOrEmptyString } from '../../utils';
 import NotifyTypeEnum from '../enums/NotifyTypeEnum';
 import SavedSearchStatusEnum from '../enums/SavedSearchStatusEnum';
 import {
@@ -142,7 +143,7 @@ export function* validateAll() {
 }
 
 function toQuery(state) {
-    return {
+    const query = {
         q: state.searchBox.q,
         counties: state.counties.checkedCounties,
         municipals: state.counties.checkedMunicipals,
@@ -153,6 +154,8 @@ function toQuery(state) {
         occupationFirstLevels: state.occupations.checkedFirstLevels,
         occupationSecondLevels: state.occupations.checkedSecondLevels
     };
+
+    return removeUndefinedOrEmptyString(query);
 }
 
 function toTitle(state) {

--- a/src/savedSearches/savedSearchesReducer.js
+++ b/src/savedSearches/savedSearchesReducer.js
@@ -3,10 +3,10 @@ import { userApiGet, userApiPost, userApiRemove, userApiPut } from '../api/userA
 import SearchApiError from '../api/SearchApiError';
 import { AD_USER_API } from '../fasitProperties';
 import { RESET_SEARCH, SEARCH } from '../search/searchReducer';
-import { fromUrl } from '../search/url';
 import { RESTORE_STATE_FROM_URL, SEARCH_PARAMETERS_DEFINITION } from '../urlReducer';
 import { FETCH_USER_SUCCESS } from '../user/userReducer';
 import { validateAll } from './form/savedSearchFormReducer';
+import { toObject } from "../search/url";
 
 export const FETCH_SAVED_SEARCHES = 'FETCH_SAVED_SEARCHES';
 export const FETCH_SAVED_SEARCHES_BEGIN = 'FETCH_SAVED_SEARCHES_BEGIN';
@@ -239,7 +239,7 @@ function* setCurrentSavedSearch() {
     const state = yield select();
     yield put({
         type: RESTORE_STATE_FROM_SAVED_SEARCH,
-        query: fromUrl(SEARCH_PARAMETERS_DEFINITION, state.savedSearches.currentSavedSearch.searchQuery)
+        query: toObject(state.savedSearches.currentSavedSearch.searchQuery)
     });
     if (state.search.initialSearchDone) {
         yield put({ type: SEARCH });

--- a/src/search/url.js
+++ b/src/search/url.js
@@ -40,6 +40,7 @@ export function toQueryString(object = {}) {
                 return key + '=' + object[key];
             }
         })
+        .filter(elem => elem !== '')
         .join('&')
         .replace(/\s/g, '%20');
 }

--- a/src/search/url.js
+++ b/src/search/url.js
@@ -1,83 +1,50 @@
-export const ParameterType = {
-    ARRAY: 'ARRAY',
-    STRING: 'STRING',
-    NUMBER: 'NUMBER'
-};
-
-export function getUrlParameterByName(name, url) {
-    name = name.replace(/[\[\]]/g, '\\$&');
-    const regex = new RegExp(`[?&]${name}(=([^&#]*)|&|#|$)`);
-    const results = regex.exec(url);
-    if (!results) return undefined;
-    if (!results[2]) return '';
-    return decodeURIComponent(results[2].replace(/\+/g, ' '));
-}
+import { parse } from 'url';
 
 /**
- * Takes an object representing the url query and transform it into a string
- * @param query: f.ex: {q: "Java", fruits: ["Apple", "Banana"], count: 10}
- * @returns {string} f.ex: q=Java&names=Apple_Banana&count=10
+ * Tar en query-string og returnerer en Object-representasjon av stringen.
+ * @param queryString   Query-stringen som skal parseres til et objekt.
+ * @returns {Object}    En Object-representasjon av 'queryString'.
  */
-export function toUrl(query) {
-    let result = {};
+export function toObject(queryString = '') {
+    const object = parse(queryString, true).query;
 
-    Object.keys(query).forEach((key) => {
-        if (query[key] !== undefined) {
-            if (Array.isArray(query[key])) {
-                if (query[key].length > 0) {
-                    result = {
-                        ...result,
-                        [key]: query[key].join('_')
-                    };
-                }
-            } else if (query[key] !== '') {
-                result = {
-                    ...result,
-                    [key]: query[key]
-                };
+    Object.keys(object).forEach((key) => {
+        if (key.includes('[]')) {
+            let value = object[key];
+
+            if (!Array.isArray(value)) {
+                value = [value];
             }
+
+            const newKey = key.replace('[]', '');
+            delete object[key];
+            object[newKey] = value;
         }
     });
 
-    const urlQuery = Object.keys(result)
-        .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(result[key])}`)
-        .join('&')
-        .replace(/%20/g, '+');
-
-
-    return urlQuery && urlQuery.length > 0 ? `?${urlQuery}` : '';
+    return object;
 }
 
 /**
- * Takes an url query string and extract url parameters and return them as in a query object
- * @param queryDefinition: f.ex: {q: ParameterType.STRING, fruits: ParameterType.ARRAY, count: ParameterType.NUMBER}
- * @param url: f.ex: q=Java&names=Apple_Banana&count=10
- * @returns {{}} f.ex: {q: "Java", fruits: ["Apple", "Banana"], count: 10}
+ * Tar et objekt og returnerer en query-string-representasjon av objektet.
+ * @param object        Objekt som skal gjøres om til en query-string.
+ * @returns {string}    En query-string-representasjon av 'object'.
  */
-export function fromUrl(queryDefinition, url) {
-    let result = {};
-    Object.keys(queryDefinition).forEach((key) => {
-        const urlParameter = getUrlParameterByName(key, url);
-        if (urlParameter) {
-            if (queryDefinition[key] === ParameterType.ARRAY) {
-                result = {
-                    ...result,
-                    [key]: urlParameter.split('_')
-                };
-            } else if (queryDefinition[key] === ParameterType.NUMBER) {
-                result = {
-                    ...result,
-                    [key]: parseInt(urlParameter, 10)
-                };
-            } else if (queryDefinition[key] === ParameterType.STRING) {
-                result = {
-                    ...result,
-                    [key]: urlParameter
-                };
+export function toQueryString(object = {}) {
+    return '?' + Object.keys(object)
+        .map(key => {
+            const value = object[key];
+            if (Array.isArray(value)) {
+                return arrayToQueryString(key, value);
             } else {
-                throw Error(`Unsupported query type: ${queryDefinition[key]}`);
+                return key + '=' + object[key];
             }
-        }
-    });
-    return result;
+        })
+        .join('&')
+        .replace(/\s/g, '%20');
+}
+
+function arrayToQueryString(key, array) {
+    return array.map(val => key + '[]=' + val)
+        .join('&');
 }

--- a/src/urlReducer.js
+++ b/src/urlReducer.js
@@ -2,27 +2,11 @@ import { select, takeLatest, put } from 'redux-saga/effects';
 import { ADD_SAVED_SEARCH_SUCCESS, SET_CURRENT_SAVED_SEARCH } from './savedSearches/savedSearchesReducer';
 import { SET_VALUE } from './search/searchBox/searchBoxReducer';
 import { LOAD_MORE, PAGE_SIZE, RESET_SEARCH, SEARCH } from './search/searchReducer';
-import { fromUrl, ParameterType, toUrl } from './search/url';
 import { SET_VIEW_MODE } from './search/viewMode/viewModeReducer';
+import { toQueryString, toObject } from "./search/url";
 
 export const RESTORE_STATE_FROM_URL_BEGIN = 'RESTORE_STATE_FROM_URL_BEGIN';
 export const RESTORE_STATE_FROM_URL = 'RESTORE_STATE_FROM_URL';
-
-export const SEARCH_PARAMETERS_DEFINITION = {
-    q: ParameterType.STRING,
-    sort: ParameterType.STRING,
-    to: ParameterType.NUMBER,
-    counties: ParameterType.ARRAY,
-    municipals: ParameterType.ARRAY,
-    published: ParameterType.ARRAY,
-    engagementType: ParameterType.ARRAY,
-    sector: ParameterType.ARRAY,
-    extent: ParameterType.ARRAY,
-    occupationFirstLevels: ParameterType.ARRAY,
-    occupationSecondLevels: ParameterType.ARRAY,
-    mode: ParameterType.STRING,
-    saved: ParameterType.STRING
-};
 
 function* updateUrl() {
     const state = yield select();
@@ -44,7 +28,7 @@ function* updateUrl() {
     };
 
     try {
-        yield sessionStorage.setItem('url', toUrl(x));
+        yield sessionStorage.setItem('url', toQueryString(x));
     } catch (e) {
         // Ignore session storage error
     }
@@ -56,7 +40,7 @@ function* restoreStateFromUrl() {
         if (url && url !== null) {
             yield put({
                 type: RESTORE_STATE_FROM_URL,
-                query: fromUrl(SEARCH_PARAMETERS_DEFINITION, url)
+                query: toObject(url)
             });
         }
     } catch (e) {

--- a/src/urlReducer.js
+++ b/src/urlReducer.js
@@ -29,7 +29,7 @@ function* updateUrl() {
     };
 
     try {
-        yield sessionStorage.setItem('url', toQueryString(removeUndefinedOrEmptyString(x)));
+        yield sessionStorage.setItem('url-v2', toQueryString(removeUndefinedOrEmptyString(x)));
     } catch (e) {
         // Ignore session storage error
     }
@@ -37,7 +37,7 @@ function* updateUrl() {
 
 function* restoreStateFromUrl() {
     try {
-        const url = sessionStorage.getItem('url');
+        const url = sessionStorage.getItem('url-v2');
         if (url && url !== null) {
             yield put({
                 type: RESTORE_STATE_FROM_URL,

--- a/src/urlReducer.js
+++ b/src/urlReducer.js
@@ -4,6 +4,7 @@ import { SET_VALUE } from './search/searchBox/searchBoxReducer';
 import { LOAD_MORE, PAGE_SIZE, RESET_SEARCH, SEARCH } from './search/searchReducer';
 import { SET_VIEW_MODE } from './search/viewMode/viewModeReducer';
 import { toQueryString, toObject } from "./search/url";
+import { removeUndefinedOrEmptyString } from './utils';
 
 export const RESTORE_STATE_FROM_URL_BEGIN = 'RESTORE_STATE_FROM_URL_BEGIN';
 export const RESTORE_STATE_FROM_URL = 'RESTORE_STATE_FROM_URL';
@@ -28,7 +29,7 @@ function* updateUrl() {
     };
 
     try {
-        yield sessionStorage.setItem('url', toQueryString(x));
+        yield sessionStorage.setItem('url', toQueryString(removeUndefinedOrEmptyString(x)));
     } catch (e) {
         // Ignore session storage error
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import { parse } from 'url';
+
 const ISO_8601_DATE = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i;
 
 export function isValidISOString(isoString) {
@@ -31,22 +33,4 @@ export function isValidUrl(input) {
         return true;
     }
     return false;
-}
-
-export function objectToQueryString(object) {
-    return Object.keys(object)
-        .map(key => {
-            const value = object[key];
-            if (Array.isArray(value)) {
-                return arrayToQueryString(key, value);
-            } else {
-                return key + '=' + object[key];
-            }
-        })
-        .join('&');
-}
-
-function arrayToQueryString(key, array) {
-    return array.map(val => key + '[]=' + val)
-        .join('&');
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,3 @@
-import { parse } from 'url';
-
 const ISO_8601_DATE = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i;
 
 export function isValidISOString(isoString) {
@@ -33,4 +31,14 @@ export function isValidUrl(input) {
         return true;
     }
     return false;
+}
+
+export function removeUndefinedOrEmptyString(obj) {
+    const newObj = {};
+    Object.keys(obj).forEach((prop) => {
+        if (obj[prop] !== undefined && obj[prop] !== '') {
+            newObj[prop] = obj[prop];
+        }
+    });
+    return newObj;
 }


### PR DESCRIPTION
Ref: [PAM-2035]

Backenden parserer querystrings på en måte som ikke er kompatibel med den gamle måten å lagre søkestrenger på. Derfor har jeg skrevet nye funksjoner for å konvertere til/fra objekter/querystrings.