### PR TITLE
[PAM-1817] Kontekstuell disabling av lagreknapp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pam-stillingsok-frontend",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pam-stillingsok-frontend",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pam-stillingsok-frontend",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pam-stillingsok-frontend",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,3 +1,6 @@
+## RELEASE - 0.49.394-6e28968
+#### New in this release: 
++ 2018-11-19 [PAM-2106] Muligjør bruk av piltaster i radiobuttons
 ## RELEASE - 0.48.386-45a0576
 #### New in this release: 
 + 2018-11-15 [PAM-2081] Ny hotjar lenke

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,3 +1,8 @@
+## RELEASE - 0.48.386-45a0576
+#### New in this release: 
++ 2018-11-15 [PAM-2081] Ny hotjar lenke
++ 2018-11-15 [PAM-2081] Ny hotjar lenke
++ 2018-11-15 [PAM-1974] Legger til validering av epost felt
 ## RELEASE - 0.47.380-dbd1471
 #### New in this release: 
 + 2018-11-15 [PAM-2076] Øk size på filter aggregering slik at alle yrkeskategorier kommer med

--- a/scripts/searchApiTemplates.js
+++ b/scripts/searchApiTemplates.js
@@ -14,21 +14,24 @@ function mapSortByOrder(value) {
 }
 
 function filterPublished(published) {
-    const filters = {
+    if (published) {
+        return {
+            bool: {
+                should: [{
+                    range: {
+                        published: {
+                            gte: published
+                        }
+                    }
+                }]
+            }
+        };
+    }
+    return {
         bool: {
             should: []
         }
     };
-    if (published && published.length > 0) {
-        filters.bool.should.push({
-            range: {
-                published: {
-                    gte: 'now-1d'
-                }
-            }
-        });
-    }
-    return filters;
 }
 
 function suggest(field, match, minLength) {

--- a/src/Application.js
+++ b/src/Application.js
@@ -17,6 +17,7 @@ import TermsOfUse from './user/TermsOfUse';
 import { FETCH_IS_AUTHENTICATED } from './user/userReducer';
 import UserSettings from './user/UserSettings';
 import ViewTermsOfUse from './user/ViewTermsOfUse';
+import UserAlertStripe from './user/UserAlertStripe';
 
 class Application extends React.Component {
     componentDidMount() {
@@ -70,7 +71,7 @@ class Application extends React.Component {
                     {this.props.authorizationError && (
                         <NotAuthenticatedModal />
                     )}
-
+                    <UserAlertStripe />
                 </div>
             </BrowserRouter>
         );

--- a/src/common/ConfirmationModal.less
+++ b/src/common/ConfirmationModal.less
@@ -12,26 +12,18 @@
     margin-bottom: @modal-body-margin-bottom;
 }
 
+.ConfirmationModal__buttons .knapp:not(:last-child) {
+    margin-right: @knapp-margin-right;
+}
+
 @media (max-width: @screen-sm-max) {
     .ConfirmationModal {
         padding: @modal-padding-mobile;
-    }
-
-    .ConfirmationModal__buttons .knapp {
-        width: 100%;
-    }
-
-    .ConfirmationModal__buttons .knapp:not(:last-child) {
-        margin-bottom: @knapp-margin-right;
     }
 }
 
 @media (min-width: @screen-md-min) {
     .ConfirmationModal {
         width: 38rem;
-    }
-
-    .ConfirmationModal__buttons .knapp:not(:last-child) {
-        margin-right: @knapp-margin-right;
     }
 }

--- a/src/common/Lenkeknapp.less
+++ b/src/common/Lenkeknapp.less
@@ -11,7 +11,7 @@
   line-height:inherit;
 
   &:focus {
-    outline: 1px solid @navOransjeLighten40;
+    outline: 2px solid @navOransjeLighten40;
     color:@navDypBla;
   }
 

--- a/src/discalimer/Disclaimer.js
+++ b/src/discalimer/Disclaimer.js
@@ -21,7 +21,7 @@ function Disclaimer({ shouldShow, hideDisclaimer }) {
                             Inntil videre kan du bare gjøre dette i dagens stillingssøk.
                         </Normaltekst>
                         <Normaltekst className="blokk-xxs">
-                            <a href="https://in.hotjar.com/s?siteId=148751&surveyId=71116" className="lenke">
+                            <a href="https://surveys.hotjar.com/s?siteId=148751&surveyId=123859" className="lenke">
                                 Gi oss din tilbakemelding på det nye stillingssøket
                             </a>
                         </Normaltekst>

--- a/src/discalimer/Disclaimer.js
+++ b/src/discalimer/Disclaimer.js
@@ -41,7 +41,7 @@ function Disclaimer({ shouldShow, hideDisclaimer }) {
                 <div className="container">
                     <div role="alert" className="Feedback typo-normal">
                         <Normaltekst className="blokk-xxs">
-                            <a href="https://in.hotjar.com/s?siteId=148751&surveyId=71116" className="lenke">
+                            <a href="https://surveys.hotjar.com/s?siteId=148751&surveyId=123859" className="lenke">
                                 Gi oss din tilbakemelding på det nye stillingssøket
                             </a>
                         </Normaltekst>

--- a/src/discalimer/Disclaimer.js
+++ b/src/discalimer/Disclaimer.js
@@ -12,13 +12,13 @@ function Disclaimer({ shouldShow, hideDisclaimer }) {
             <div className="DisclaimerWrapper no-print">
                 <div className="container">
                     <div role="alert" className="Disclaimer typo-normal">
-                        <Element className="blokk-xxs">Tidlig versjon av nytt stillingssøk</Element>
+                        <Element className="blokk-xxs">Stillingssøket har blitt fornyet</Element>
                         <Normaltekst className="blokk-xxs">
-                            Vi utvikler nytt stillingssøk, og ønsker at du skal prøve det underveis.
-                            Midlertidige feil i tjenesten på grunn av teknisk arbeid kan forekomme.
-                            <br/>
+                            Vi erstatter vårt gamle stillingssøk med en ny versjon.
                             Akkurat nå jobber vi for at du skal kunne lagre søk og annonser.
-                            Inntil videre kan du bare gjøre dette i dagens stillingssøk.
+                            <br />
+                            Inntil videre kan du bare gjøre dette i det gamle stillingssøket.
+                            Midlertidige feil i tjenesten på grunn av teknisk arbeid kan forekomme.
                         </Normaltekst>
                         <Normaltekst className="blokk-xxs">
                             <a href="https://surveys.hotjar.com/s?siteId=148751&surveyId=123859" className="lenke">
@@ -27,7 +27,7 @@ function Disclaimer({ shouldShow, hideDisclaimer }) {
                         </Normaltekst>
                         <Normaltekst className="blokk-xs">
                             <a href="https://tjenester.nav.no/stillinger/" className="lenke">
-                                Gå tilbake til dagens stillingssøk
+                                Gå til det gamle stillingssøket
                             </a>
                         </Normaltekst>
                         <Knapp mini onClick={hideDisclaimer}>Skjul</Knapp>

--- a/src/savedSearches/SaveSearchButton.js
+++ b/src/savedSearches/SaveSearchButton.js
@@ -23,7 +23,7 @@ class SaveSearchButton extends React.Component {
         }
     };
 
-    lagreKnappDisabled = () => <div role="button" className="knapp knapp--mini knapp--disabled">Lagre søk</div>;
+    lagreKnappDisabled = () => <div role="button" className="knapp knapp--mini knapp--disabled SaveSearchButton">Lagre søk</div>;
 
     shouldBeDisabled = () => {
         const { searchBoxValue, searchIsNonEmpty } = this.props;

--- a/src/savedSearches/SaveSearchButton.js
+++ b/src/savedSearches/SaveSearchButton.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import AuthorizationEnum from '../user/AuthorizationEnum';
 import { SHOW_AUTHORIZATION_ERROR_MODAL, SHOW_TERMS_OF_USE_MODAL } from '../user/userReducer';
 import { SavedSearchFormMode, SHOW_SAVED_SEARCH_FORM } from './form/savedSearchFormReducer';
+import HjelpetekstBase from 'nav-frontend-hjelpetekst';
 
 class SaveSearchButton extends React.Component {
     onClick = () => {
@@ -22,14 +23,24 @@ class SaveSearchButton extends React.Component {
         }
     };
 
+    lagreKnappDisabled = () => <div role="button" className="knapp knapp--mini knapp--disabled">Lagre søk</div>;
+
     shouldBeDisabled = () => {
         const { searchBoxValue, searchIsNonEmpty } = this.props;
         return searchBoxValue.length === 0 && !searchIsNonEmpty;
     };
 
     render() {
-        return (
-            <Knapp mini className="SaveSearchButton" onClick={this.onClick} disabled={this.shouldBeDisabled()}>Lagre søk</Knapp>
+        return this.shouldBeDisabled() ? (
+            <HjelpetekstBase
+                id="hjelpetekstLagreknapp"
+                anchor={this.lagreKnappDisabled}
+                tittel="Du må fylle inn søkeord eller kriterier for å kunne lagre."
+            >
+                Du må fylle inn søkeord eller kriterier for å kunne lagre.
+            </HjelpetekstBase>
+        ) : (
+            <Knapp mini className="SaveSearchButton" onClick={this.onClick}>Lagre søk</Knapp>
         );
     }
 }

--- a/src/savedSearches/SaveSearchButton.js
+++ b/src/savedSearches/SaveSearchButton.js
@@ -38,7 +38,7 @@ SaveSearchButton.defaultProps = {
     currentSavedSearch: undefined,
     user: undefined,
     isAuthenticated: undefined,
-    searchIsNonEmpty: undefined,
+    searchIsNonEmpty: false,
     searchBoxValue: undefined
 };
 

--- a/src/savedSearches/SaveSearchButton.js
+++ b/src/savedSearches/SaveSearchButton.js
@@ -8,22 +8,28 @@ import { SavedSearchFormMode, SHOW_SAVED_SEARCH_FORM } from './form/savedSearchF
 
 class SaveSearchButton extends React.Component {
     onClick = () => {
-        if (this.props.isAuthenticated !== true) {
-            this.props.showError(AuthorizationEnum.SAVE_SEARCH_ERROR);
-        } else if (!this.props.user) {
-            this.props.showTermsOfUseModal();
+        const { isAuthenticated, showError, user, showTermsOfUseModal, showSavedSearchForm, currentSavedSearch } = this.props;
+        if (isAuthenticated !== true) {
+            showError(AuthorizationEnum.SAVE_SEARCH_ERROR);
+        } else if (!user) {
+            showTermsOfUseModal();
         } else {
-            this.props.showSavedSearchForm(
-                this.props.currentSavedSearch ? SavedSearchFormMode.REPLACE : SavedSearchFormMode.ADD,
-                this.props.currentSavedSearch !== undefined
+            showSavedSearchForm(
+                currentSavedSearch ? SavedSearchFormMode.REPLACE : SavedSearchFormMode.ADD,
+                currentSavedSearch !== undefined
 
             );
         }
     };
 
+    shouldBeDisabled = () => {
+        const { searchBoxValue, searchIsNonEmpty } = this.props;
+        return searchBoxValue.length === 0 && !searchIsNonEmpty;
+    };
+
     render() {
         return (
-            <Knapp mini className="SaveSearchButton" onClick={this.onClick}>Lagre søk</Knapp>
+            <Knapp mini className="SaveSearchButton" onClick={this.onClick} disabled={this.shouldBeDisabled()}>Lagre søk</Knapp>
         );
     }
 }
@@ -31,7 +37,9 @@ class SaveSearchButton extends React.Component {
 SaveSearchButton.defaultProps = {
     currentSavedSearch: undefined,
     user: undefined,
-    isAuthenticated: undefined
+    isAuthenticated: undefined,
+    searchIsNonEmpty: undefined,
+    searchBoxValue: undefined
 };
 
 SaveSearchButton.propTypes = {
@@ -40,12 +48,16 @@ SaveSearchButton.propTypes = {
     showError: PropTypes.func.isRequired,
     showTermsOfUseModal: PropTypes.func.isRequired,
     isAuthenticated: PropTypes.bool,
+    searchIsNonEmpty: PropTypes.bool,
+    searchBoxValue: PropTypes.string,
     user: PropTypes.shape({})
 };
 
 const mapStateToProps = (state) => ({
     currentSavedSearch: state.savedSearches.currentSavedSearch,
     isAuthenticated: state.user.isAuthenticated,
+    searchIsNonEmpty: state.search.searchIsNonEmpty,
+    searchBoxValue: state.searchBox.q,
     user: state.user.user
 });
 

--- a/src/savedSearches/form/SavedSearchForm.js
+++ b/src/savedSearches/form/SavedSearchForm.js
@@ -56,7 +56,7 @@ class SavedSearchForm extends React.Component {
                                     >
                                         <Radio
                                             label="Lagre endringene"
-                                            name="replace"
+                                            name="add_or_replace"
                                             key="replace"
                                             value={SavedSearchFormMode.REPLACE}
                                             onChange={this.onFormModeChange}
@@ -64,7 +64,7 @@ class SavedSearchForm extends React.Component {
                                         />
                                         <Radio
                                             label="Lagre nytt søk"
-                                            name="add"
+                                            name="add_or_replace"
                                             key="add"
                                             value={SavedSearchFormMode.ADD}
                                             onChange={this.onFormModeChange}

--- a/src/savedSearches/form/SavedSearchForm.less
+++ b/src/savedSearches/form/SavedSearchForm.less
@@ -6,7 +6,7 @@
 
 @media (max-width: @screen-sm-max) {
   .SavedSearchModal {
-    padding: 0.5rem 0.25rem;
+    padding: 0;
   }
 }
 
@@ -26,27 +26,20 @@
   margin-bottom: @modal-body-margin-bottom;
 }
 
+
+.SavedSearchModal__buttons .knapp:not(:last-child) {
+  margin-right: @knapp-margin-right;
+}
+
 @media (max-width: @screen-sm-max) {
   .SavedSearchModal__form-mode {
     margin-bottom: 0;
-  }
-
-  .SavedSearchModal__buttons .knapp {
-    width: 100%;
-  }
-
-  .SavedSearchModal__buttons .knapp:not(:last-child) {
-    margin-bottom: @knapp-margin-bottom;
   }
 }
 
 @media (min-width: @screen-md-min) {
   .SavedSearchModal {
     width: 38rem;
-  }
-
-  .SavedSearchModal__buttons .knapp:not(:last-child) {
-    margin-right: @knapp-margin-right;
   }
 }
 

--- a/src/savedSearches/savedSearchesReducer.js
+++ b/src/savedSearches/savedSearchesReducer.js
@@ -3,10 +3,10 @@ import { userApiGet, userApiPost, userApiRemove, userApiPut } from '../api/userA
 import SearchApiError from '../api/SearchApiError';
 import { AD_USER_API } from '../fasitProperties';
 import { RESET_SEARCH, SEARCH } from '../search/searchReducer';
-import { RESTORE_STATE_FROM_URL, SEARCH_PARAMETERS_DEFINITION } from '../urlReducer';
+import { RESTORE_STATE_FROM_URL } from '../urlReducer';
 import { FETCH_USER_SUCCESS } from '../user/userReducer';
 import { validateAll } from './form/savedSearchFormReducer';
-import { toObject } from "../search/url";
+import { toObject } from '../search/url';
 
 export const FETCH_SAVED_SEARCHES = 'FETCH_SAVED_SEARCHES';
 export const FETCH_SAVED_SEARCHES_BEGIN = 'FETCH_SAVED_SEARCHES_BEGIN';

--- a/src/search/Search.less
+++ b/src/search/Search.less
@@ -69,6 +69,10 @@
   margin-right: 1rem;
 }
 
+.hjelpetekst {
+  padding-left: 0;
+}
+
 .Search__minside-lenke {
   margin-left: @knapp-margin-right;
   font-size: 14px!important;

--- a/src/search/Search.less
+++ b/src/search/Search.less
@@ -65,10 +65,6 @@
   margin-bottom: 2.5rem;
 }
 
-.SaveSearchButton {
-  margin-right: 1rem;
-}
-
 .hjelpetekst {
   padding-left: 0;
 }

--- a/src/search/Search.less
+++ b/src/search/Search.less
@@ -65,6 +65,10 @@
   margin-bottom: 2.5rem;
 }
 
+.SaveSearchButton {
+  margin-right: 1rem;
+}
+
 .hjelpetekst {
   padding-left: 0;
 }

--- a/src/search/facets/published/Published.js
+++ b/src/search/facets/published/Published.js
@@ -3,19 +3,20 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Checkbox } from 'nav-frontend-skjema';
 import { SEARCH } from '../../searchReducer';
-import {
-    CHECK_PUBLISHED,
-    UNCHECK_PUBLISHED
-} from './publishedReducer';
+import { SET_PUBLISHED } from './publishedReducer';
 import './Published.less';
+
+const PublishedLabelsEnum = {
+    'now-1d': 'Nye i dag'
+};
 
 class Published extends React.Component {
     onPublishedClick = (e) => {
         const { value } = e.target;
         if (e.target.checked) {
-            this.props.checkPublished(value);
+            this.props.setPublished(value);
         } else {
-            this.props.uncheckPublished(value);
+            this.props.setPublished(undefined);
         }
         this.props.search();
     };
@@ -30,10 +31,10 @@ class Published extends React.Component {
                     <Checkbox
                         name="published"
                         key={item.key}
-                        label={`Nye i dag (${item.count})`}
+                        label={`${PublishedLabelsEnum[item.key]} (${item.count})`}
                         value={item.key}
                         onChange={this.onPublishedClick}
-                        checked={checkedPublished.includes(item.key)}
+                        checked={checkedPublished === item.key}
                     />
                 ))}
             </div>
@@ -41,14 +42,17 @@ class Published extends React.Component {
     }
 }
 
+Published.defaultProps = {
+    checkedPublished: undefined
+};
+
 Published.propTypes = {
     published: PropTypes.arrayOf(PropTypes.shape({
         key: PropTypes.string,
         count: PropTypes.number
     })).isRequired,
-    checkedPublished: PropTypes.arrayOf(PropTypes.string).isRequired,
-    checkPublished: PropTypes.func.isRequired,
-    uncheckPublished: PropTypes.func.isRequired,
+    checkedPublished: PropTypes.string,
+    setPublished: PropTypes.func.isRequired,
     search: PropTypes.func.isRequired
 };
 
@@ -59,8 +63,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
     search: () => dispatch({ type: SEARCH }),
-    checkPublished: (value) => dispatch({ type: CHECK_PUBLISHED, value }),
-    uncheckPublished: (value) => dispatch({ type: UNCHECK_PUBLISHED, value })
+    setPublished: (value) => dispatch({ type: SET_PUBLISHED, value })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Published);

--- a/src/search/facets/published/publishedReducer.js
+++ b/src/search/facets/published/publishedReducer.js
@@ -2,12 +2,11 @@ import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSea
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
 import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
 
-export const CHECK_PUBLISHED = 'CHECK_PUBLISHED';
-export const UNCHECK_PUBLISHED = 'UNCHECK_PUBLISHED';
+export const SET_PUBLISHED = 'SET_PUBLISHED';
 
 const initialState = {
     published: [],
-    checkedPublished: []
+    checkedPublished: undefined
 };
 
 export default function publishedReducer(state = initialState, action) {
@@ -16,12 +15,12 @@ export default function publishedReducer(state = initialState, action) {
         case RESTORE_STATE_FROM_SAVED_SEARCH:
             return {
                 ...state,
-                checkedPublished: action.query.published || []
+                checkedPublished: action.query.published
             };
         case RESET_SEARCH:
             return {
                 ...state,
-                checkedPublished: []
+                checkedPublished: undefined
             };
         case FETCH_INITIAL_FACETS_SUCCESS:
             return {
@@ -41,18 +40,10 @@ export default function publishedReducer(state = initialState, action) {
                     };
                 })
             };
-        case CHECK_PUBLISHED:
+        case SET_PUBLISHED:
             return {
                 ...state,
-                checkedPublished: [
-                    ...state.checkedPublished,
-                    action.value
-                ]
-            };
-        case UNCHECK_PUBLISHED:
-            return {
-                ...state,
-                checkedPublished: state.checkedPublished.filter((m) => (m !== action.value))
+                checkedPublished: action.value
             };
         default:
             return state;

--- a/src/search/searchBox/SearchBox.less
+++ b/src/search/searchBox/SearchBox.less
@@ -5,6 +5,10 @@
   margin-bottom: 1rem;
 }
 
+#search-form-fritekst-input {
+  padding-right: 4rem;
+}
+
 .SearchBox__button {
   height: 3.5rem;
   background-color: transparent;

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -127,8 +127,14 @@ export function toSearchQuery(state) {
     return query;
 }
 
-function queryIsNonEmpty(query) {
-    return Object.keys(query).length > 0;
+/**
+ * Sjekker om bruker har foretatt et valg i stillingssøkskjemaet ved søk.
+ * @param query         Query som brukes i søket.
+ * @returns {boolean}   True dersom bruker har huket av for en fasett eller skrevet noe i søkeboksen.
+ */
+function queryHasSelectedFacets(query) {
+    const { length } = Object.keys(query);
+    return (length > 1 && query.q !== undefined) || (length > 0 && query.q === undefined);
 }
 
 /**
@@ -153,7 +159,7 @@ function* initialSearch() {
                 response = yield call(fetchSearch, query);
             }
 
-            yield put({ type: SEARCH_SUCCESS, response, searchIsNonEmpty: queryIsNonEmpty(query) });
+            yield put({ type: SEARCH_SUCCESS, response });
         }
     } catch (e) {
         if (e instanceof SearchApiError) {
@@ -172,7 +178,7 @@ function* search() {
         const state = yield select();
         const query = toSearchQuery(state);
         const searchResult = yield call(fetchSearch, query);
-        yield put({ type: SEARCH_SUCCESS, response: searchResult, searchIsNonEmpty: queryIsNonEmpty(query) });
+        yield put({ type: SEARCH_SUCCESS, response: searchResult, searchIsNonEmpty: queryHasSelectedFacets(query) });
     } catch (e) {
         if (e instanceof SearchApiError) {
             yield put({ type: SEARCH_FAILURE, error: e });

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -28,7 +28,8 @@ const initialState = {
     searchResult: undefined,
     from: 0,
     to: PAGE_SIZE,
-    page: 0
+    page: 0,
+    searchIsNonEmpty: false
 };
 
 export function mergeAndRemoveDuplicates(array1, array2) {
@@ -76,6 +77,7 @@ export default function searchReducer(state = initialState, action) {
             return {
                 ...state,
                 initialSearchDone: true,
+                searchIsNonEmpty: action.searchIsNonEmpty,
                 searchResult: {
                     total: action.response.total,
                     stillinger: action.response.stillinger
@@ -125,6 +127,10 @@ export function toSearchQuery(state) {
     return query;
 }
 
+function queryIsNonEmpty(query) {
+    return Object.keys(query).length > 0;
+}
+
 /**
  * Fetcher alle tilgjengelige fasetter og gjør deretter det første søket.
  */
@@ -147,7 +153,7 @@ function* initialSearch() {
                 response = yield call(fetchSearch, query);
             }
 
-            yield put({ type: SEARCH_SUCCESS, response });
+            yield put({ type: SEARCH_SUCCESS, response, searchIsNonEmpty: queryIsNonEmpty(query) });
         }
     } catch (e) {
         if (e instanceof SearchApiError) {
@@ -166,7 +172,7 @@ function* search() {
         const state = yield select();
         const query = toSearchQuery(state);
         const searchResult = yield call(fetchSearch, query);
-        yield put({ type: SEARCH_SUCCESS, response: searchResult });
+        yield put({ type: SEARCH_SUCCESS, response: searchResult, searchIsNonEmpty: queryIsNonEmpty(query) });
     } catch (e) {
         if (e instanceof SearchApiError) {
             yield put({ type: SEARCH_FAILURE, error: e });

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -159,7 +159,7 @@ function* initialSearch() {
                 response = yield call(fetchSearch, query);
             }
 
-            yield put({ type: SEARCH_SUCCESS, response });
+            yield put({ type: SEARCH_SUCCESS, response, searchIsNonEmpty: queryHasSelectedFacets(query) });
         }
     } catch (e) {
         if (e instanceof SearchApiError) {

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -129,12 +129,22 @@ export function toSearchQuery(state) {
 
 /**
  * Sjekker om bruker har foretatt et valg i stillingssøkskjemaet ved søk.
+ * Tar ikke stilling til om bruker har valgt å skrive noe i søkefeltet.
  * @param query         Query som brukes i søket.
- * @returns {boolean}   True dersom bruker har huket av for en fasett eller skrevet noe i søkeboksen.
+ * @returns {boolean}   True dersom bruker har huket av for en fasett.
  */
 function queryHasSelectedFacets(query) {
-    const { length } = Object.keys(query);
-    return (length > 1 && query.q !== undefined) || (length > 0 && query.q === undefined);
+    let { length } = Object.keys(query);
+
+    if (query.q !== undefined) {
+        length -= 1;
+    }
+
+    if (query.published !== undefined) {
+        length -= 1;
+    }
+
+    return length > 0;
 }
 
 /**

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -114,7 +114,7 @@ export function toSearchQuery(state) {
     if (state.sorting.sort.length > 0) query.sort = state.sorting.sort;
     if (state.counties.checkedCounties.length > 0) query.counties = state.counties.checkedCounties;
     if (state.counties.checkedMunicipals.length > 0) query.municipals = state.counties.checkedMunicipals;
-    if (state.published.checkedPublished.length > 0) query.published = state.published.checkedPublished;
+    if (state.published.checkedPublished) query.published = state.published.checkedPublished;
     if (state.engagement.checkedEngagementType.length > 0) query.engagementType = state.engagement.checkedEngagementType;
     if (state.sector.checkedSector.length > 0) query.sector = state.sector.checkedSector;
     if (state.extent.checkedExtent.length > 0) query.extent = state.extent.checkedExtent;

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -1,4 +1,6 @@
-import { call, put, select, takeLatest, throttle } from 'redux-saga/effects';
+import {
+    call, put, select, takeLatest, throttle
+} from 'redux-saga/effects';
 import { fetchSearch } from '../api/api';
 import SearchApiError from '../api/SearchApiError';
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../savedSearches/savedSearchesReducer';

--- a/src/search/url.js
+++ b/src/search/url.js
@@ -3,25 +3,27 @@
  * @param queryString   Query-stringen som skal parseres til et objekt.
  * @returns {Object}    En Object-representasjon av 'queryString'.
  */
-export function toObject(queryString = '') {
+export function toObject(queryString = '?') {
     const parameters = queryString.substring(1).split('&');
     const object = {};
 
     parameters.forEach((parameter) => {
         const pair = parameter.split('=');
-        let key = decodeURIComponent(pair[0]);
-        let val = decodeURIComponent(pair[1]);
+        if (pair[0] !== undefined || pair[0] !== '') {
+            let key = decodeURIComponent(pair[0]);
+            const val = pair[1] !== undefined ? decodeURIComponent(pair[1]) : '';
 
-        if (key.includes('[]')) {
-            key = key.replace('[]', '');
+            if (key.includes('[]')) {
+                key = key.replace('[]', '');
 
-            if (object[key] === undefined) {
-                object[key] = [val];
+                if (object[key] === undefined) {
+                    object[key] = [val];
+                } else {
+                    object[key].push(val);
+                }
             } else {
-                object[key].push(val);
+                object[key] = val;
             }
-        } else {
-            object[key] = val;
         }
     });
 

--- a/src/stilling/Stilling.js
+++ b/src/stilling/Stilling.js
@@ -23,6 +23,7 @@ import PersonalAttributes from './requirements/PersonalAttributes';
 import SoftRequirements from './requirements/SoftRequirements';
 import './Stilling.less';
 import { FETCH_STILLING_BEGIN } from './stillingReducer';
+import { urlFromSessionStorageOrIndex } from '../urlReducer';
 
 class Stilling extends React.Component {
     constructor(props) {
@@ -72,7 +73,7 @@ class Stilling extends React.Component {
                                     <Column xs="12">
                                         <div className="blokk-s">
                                             <Link
-                                                to="/"
+                                                to={`${urlFromSessionStorageOrIndex()}`}
                                                 className="PageHeader__back typo-normal lenke no-print"
                                             >
                                                 <Chevron type="venstre" className="PageHeader__back__chevron" />

--- a/src/stilling/employmentDetails/EmploymentDetails.js
+++ b/src/stilling/employmentDetails/EmploymentDetails.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Undertittel } from 'nav-frontend-typografi';
 import { formatISOString, isValidISOString } from '../../utils';
-
+import worktimeParser from './worktimeParser';
 
 export default function EmploymentDetails({ properties }) {
     return (
@@ -35,11 +35,11 @@ export default function EmploymentDetails({ properties }) {
                 ]}
                 {properties.workday && [
                     <dt key="dt">Arbeidsdager:</dt>,
-                    <dd key="dd">{properties.workday}</dd>
+                    <dd key="dd">{worktimeParser(properties.workday)}</dd>
                 ]}
                 {properties.workhours && [
                     <dt key="dt">Arbeidstid:</dt>,
-                    <dd key="dd">{properties.workhours}</dd>
+                    <dd key="dd">{worktimeParser(properties.workhours)}</dd>
                 ]}
                 {properties.jobarrangement && [
                     <dt key="dt">Arb.tidsordning:</dt>,

--- a/src/stilling/employmentDetails/worktimeParser.js
+++ b/src/stilling/employmentDetails/worktimeParser.js
@@ -1,0 +1,16 @@
+const worktimeParser = (worktime) => {
+    // We need this check in case of old workhour/-day property values, formatted like 'Opt1 Opt2'
+    let arrayString = '';
+    try {
+        const jsonArray = JSON.parse(worktime);
+
+        for (let i = 0; i < jsonArray.length; i++) {
+            arrayString += `${jsonArray[i]} `;
+        }
+    } catch (e) {
+        arrayString = worktime;
+    }
+    return arrayString;
+};
+
+export default worktimeParser;

--- a/src/styles.less
+++ b/src/styles.less
@@ -112,3 +112,7 @@ input::-ms-clear {
   }
 }
 
+.knapp--disabled:hover {
+  background: @navGra40;
+  border-color: transparent;
+}

--- a/src/urlReducer.js
+++ b/src/urlReducer.js
@@ -1,50 +1,52 @@
 import { select, takeLatest, put } from 'redux-saga/effects';
 import { ADD_SAVED_SEARCH_SUCCESS, SET_CURRENT_SAVED_SEARCH } from './savedSearches/savedSearchesReducer';
 import { SET_VALUE } from './search/searchBox/searchBoxReducer';
-import { LOAD_MORE, PAGE_SIZE, RESET_SEARCH, SEARCH } from './search/searchReducer';
 import { SET_VIEW_MODE } from './search/viewMode/viewModeReducer';
-import { toQueryString, toObject } from "./search/url";
+import { toQueryString, toObject } from './search/url';
 import { removeUndefinedOrEmptyString } from './utils';
+import {
+    LOAD_MORE,
+    RESET_SEARCH,
+    SEARCH,
+    toSearchQuery
+} from './search/searchReducer';
 
 export const RESTORE_STATE_FROM_URL_BEGIN = 'RESTORE_STATE_FROM_URL_BEGIN';
 export const RESTORE_STATE_FROM_URL = 'RESTORE_STATE_FROM_URL';
 
+const LATEST_QUERY_STRING_KEY = 'latestQueryString';
+
+export function urlFromSessionStorageOrIndex() {
+    const url = sessionStorage.getItem(LATEST_QUERY_STRING_KEY);
+    return url ? `/${url}` : '/';
+}
+
+/**
+ * Lagrer en queryString til sessionStorage, samt oppdaterer urlen i nettleserens adressefelt
+ * slik at den viser denne queryStringen. Stringen lagres til sessionStorage for at brukeren
+ * skal kunne navigere vekk fra stillingssøket uten å miste det siste foretatte søket, f.eks.
+ * når en bruker klikker seg videre til annonsen på f.eks. Finn.no.
+ * @param queryString   QueryStringen som skal lagres til sessionStorage.
+ */
+function setCurrentQueryString(queryString) {
+    window.history.replaceState({}, '', queryString);
+    sessionStorage.setItem(LATEST_QUERY_STRING_KEY, queryString);
+}
+
 function* updateUrl() {
     const state = yield select();
+    const query = toSearchQuery(state);
+    const queryString = toQueryString(removeUndefinedOrEmptyString(query));
 
-    const x = {
-        q: state.searchBox.q,
-        sort: state.sorting.sort,
-        to: state.search.to > PAGE_SIZE ? state.search.to : undefined,
-        counties: state.counties.checkedCounties,
-        municipals: state.counties.checkedMunicipals,
-        published: state.published.checkedPublished,
-        engagementType: state.engagement.checkedEngagementType,
-        sector: state.sector.checkedSector,
-        extent: state.extent.checkedExtent,
-        occupationFirstLevels: state.occupations.checkedFirstLevels,
-        occupationSecondLevels: state.occupations.checkedSecondLevels,
-        saved: state.savedSearches.currentSavedSearch ? state.savedSearches.currentSavedSearch.uuid : undefined
-    };
-
-    try {
-        yield sessionStorage.setItem('url-v2', toQueryString(removeUndefinedOrEmptyString(x)));
-    } catch (e) {
-        // Ignore session storage error
-    }
+    setCurrentQueryString(queryString);
 }
 
 function* restoreStateFromUrl() {
-    try {
-        const url = sessionStorage.getItem('url-v2');
-        if (url && url !== null) {
-            yield put({
-                type: RESTORE_STATE_FROM_URL,
-                query: toObject(url)
-            });
-        }
-    } catch (e) {
-        // Ignore session storage error
+    const searchString = document.location.search;
+    setCurrentQueryString(searchString || '');
+
+    if (searchString.length > 0) {
+        yield put({ type: RESTORE_STATE_FROM_URL, query: toObject(searchString) });
     }
 }
 

--- a/src/user/ConfirmDeleteUserModal.js
+++ b/src/user/ConfirmDeleteUserModal.js
@@ -17,10 +17,10 @@ class ConfirmDeleteUserModal extends React.Component {
     render() {
         return (
             <ConfirmationModal
-                title="Er du sikker på at du vil slette din bruker?"
+                title="Slett bruker"
                 onConfirm={this.onRemoveClick}
                 onCancel={this.closeModal}
-                confirmLabel="Slett bruker"
+                confirmLabel="Slett"
                 spinner={this.props.isDeletingUser}
             >
                 Når du sletter brukeren, sletter du også alle dine favoritter og lagrede søk.

--- a/src/user/NoUser.less
+++ b/src/user/NoUser.less
@@ -8,14 +8,15 @@
     margin-bottom: 2.5rem;
 }
 
-.NoUser__button {
-    margin-right: @knapp-margin-right;
+@media (max-width: @screen-sm-max) {
+    .NoUser .knapp{
+        display: block;
+        margin-bottom: @knapp-margin-bottom;
+    }
 }
 
-@media (max-width: @screen-xs-max) {
-    .NoUser__button{
-        width: 100%;
-        margin-right: 0;
-        margin-bottom: @knapp-margin-bottom;
+@media (min-width: @screen-md-min) {
+    .NoUser__button {
+        margin-right: @knapp-margin-right;
     }
 }

--- a/src/user/NotAuthenticated.less
+++ b/src/user/NotAuthenticated.less
@@ -8,18 +8,7 @@
   margin-bottom: @modal-body-margin-bottom;
 }
 
-@media (max-width: @screen-sm-max) {
-  .NotAuthenticated__buttons .knapp {
-    width: 100%;
-  }
-
-  .NotAuthenticated__buttons .knapp:not(:last-child) {
-    margin-bottom: @knapp-margin-right;
-  }
+.NotAuthenticated__buttons .knapp:not(:last-child) {
+  margin-right: @knapp-margin-right;
 }
 
-@media (min-width: @screen-md-min) {
-  .NotAuthenticated__buttons .knapp:not(:last-child) {
-    margin-right: @knapp-margin-right;
-  }
-}

--- a/src/user/NotAuthenticatedModal.less
+++ b/src/user/NotAuthenticatedModal.less
@@ -6,7 +6,7 @@
 
 @media (max-width: @screen-sm-max) {
   .NotAuthenticatedModal {
-    padding: @modal-padding-mobile;
+    padding: 0;
   }
 }
 

--- a/src/user/TermsOfUse.js
+++ b/src/user/TermsOfUse.js
@@ -12,17 +12,26 @@ class TermsOfUse extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            email: ''
+            email: '',
+            hasValidationError: false
         };
     }
 
     onAcceptTerms = () => {
-        this.props.createUser(this.state.email);
+        if (this.state.hasValidationError === false) {
+            this.props.createUser(this.state.email);
+        }
     };
 
     onEmailChange = (e) => {
         this.setState({
             email: e.target.value
+        });
+    };
+
+    onEmailBlur = () => {
+        this.setState({
+            hasValidationError: this.state.email.length > 0 && this.state.email.indexOf('@') === -1
         });
     };
 
@@ -54,6 +63,10 @@ class TermsOfUse extends React.Component {
                             label="E-postadressen din"
                             value={this.state.email}
                             onChange={this.onEmailChange}
+                            onBlur={this.onEmailBlur}
+                            feil={this.state.hasValidationError ? {
+                                feilmelding: 'E-postadressen er ugyldig. Den må minimum inneholde en «@»'
+                            } : undefined}
                         />
                     </div>
                     <div className="TermsOfUse__buttons">

--- a/src/user/TermsOfUse.less
+++ b/src/user/TermsOfUse.less
@@ -24,17 +24,18 @@
   margin-bottom: 1rem;
 }
 
+.TermsOfUse__buttons .knapp:not(:last-child) {
+  margin-right: @knapp-margin-right;
+}
+
 @media (max-width: @screen-sm-max) {
   .TermsOfUse {
     padding: @modal-padding-mobile;
   }
 
-  .TermsOfUse__buttons .knapp {
-    width: 100%;
-  }
-
   .TermsOfUse__buttons .knapp:not(:last-child) {
-    margin-bottom: @knapp-margin-right;
+    display: block;
+    margin-bottom: @knapp-margin-bottom;
   }
 }
 

--- a/src/user/UserAlertStripe.js
+++ b/src/user/UserAlertStripe.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { CONTEXT_PATH } from '../fasitProperties';
+import StickyAlertStripe from '../common/StickyAlertStripe';
+
+function UserAlertStripe({ userAlertStripeMode, userAlertStripeIsVisible }) {
+    if (userAlertStripeIsVisible && (userAlertStripeMode === 'added')) {
+        return (
+            <StickyAlertStripe type="suksess">
+                Din e-postadresse er lagret på <Link className="lenke" to={`${CONTEXT_PATH}/minside`}>min side</Link>
+            </StickyAlertStripe>
+        );
+    } else if (userAlertStripeIsVisible && userAlertStripeMode === 'changed') {
+        return (
+            <StickyAlertStripe type="suksess">
+                E-postadressen din ble endret
+            </StickyAlertStripe>
+        );
+    }
+    return <div />;
+}
+
+UserAlertStripe.propTypes = {
+    userAlertStripeIsVisible: PropTypes.bool.isRequired,
+    userAlertStripeMode: PropTypes.string.isRequired
+};
+
+const mapStateToProps = (state) => ({
+    userAlertStripeIsVisible: state.user.userAlertStripeIsVisible,
+    userAlertStripeMode: state.user.userAlertStripeMode
+});
+
+export default connect(mapStateToProps)(UserAlertStripe);

--- a/src/user/UserSettings.js
+++ b/src/user/UserSettings.js
@@ -118,7 +118,7 @@ class UserSettings extends React.Component {
                                                             spinner={this.props.isUpdating}
                                                             disabled={this.props.isUpdating}
                                                         >
-                                                            Slett e-post
+                                                            Slett
                                                         </Flatknapp>
                                                     )}
                                                 </div>

--- a/src/user/UserSettings.js
+++ b/src/user/UserSettings.js
@@ -12,7 +12,7 @@ import { CONTEXT_PATH } from '../fasitProperties';
 import ConfirmDeleteUserModal from './ConfirmDeleteUserModal';
 import NotAuthenticated from './NotAuthenticated';
 import NoUser from './NoUser';
-import { SET_USER_EMAIL, SHOW_CONFIRM_DELETE_USER_MODAL, UPDATE_USER } from './userReducer';
+import { SET_USER_EMAIL, SHOW_CONFIRM_DELETE_USER_MODAL, UPDATE_USER, VALIDATE_USER_EMAIL } from './userReducer';
 import './UserSettings.less';
 
 const PAGE_TITLE = 'Min side';
@@ -25,6 +25,10 @@ class UserSettings extends React.Component {
 
     onEmailChange = (e) => {
         this.props.setUserEmail(e.target.value);
+    };
+
+    onEmailBlur = () => {
+        this.props.validateEmail();
     };
 
     onUpdateUserClick = () => {
@@ -41,6 +45,8 @@ class UserSettings extends React.Component {
     };
 
     render() {
+        const { validation } = this.props;
+
         return (
             <div className="UserSettings">
                 <PageHeader
@@ -92,6 +98,10 @@ class UserSettings extends React.Component {
                                                         label="E-postadressen din"
                                                         value={this.props.user.email || ''}
                                                         onChange={this.onEmailChange}
+                                                        onBlur={this.onEmailBlur}
+                                                        feil={validation.email ? {
+                                                            feilmelding: validation.email
+                                                        } : undefined}
                                                     />
                                                 </div>
                                                 <div className="UserSettings__email-buttons">
@@ -122,8 +132,11 @@ class UserSettings extends React.Component {
                                                     Din bruker
                                                 </Undertittel>
                                                 <Normaltekst className="TermsOfUse__text">
-                                                    Du har samtykket til våre <Link to={`${CONTEXT_PATH}/vilkar`} className="lenke">vilkår
-                                                    for å bruke innloggede tjenester.
+                                                    Du har samtykket til våre <Link
+                                                        to={`${CONTEXT_PATH}/vilkar`}
+                                                        className="lenke"
+                                                    >
+                                                     vilkår for å bruke innloggede tjenester.
                                                     </Link>
                                                     <br /><br />
                                                     Hvis du ikke lenger ønsker å bruke innloggede tjenester i
@@ -170,11 +183,15 @@ UserSettings.propTypes = {
     }),
     isAuthenticated: PropTypes.bool,
     setUserEmail: PropTypes.func.isRequired,
+    validateEmail: PropTypes.func.isRequired,
     showConfirmDeleteUserModal: PropTypes.func.isRequired,
     updateUser: PropTypes.func.isRequired,
     confirmDeleteUserModalIsVisible: PropTypes.bool.isRequired,
     userAlertStripeIsVisible: PropTypes.bool.isRequired,
-    isUpdating: PropTypes.bool.isRequired
+    isUpdating: PropTypes.bool.isRequired,
+    validation: PropTypes.shape({
+        email: PropTypes.string
+    }).isRequired
 };
 
 const mapStateToProps = (state) => ({
@@ -183,11 +200,13 @@ const mapStateToProps = (state) => ({
     isUpdating: state.user.isUpdating,
     updateUserError: state.user.updateUserError,
     userAlertStripeIsVisible: state.user.userAlertStripeIsVisible,
-    confirmDeleteUserModalIsVisible: state.user.confirmDeleteUserModalIsVisible
+    confirmDeleteUserModalIsVisible: state.user.confirmDeleteUserModalIsVisible,
+    validation: state.user.validation
 });
 
 const mapDispatchToProps = (dispatch) => ({
     setUserEmail: (email) => dispatch({ type: SET_USER_EMAIL, email }),
+    validateEmail: () => dispatch({ type: VALIDATE_USER_EMAIL }),
     updateUser: () => dispatch({ type: UPDATE_USER }),
     showConfirmDeleteUserModal: () => dispatch({ type: SHOW_CONFIRM_DELETE_USER_MODAL })
 });

--- a/src/user/UserSettings.js
+++ b/src/user/UserSettings.js
@@ -41,6 +41,7 @@ class UserSettings extends React.Component {
 
     onRemoveEmailClick = () => {
         this.props.setUserEmail(null);
+        this.props.validateEmail();
         this.props.updateUser();
     };
 

--- a/src/user/UserSettings.js
+++ b/src/user/UserSettings.js
@@ -1,6 +1,5 @@
-import AlertStripe from 'nav-frontend-alertstriper';
 import { Column, Container, Row } from 'nav-frontend-grid';
-import { Flatknapp, Hovedknapp, Knapp } from 'nav-frontend-knapper';
+import { Flatknapp, Knapp } from 'nav-frontend-knapper';
 import { Input } from 'nav-frontend-skjema';
 import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import PropTypes from 'prop-types';
@@ -160,11 +159,6 @@ class UserSettings extends React.Component {
                             {this.props.confirmDeleteUserModalIsVisible && (
                                 <ConfirmDeleteUserModal />
                             )}
-                            {this.props.userAlertStripeIsVisible && (
-                                <AlertStripe type="suksess" solid className="UserSettingsAlertStripe">
-                                    E-postadressen din ble endret
-                                </AlertStripe>
-                            )}
                         </div>
                     )}
                 </Container>
@@ -188,7 +182,6 @@ UserSettings.propTypes = {
     showConfirmDeleteUserModal: PropTypes.func.isRequired,
     updateUser: PropTypes.func.isRequired,
     confirmDeleteUserModalIsVisible: PropTypes.bool.isRequired,
-    userAlertStripeIsVisible: PropTypes.bool.isRequired,
     isUpdating: PropTypes.bool.isRequired,
     validation: PropTypes.shape({
         email: PropTypes.string
@@ -200,7 +193,6 @@ const mapStateToProps = (state) => ({
     user: state.user.user,
     isUpdating: state.user.isUpdating,
     updateUserError: state.user.updateUserError,
-    userAlertStripeIsVisible: state.user.userAlertStripeIsVisible,
     confirmDeleteUserModalIsVisible: state.user.confirmDeleteUserModalIsVisible,
     validation: state.user.validation
 });

--- a/src/user/UserSettings.less
+++ b/src/user/UserSettings.less
@@ -43,20 +43,8 @@
   margin-bottom: 2.5rem;
 }
 
-@media (min-width: @screen-md-min) {
-  .UserSettings__email-buttons .knapp:not(:last-child) {
+.UserSettings__email-buttons .knapp:not(:last-child) {
     margin-right: @knapp-margin-right;
-  }
-}
-
-@media (max-width: @screen-sm-max) {
-  .UserSettings__email-buttons .knapp {
-    width: 100%;
-  }
-
-  .UserSettings__email-buttons .knapp:not(:last-child) {
-    margin-bottom: @knapp-margin-right;
-  }
 }
 
 .UserSettings__not-authenticated-title {

--- a/src/user/UserSettings.less
+++ b/src/user/UserSettings.less
@@ -24,9 +24,6 @@
   margin: 0 auto;
 }
 
-.UserSettings__main {
-}
-
 .UserSettings__section {
   background: #fff;
   padding: 2rem;
@@ -46,8 +43,20 @@
   margin-bottom: 2.5rem;
 }
 
-.UserSettings__email-buttons .knapp:not(:last-child) {
-  margin-right: @knapp-margin-right;
+@media (min-width: @screen-md-min) {
+  .UserSettings__email-buttons .knapp:not(:last-child) {
+    margin-right: @knapp-margin-right;
+  }
+}
+
+@media (max-width: @screen-sm-max) {
+  .UserSettings__email-buttons .knapp {
+    width: 100%;
+  }
+
+  .UserSettings__email-buttons .knapp:not(:last-child) {
+    margin-bottom: @knapp-margin-right;
+  }
 }
 
 .UserSettings__not-authenticated-title {

--- a/src/user/userReducer.js
+++ b/src/user/userReducer.js
@@ -21,6 +21,8 @@ export const FETCH_USER_FAILURE = 'FETCH_USER_FAILURE';
 export const CREATE_USER = 'CREATE_USER';
 export const CREATE_USER_BEGIN = 'CREATE_USER_BEGIN';
 export const CREATE_USER_SUCCESS = 'CREATE_USER_SUCCESS';
+export const CREATE_USER_HIDE_ALERT = 'CREATE_USER_HIDE_ALERT';
+export const CREATE_USER_SHOW_ALERT = 'CREATE_USER_SHOW_ALERT';
 export const CREATE_USER_FAILURE = 'CREATE_USER_FAILURE';
 
 export const UPDATE_USER = 'UPDATE_USER';
@@ -52,6 +54,7 @@ const initialState = {
     isUpdating: false,
     isDeletingUser: false,
     userAlertStripeIsVisible: false,
+    userAlertStripeMode: 'added',
     termsOfUseModalIsVisible: false,
     confirmDeleteUserModalIsVisible: false,
     validation: {}
@@ -84,13 +87,21 @@ export default function authorizationReducer(state = initialState, action) {
                 ...state,
                 user: action.response,
                 isCreating: false,
-                termsOfUseModalIsVisible: false
+                termsOfUseModalIsVisible: false,
+                userAlertStripeIsVisible: false
+            };
+        case CREATE_USER_SHOW_ALERT:
+            return {
+                ...state,
+                userAlertStripeIsVisible: true,
+                userAlertStripeMode: 'added'
             };
         case CREATE_USER_FAILURE:
             return {
                 ...state,
                 isCreating: false,
-                termsOfUseModalIsVisible: false
+                termsOfUseModalIsVisible: false,
+                userAlertStripeIsVisible: false
             };
         case SET_USER_EMAIL:
             return {
@@ -110,8 +121,10 @@ export default function authorizationReducer(state = initialState, action) {
                 ...state,
                 isUpdating: false,
                 user: action.response,
-                userAlertStripeIsVisible: true
+                userAlertStripeIsVisible: true,
+                userAlertStripeMode: 'changed'
             };
+        case CREATE_USER_HIDE_ALERT:
         case UPDATE_USER_HIDE_ALERT:
             return {
                 ...state,
@@ -239,6 +252,11 @@ function* createUser(action) {
         };
         const response = yield call(userApiPost, `${AD_USER_API}/api/v1/user`, fixUser(user));
         yield put({ type: CREATE_USER_SUCCESS, response });
+        if (user.email) {
+            yield put({ type: CREATE_USER_SHOW_ALERT });
+            yield call(delay, 5000);
+            yield put({ type: CREATE_USER_HIDE_ALERT });
+        }
     } catch (e) {
         if (e instanceof SearchApiError) {
             yield put({ type: CREATE_USER_FAILURE, error: e });

--- a/src/user/userReducer.js
+++ b/src/user/userReducer.js
@@ -38,6 +38,10 @@ export const DELETE_USER_FAILURE = 'DELETE_USER_FAILURE';
 
 export const SET_USER_EMAIL = 'SET_USER_EMAIL';
 
+export const VALIDATE_USER_EMAIL = 'VALIDATE_USER_EMAIL';
+export const SET_VALIDATION_ERROR = 'SET_VALIDATION_ERROR';
+export const REMOVE_VALIDATION_ERROR = 'REMOVE_VALIDATION_ERROR';
+
 const TERMS_VERSION = 'sok_v1';
 
 const initialState = {
@@ -49,7 +53,8 @@ const initialState = {
     isDeletingUser: false,
     userAlertStripeIsVisible: false,
     termsOfUseModalIsVisible: false,
-    confirmDeleteUserModalIsVisible: false
+    confirmDeleteUserModalIsVisible: false,
+    validation: {}
 };
 
 export default function authorizationReducer(state = initialState, action) {
@@ -159,6 +164,22 @@ export default function authorizationReducer(state = initialState, action) {
                 confirmDeleteUserModalIsVisible: false,
                 isDeletingUser: false
             };
+        case SET_VALIDATION_ERROR:
+            return {
+                ...state,
+                validation: {
+                    ...state.validation,
+                    [action.field]: action.message
+                }
+            };
+        case REMOVE_VALIDATION_ERROR:
+            return {
+                ...state,
+                validation: {
+                    ...state.validation,
+                    [action.field]: undefined
+                }
+            };
         default:
             return state;
     }
@@ -228,18 +249,20 @@ function* createUser(action) {
 }
 
 function* updateUser() {
-    try {
-        const state = yield select();
-        yield put({ type: UPDATE_USER_BEGIN });
-        const response = yield call(userApiPut, `${AD_USER_API}/api/v1/user`, fixUser(state.user.user));
-        yield put({ type: UPDATE_USER_SUCCESS, response });
-        yield call(delay, 5000);
-        yield put({ type: UPDATE_USER_HIDE_ALERT });
-    } catch (e) {
-        if (e instanceof SearchApiError) {
-            yield put({ type: UPDATE_USER_FAILURE, error: e });
-        } else {
-            throw e;
+    const state = yield select();
+    if (state.user.validation.email === undefined) {
+        try {
+            yield put({ type: UPDATE_USER_BEGIN });
+            const response = yield call(userApiPut, `${AD_USER_API}/api/v1/user`, fixUser(state.user.user));
+            yield put({ type: UPDATE_USER_SUCCESS, response });
+            yield call(delay, 5000);
+            yield put({ type: UPDATE_USER_HIDE_ALERT });
+        } catch (e) {
+            if (e instanceof SearchApiError) {
+                yield put({ type: UPDATE_USER_FAILURE, error: e });
+            } else {
+                throw e;
+            }
         }
     }
 }
@@ -258,10 +281,25 @@ function* deleteUser() {
     }
 }
 
+function* validateEMail() {
+    const email = yield select((state) => state.user.user.email);
+    const error = email && (email.length > 0) && (email.indexOf('@') === -1);
+    if (error) {
+        yield put({
+            type: SET_VALIDATION_ERROR,
+            field: 'email',
+            message: 'E-postadressen er ugyldig. Den må minimum inneholde en «@»'
+        });
+    } else {
+        yield put({ type: REMOVE_VALIDATION_ERROR, field: 'email' });
+    }
+}
+
 export const userSaga = function* saga() {
     yield takeEvery(FETCH_IS_AUTHENTICATED, fetchIsAuthenticated);
     yield takeEvery(FETCH_IS_AUTHENTICATED_SUCCESS, fetchUser);
     yield takeLatest(CREATE_USER, createUser);
     yield takeLatest(UPDATE_USER, updateUser);
     yield takeLatest(DELETE_USER, deleteUser);
+    yield takeLatest(VALIDATE_USER_EMAIL, validateEMail);
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,16 +21,13 @@ export function formatISOString(isoString, format = 'DD.MM.YYYY') {
 }
 
 export function isValidUrl(input) {
-    const pattern = new RegExp('^(https?:\\/\\/)' + // protocol (requires http://or https://)
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,})' + // domain name
-        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-        '(\\#[-a-z\\d_]*)?$', 'i'); // fragment locater
+    const pattern = new RegExp('^(https?:\\/\\/)' // protocol (requires http://or https://)
+        + '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,})' // domain name
+        + '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' // port and path
+        + '(\\?[;&a-z\\d%_.~+=-]*)?' // query string
+        + '(\\#[-a-z\\d_]*)?$', 'i'); // fragment locater
 
-    if (pattern.test(input)) {
-        return true;
-    }
-    return false;
+    return pattern.test(input);
 }
 
 export function removeUndefinedOrEmptyString(obj) {

--- a/src/variables.less
+++ b/src/variables.less
@@ -17,7 +17,7 @@
 @muted-text-color: @navGra60;
 
 @modal-padding: 1rem;
-@modal-padding-mobile: 0.25rem;
+@modal-padding-mobile: 0;
 @modal-title-margin-bottom: 1.25rem;
 @modal-body-margin-bottom: 2.5rem;
 


### PR DESCRIPTION
Ref: [PAM-1817]

Det er ikke hensiktsmessig at en bruker skal kunne lagre et "tomt" søk og dermed kunne abonnere på absolutt alle stillinger som kommer inn. En enkel fiks er å disable lagreknappen når søkeskjemaet er tomt for avhukinger og søketekst, og det er det jeg har gjort her.

SaveSearchButton mapper to nye properties fra store til props, searchIsNonEmpty og searchBoxValue. Disse brukes til å se om bruker har tekst i søkefeltet og/eller har huket av noe i søkeskjemaet, og avhengig av dette blir lagringsknappen disabled/enabled.