### PR TITLE
[PAM-2179] Fjern pilotbanner når vi skrur av på lagre søk og funn

### DIFF
--- a/src/styles.less
+++ b/src/styles.less
@@ -52,32 +52,6 @@ body {
   }
 }
 
-.pilot {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-  width: 272.5px;
-  transform: rotate(-45deg);
-  text-align: center;
-  color: #3E3832;
-  background-color: #ff9100;
-  position: absolute;
-  top: 45px;
-  left: -92px;
-  padding: 7px 20px 10px 46px;
-  z-index: 9999;
-  font-size: 110%;
-}
-
-@media (max-width: @screen-xs-max) {
-  .pilot {
-    font-size: 100%;
-    top: 37px;
-    left: -102px;
-    padding: 3px 20px 6px 46px;
-  }
-}
-
 .background--light-green {
   background-color: @background-green;
 }

--- a/views/index.html
+++ b/views/index.html
@@ -15,7 +15,6 @@
 <body>
     <div id="top" class="no-print"></div>
     <header class="header text-center no-print">
-        <span class="pilot typo-element">Tidlig versjon</span>
         <a class="header__nav-logo" href="https://www.nav.no/Forsiden" title="Gå til nav.no">
             <img src="https://www.nav.no/_public/beta.nav.no/images/logo.png" width="99px" height="65px" alt="NAV-logo"/>
         </a>


### PR DESCRIPTION
Den orange banneren som sier Tidlig versjon i stillingssøket fjernes når det har gått noen dager etter at vi har fått på plass lagre søk og lagre stillinger. 

MERGE DENNE ETTER AT TOGGLE ER AVSKRUDD og det har godt et par dager