### PR TITLE
[PAM-2182] Gjør besøkte lenker lilla

### DIFF
--- a/src/search/searchResults/SearchResultsItemDetails.less
+++ b/src/search/searchResults/SearchResultsItemDetails.less
@@ -29,7 +29,15 @@
     color: @navGronn;
 
     &:hover {
-      border-color: @navGronn;
+      border-color: @navGra40;
+    }
+
+    &:visited {
+      color: @navLilla;
+    }
+
+    &:visited:hover {
+      color: @navLillaDarken20;
     }
   }
 }


### PR DESCRIPTION
Gitt at jeg er på stillingssøket har besøkt en stilling. Når jeg kommer tilbake til resultatvisningen så skal den aktuelle stillingen bli markert som besøkt (lilla tekst)