### PR TITLE
[PAM-2123]: Tilpasser hjelpeteksten til mobil.

### DIFF
--- a/src/savedSearches/SaveSearchButton.js
+++ b/src/savedSearches/SaveSearchButton.js
@@ -3,6 +3,7 @@ import HjelpetekstBase from 'nav-frontend-hjelpetekst';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import HjelpetekstBase from 'nav-frontend-hjelpetekst';
 import AuthorizationEnum from '../user/AuthorizationEnum';
 import { SHOW_AUTHORIZATION_ERROR_MODAL, SHOW_TERMS_OF_USE_MODAL } from '../user/userReducer';
 import { SavedSearchFormMode, SHOW_SAVED_SEARCH_FORM } from './form/savedSearchFormReducer';
@@ -30,6 +31,7 @@ class SaveSearchButton extends React.Component {
             <Knapp mini className="SaveSearchButton" onClick={this.onClick}>Lagre søk</Knapp>
         ) : (
             <HjelpetekstBase
+                type="over"
                 id="hjelpetekstLagreknapp"
                 anchor={() => (
                     <div role="button" className="knapp knapp--mini knapp--disabled SaveSearchButton">

--- a/src/savedSearches/SaveSearchButton.js
+++ b/src/savedSearches/SaveSearchButton.js
@@ -3,7 +3,6 @@ import HjelpetekstBase from 'nav-frontend-hjelpetekst';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import HjelpetekstBase from 'nav-frontend-hjelpetekst';
 import AuthorizationEnum from '../user/AuthorizationEnum';
 import { SHOW_AUTHORIZATION_ERROR_MODAL, SHOW_TERMS_OF_USE_MODAL } from '../user/userReducer';
 import { SavedSearchFormMode, SHOW_SAVED_SEARCH_FORM } from './form/savedSearchFormReducer';

--- a/src/savedSearches/SavedSearches.less
+++ b/src/savedSearches/SavedSearches.less
@@ -14,3 +14,57 @@
     display: flex;
     justify-content: center;
 }
+
+
+/* Hjelpetekst-komponeneten er kodet slik at den blir fullscreen på mobil.
+Endringer på dette skal skje, men bruker koden under intil det er på plass */
+@media (max-width: @screen-xs-max) {
+  #tooltip-hjelpetekstLagreknapp  {
+      position: absolute;
+      width: 95vw;
+      max-width: 24rem;
+      top: auto;
+      left: auto;
+      right: auto;
+      bottom: 3rem;
+      border-radius: 0.25rem;
+
+    &:before,
+    &:after {
+      content: '';
+      height: sqrt(2.25rem / 2); // Pythagoras
+      width: sqrt(2.25rem / 2); // Pythagoras
+      background-color: @navMorkGra;
+      display: block;
+      position: absolute;
+      transform: rotate(-45deg);
+      transform-origin: 0 0;
+      z-index: 1;
+      border: 3px solid transparent;
+      box-sizing: border-box;
+    }
+
+    &:after {
+      z-index: 0;
+      background-color: transparent;
+      transform: rotate(-45deg);
+      box-sizing: content-box;
+      border: 3px solid transparent;
+    }
+    
+     &:before,
+     &:focus:after {
+       top: 100%;
+       bottom: 3rem;
+       left: 1.25rem;
+     }
+
+
+     &:focus:after {
+       left: 1rem;
+       border-left-color: @orangeFocus;
+       border-bottom-color: @orangeFocus;
+     }
+
+  }
+}


### PR DESCRIPTION
folkene i designsystemet sier at de har i backlog'en å støtte mobilvisning av denne komponenten. Intil videre la jeg til en media queries for mobilvisning. Måtte sette komponeneten til alltid å vises over tilhørende knapp for å få til dette, men tenker det er greit?