### PR TITLE
[PAM-1999] Legg til støtte for utc string i published søkefilter

### DIFF
--- a/scripts/searchApiTemplates.js
+++ b/scripts/searchApiTemplates.js
@@ -14,21 +14,24 @@ function mapSortByOrder(value) {
 }
 
 function filterPublished(published) {
-    const filters = {
+    if (published) {
+        return {
+            bool: {
+                should: [{
+                    range: {
+                        published: {
+                            gte: published
+                        }
+                    }
+                }]
+            }
+        };
+    }
+    return {
         bool: {
             should: []
         }
     };
-    if (published && published.length > 0) {
-        filters.bool.should.push({
-            range: {
-                published: {
-                    gte: 'now-1d'
-                }
-            }
-        });
-    }
-    return filters;
 }
 
 function suggest(field, match, minLength) {

--- a/src/search/facets/published/Published.js
+++ b/src/search/facets/published/Published.js
@@ -3,19 +3,20 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Checkbox } from 'nav-frontend-skjema';
 import { SEARCH } from '../../searchReducer';
-import {
-    CHECK_PUBLISHED,
-    UNCHECK_PUBLISHED
-} from './publishedReducer';
+import { SET_PUBLISHED } from './publishedReducer';
 import './Published.less';
+
+const PublishedLabelsEnum = {
+    'now-1d': 'Nye i dag'
+};
 
 class Published extends React.Component {
     onPublishedClick = (e) => {
         const { value } = e.target;
         if (e.target.checked) {
-            this.props.checkPublished(value);
+            this.props.setPublished(value);
         } else {
-            this.props.uncheckPublished(value);
+            this.props.setPublished(undefined);
         }
         this.props.search();
     };
@@ -30,10 +31,10 @@ class Published extends React.Component {
                     <Checkbox
                         name="published"
                         key={item.key}
-                        label={`Nye i dag (${item.count})`}
+                        label={`${PublishedLabelsEnum[item.key]} (${item.count})`}
                         value={item.key}
                         onChange={this.onPublishedClick}
-                        checked={checkedPublished.includes(item.key)}
+                        checked={checkedPublished === item.key}
                     />
                 ))}
             </div>
@@ -41,14 +42,17 @@ class Published extends React.Component {
     }
 }
 
+Published.defaultProps = {
+    checkedPublished: undefined
+};
+
 Published.propTypes = {
     published: PropTypes.arrayOf(PropTypes.shape({
         key: PropTypes.string,
         count: PropTypes.number
     })).isRequired,
-    checkedPublished: PropTypes.arrayOf(PropTypes.string).isRequired,
-    checkPublished: PropTypes.func.isRequired,
-    uncheckPublished: PropTypes.func.isRequired,
+    checkedPublished: PropTypes.string,
+    setPublished: PropTypes.func.isRequired,
     search: PropTypes.func.isRequired
 };
 
@@ -59,8 +63,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
     search: () => dispatch({ type: SEARCH }),
-    checkPublished: (value) => dispatch({ type: CHECK_PUBLISHED, value }),
-    uncheckPublished: (value) => dispatch({ type: UNCHECK_PUBLISHED, value })
+    setPublished: (value) => dispatch({ type: SET_PUBLISHED, value })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Published);

--- a/src/search/facets/published/publishedReducer.js
+++ b/src/search/facets/published/publishedReducer.js
@@ -2,7 +2,7 @@ import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSea
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
 import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
 
-export const SET_PUBLISHED = 'CHECK_PUBLISHED';
+export const SET_PUBLISHED = 'SET_PUBLISHED';
 
 const initialState = {
     published: [],

--- a/src/search/facets/published/publishedReducer.js
+++ b/src/search/facets/published/publishedReducer.js
@@ -2,12 +2,11 @@ import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSea
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
 import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
 
-export const CHECK_PUBLISHED = 'CHECK_PUBLISHED';
-export const UNCHECK_PUBLISHED = 'UNCHECK_PUBLISHED';
+export const SET_PUBLISHED = 'CHECK_PUBLISHED';
 
 const initialState = {
     published: [],
-    checkedPublished: []
+    checkedPublished: undefined
 };
 
 export default function publishedReducer(state = initialState, action) {
@@ -16,12 +15,12 @@ export default function publishedReducer(state = initialState, action) {
         case RESTORE_STATE_FROM_SAVED_SEARCH:
             return {
                 ...state,
-                checkedPublished: action.query.published || []
+                checkedPublished: action.query.published
             };
         case RESET_SEARCH:
             return {
                 ...state,
-                checkedPublished: []
+                checkedPublished: undefined
             };
         case FETCH_INITIAL_FACETS_SUCCESS:
             return {
@@ -41,18 +40,10 @@ export default function publishedReducer(state = initialState, action) {
                     };
                 })
             };
-        case CHECK_PUBLISHED:
+        case SET_PUBLISHED:
             return {
                 ...state,
-                checkedPublished: [
-                    ...state.checkedPublished,
-                    action.value
-                ]
-            };
-        case UNCHECK_PUBLISHED:
-            return {
-                ...state,
-                checkedPublished: state.checkedPublished.filter((m) => (m !== action.value))
+                checkedPublished: action.value
             };
         default:
             return state;

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -114,7 +114,7 @@ export function toSearchQuery(state) {
     if (state.sorting.sort.length > 0) query.sort = state.sorting.sort;
     if (state.counties.checkedCounties.length > 0) query.counties = state.counties.checkedCounties;
     if (state.counties.checkedMunicipals.length > 0) query.municipals = state.counties.checkedMunicipals;
-    if (state.published.checkedPublished.length > 0) query.published = state.published.checkedPublished;
+    if (state.published.checkedPublished) query.published = state.published.checkedPublished;
     if (state.engagement.checkedEngagementType.length > 0) query.engagementType = state.engagement.checkedEngagementType;
     if (state.sector.checkedSector.length > 0) query.sector = state.sector.checkedSector;
     if (state.extent.checkedExtent.length > 0) query.extent = state.extent.checkedExtent;


### PR DESCRIPTION
E-postutsendelse forusetter at man kan søke med feks ?published=2018-11-15T10:07:33.873.