### PR TITLE
Pam 2226 samtykke ved innlogging

### DIFF
--- a/src/Application.js
+++ b/src/Application.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { PersonbrukerHeader } from 'pam-frontend-header';
 import Error from './error/Error';
 import { CONTEXT_PATH } from './fasitProperties';
 import Favourites from './favourites/Favourites';
@@ -10,11 +11,12 @@ import SavedSearches from './savedSearches/SavedSearches';
 import SearchPage from './search/Search';
 import StillingPage from './stilling/Stilling';
 import NotAuthenticatedModal from './authentication/NotAuthenticatedModal';
-import TermsOfUse from './user/TermsOfUse';
 import { FETCH_IS_AUTHENTICATED } from './authentication/authenticationReducer';
 import UserSettings from './user/UserSettings';
 import UserAlertStripe from './user/UserAlertStripe';
 import TopMenu from './common/topMenu/TopMenu';
+import TermsOfUseModal from './user/TermsOfUseModal';
+import TermsOfUsePage from './user/TermsOfUsePage';
 
 class Application extends React.Component {
     componentDidMount() {
@@ -27,6 +29,7 @@ class Application extends React.Component {
                 <div>
                     <Error />
                     <Switch>
+                        <Route exact path={`${CONTEXT_PATH}/samtykke`} component={PersonbrukerHeader} />
                         <Route component={TopMenu} />
                     </Switch>
                     <Switch>
@@ -36,11 +39,12 @@ class Application extends React.Component {
                         <Route path={`${CONTEXT_PATH}/favoritter`} component={Favourites} />
                         <Route path={`${CONTEXT_PATH}/lagrede-sok`} component={SavedSearches} />
                         <Route path={`${CONTEXT_PATH}/innstillinger`} component={UserSettings} />
+                        <Route path={`${CONTEXT_PATH}/samtykke`} component={TermsOfUsePage} />
                         <Route path="*" component={SearchPage} />
                     </Switch>
 
                     {this.props.termsOfUseModalIsVisible && (
-                        <TermsOfUse />
+                        <TermsOfUseModal />
                     )}
 
                     {this.props.authenticationRequiredModalIsVisible && (

--- a/src/common/pageHeader/PageHeader.js
+++ b/src/common/pageHeader/PageHeader.js
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import './PageHeader.less';
 
 export default function PageHeader({
-    backUrl, title, backLabel
+    backUrl, title, backLabel, isInternalRedirect
 }) {
     return (
         <div className="PageHeader">
@@ -16,15 +16,27 @@ export default function PageHeader({
                     <Column xs="12" sm="3">
                         {backUrl && (
                             <div className="PageHeader__left">
-                                <Link
-                                    to={backUrl}
-                                    className="PageHeader__back typo-normal lenke no-print"
-                                >
-                                    <Chevron type="venstre" className="PageHeader__back__chevron" />
-                                    <span className="PageHeader__back__text">
-                                        {backLabel || 'Til stillingsøk'}
-                                    </span>
-                                </Link>
+                                {isInternalRedirect ? (
+                                    <Link
+                                        to={backUrl}
+                                        className="PageHeader__back typo-normal lenke no-print"
+                                    >
+                                        <Chevron type="venstre" className="PageHeader__back__chevron" />
+                                        <span className="PageHeader__back__text">
+                                            {backLabel || 'Til stillingsøk'}
+                                        </span>
+                                    </Link>
+                                ) : (
+                                    <a
+                                        href={backUrl}
+                                        className="PageHeader__back typo-normal lenke no-print"
+                                    >
+                                        <Chevron type="venstre" className="PageHeader__back__chevron" />
+                                        <span className="PageHeader__back__text">
+                                            {backLabel || 'Til stillingsøk'}
+                                        </span>
+                                    </a>
+                                )}
                             </div>
                         )}
                     </Column>
@@ -41,13 +53,14 @@ export default function PageHeader({
 PageHeader.defaultProps = {
     backUrl: undefined,
     backLabel: undefined,
-    buttons: undefined
+    buttons: undefined,
+    isInternalRedirect: true
 };
 
 PageHeader.propTypes = {
     backUrl: PropTypes.string,
     backLabel: PropTypes.string,
     title: PropTypes.string.isRequired,
-    buttons: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node])
+    isInternalRedirect: PropTypes.bool
 };
 

--- a/src/search/Search.js
+++ b/src/search/Search.js
@@ -36,6 +36,7 @@ class Search extends React.Component {
         super(props);
         this.props.restoreStateFromUrl();
         this.props.initialSearch();
+        this.fraArbeidsplassen = localStorage.getItem('fraArbeidsplassen');
     }
 
     componentDidMount() {
@@ -43,9 +44,13 @@ class Search extends React.Component {
     }
 
     componentWillUpdate(nextProps) {
-        if (window.location.pathname === `${CONTEXT_PATH}/stillinger` && nextProps.userNotFound) {
+        if (this.fraArbeidsplassen && nextProps.userNotFound) {
             this.props.history.replace(`${CONTEXT_PATH}/samtykke`);
         }
+    }
+
+    componentWillUnmount() {
+        localStorage.removeItem('fraArbeidsplassen');
     }
 
 

--- a/src/search/Search.js
+++ b/src/search/Search.js
@@ -41,6 +41,13 @@ class Search extends React.Component {
         document.title = 'Ledige stillinger';
     }
 
+    componentWillUpdate(nextProps) {
+        if (window.location.pathname === '/pam-stillingsok/stillinger' && nextProps.userNotFound) {
+            this.props.history.push('/pam-stillingsok/samtykke');
+        }
+    }
+
+
     onSearchFormSubmit = (e) => {
         e.preventDefault();
         this.props.search();
@@ -154,7 +161,10 @@ Search.propTypes = {
     initialSearchDone: PropTypes.bool.isRequired,
     isSearching: PropTypes.bool.isRequired,
     isAuthenticated: PropTypes.string.isRequired,
-    user: PropTypes.shape({})
+    user: PropTypes.shape({}),
+    history: PropTypes.shape({
+        push: PropTypes.func
+    }).isRequired
 };
 
 const mapStateToProps = (state) => ({
@@ -164,7 +174,8 @@ const mapStateToProps = (state) => ({
     savedSearches: state.savedSearches.savedSearches,
     isSavedSearchesExpanded: state.savedSearchExpand.isSavedSearchesExpanded,
     isAuthenticated: state.authentication.isAuthenticated,
-    user: state.user.user
+    user: state.user.user,
+    userNotFound: state.user.userNotFound
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/search/Search.js
+++ b/src/search/Search.js
@@ -29,6 +29,7 @@ import SearchResults from './searchResults/SearchResults';
 import Sorting from './sorting/Sorting';
 import ViewMode from './viewMode/ViewMode';
 import { authenticationEnum } from '../authentication/authenticationReducer';
+import { CONTEXT_PATH } from '../fasitProperties';
 
 class Search extends React.Component {
     constructor(props) {
@@ -42,8 +43,8 @@ class Search extends React.Component {
     }
 
     componentWillUpdate(nextProps) {
-        if (window.location.pathname === '/pam-stillingsok/stillinger' && nextProps.userNotFound) {
-            this.props.history.push('/pam-stillingsok/samtykke');
+        if (window.location.pathname === `${CONTEXT_PATH}/stillinger` && nextProps.userNotFound) {
+            this.props.history.replace(`${CONTEXT_PATH}/samtykke`);
         }
     }
 
@@ -163,7 +164,7 @@ Search.propTypes = {
     isAuthenticated: PropTypes.string.isRequired,
     user: PropTypes.shape({}),
     history: PropTypes.shape({
-        push: PropTypes.func
+        replace: PropTypes.func
     }).isRequired
 };
 

--- a/src/search/Search.js
+++ b/src/search/Search.js
@@ -36,7 +36,6 @@ class Search extends React.Component {
         super(props);
         this.props.restoreStateFromUrl();
         this.props.initialSearch();
-        this.fraArbeidsplassen = localStorage.getItem('fraArbeidsplassen');
     }
 
     componentDidMount() {
@@ -44,13 +43,9 @@ class Search extends React.Component {
     }
 
     componentWillUpdate(nextProps) {
-        if (this.fraArbeidsplassen && nextProps.userNotFound) {
+        if (window.location.pathname === `${CONTEXT_PATH}/stillinger` && nextProps.userNotFound) {
             this.props.history.replace(`${CONTEXT_PATH}/samtykke`);
         }
-    }
-
-    componentWillUnmount() {
-        localStorage.removeItem('fraArbeidsplassen');
     }
 
 

--- a/src/user/TermsOfUse.js
+++ b/src/user/TermsOfUse.js
@@ -1,12 +1,11 @@
 import { Flatknapp, Hovedknapp } from 'nav-frontend-knapper';
-import Modal from 'nav-frontend-modal';
 import { Checkbox, Input } from 'nav-frontend-skjema';
 import { Element, Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import './TermsOfUse.less';
-import { CREATE_USER, HIDE_TERMS_OF_USE_MODAL, SET_USER_TERMS_ACCEPTED } from './userReducer';
+import { CREATE_USER, SET_USER_TERMS_ACCEPTED } from './userReducer';
 
 class TermsOfUse extends React.Component {
     constructor(props) {
@@ -24,6 +23,10 @@ class TermsOfUse extends React.Component {
     onAcceptTerms = () => {
         if (this.state.hasValidationError === false) {
             this.props.createUser(this.state.email);
+
+            if (this.props.redirectPage !== undefined && this.props.termsAccepted) {
+                this.props.history.push(this.props.redirectPage);
+            }
         }
     };
 
@@ -39,94 +42,96 @@ class TermsOfUse extends React.Component {
         });
     };
 
-    closeModal = () => {
-        this.props.hideModal();
+    onCancelClick = () => {
+        this.props.onCancel();
     };
 
     render() {
         return (
-            <Modal
-                isOpen
-                onRequestClose={this.closeModal}
-                contentLabel="Ta i bruk innloggede tjenester"
-                appElement={document.getElementById('app')}
-            >
-                <div className="TermsOfUse">
-                    <Undertittel className="TermsOfUse__title">
+            <div className="TermsOfUse">
+                <Undertittel className="TermsOfUse__title">
                         Ta i bruk innloggede tjenester
-                    </Undertittel>
-                    <Normaltekst className="TermsOfUse__section">
+                </Undertittel>
+                <Normaltekst className="TermsOfUse__section">
                         Du må samtykke for å bruke innloggede tjenester i stillingssøk.
-                    </Normaltekst>
-                    <div className="TermsOfUse__section">
-                        <Element>Vi lagrer:</Element>
-                        <ul className="typo-normal">
-                            <li>dine favoritter</li>
-                            <li>søk med søkekriterier</li>
-                            <li>e-postadresse (valgfritt)</li>
-                        </ul>
-                    </div>
-                    <div className="TermsOfUse__section TermsOfUse__section--email">
-                        <Element>E-post til lagrede søk</Element>
-                        <Normaltekst>
+                </Normaltekst>
+                <div className="TermsOfUse__section">
+                    <Element>Vi lagrer:</Element>
+                    <ul className="typo-normal">
+                        <li>dine favoritter</li>
+                        <li>søk med søkekriterier</li>
+                        <li>e-postadresse (valgfritt)</li>
+                    </ul>
+                </div>
+                <div className="TermsOfUse__section TermsOfUse__section--email">
+                    <Element>E-post til lagrede søk</Element>
+                    <Normaltekst>
                             Ønsker du å motta varslinger på et lagret søk trenger vi e-postadressen din.
                             Den vil bare bli brukt til dette formålet. Du kan senere velge å skru av
                             e-postvarsling under lagrede søk eller slette e-postadressen under dine innstillinger.
-                        </Normaltekst>
-                        <div className="TermsOfUse__input">
-                            <Input
-                                label="Oppgi e-post hvis du ønsker varsling (valgfritt)"
-                                value={this.state.email}
-                                onChange={this.onEmailChange}
-                                onBlur={this.onEmailBlur}
-                                feil={this.state.hasValidationError ? {
-                                    feilmelding: 'E-postadressen er ugyldig. Den må minimum inneholde en «@»'
-                                } : undefined}
-                            />
-                        </div>
-                    </div>
-                    <div className="TermsOfUse__section TermsOfUse__section--last">
-                        <Checkbox
-                            name="terms"
-                            label="Jeg samtykker til at Arbeidsplassen lagrer favoritter, søk og e-postadresse (valgfri)"
-                            value="terms"
-                            onChange={this.onCheckboxClick}
-                            checked={this.props.termsAccepted}
-                            feil={{
-                                feilmelding: this.props.showUserTermsRequiredMessage ?
-                                    'Du må huke av i avkryssingsboksen for å samtykke' : ''
-                            }}
+                    </Normaltekst>
+                    <div className="TermsOfUse__input">
+                        <Input
+                            label="Oppgi e-post hvis du ønsker varsling (valgfritt)"
+                            value={this.state.email}
+                            onChange={this.onEmailChange}
+                            onBlur={this.onEmailBlur}
+                            feil={this.state.hasValidationError ? {
+                                feilmelding: 'E-postadressen er ugyldig. Den må minimum inneholde en «@»'
+                            } : undefined}
                         />
-                        <Normaltekst>
-                            Du kan trekke samtykket hvis du ikke lenger ønsker å bruke innloggede tjenester
-                            i stillingssøket. Dette kan du gjøre under dine innstillinger.
-                        </Normaltekst>
-                    </div>
-                    <div className="TermsOfUse__buttons">
-                        <Hovedknapp
-                            onClick={this.onAcceptTerms}
-                            spinner={this.props.isCreating}
-                            disabled={this.props.isCreating}
-                        >
-                            Jeg samtykker
-                        </Hovedknapp>
-                        <Flatknapp onClick={this.closeModal}>
-                            Avbryt
-                        </Flatknapp>
                     </div>
                 </div>
-            </Modal>
+                <div className="TermsOfUse__section TermsOfUse__section--last">
+                    <Checkbox
+                        name="terms"
+                        label="Jeg samtykker til at Arbeidsplassen lagrer favoritter, søk og e-postadresse (valgfri)"
+                        value="terms"
+                        onChange={this.onCheckboxClick}
+                        checked={this.props.termsAccepted}
+                        feil={{
+                            feilmelding: this.props.showUserTermsRequiredMessage ?
+                                'Du må huke av i avkryssingsboksen for å samtykke' : ''
+                        }}
+                    />
+                    <Normaltekst>
+                            Du kan trekke samtykket hvis du ikke lenger ønsker å bruke innloggede tjenester
+                            i stillingssøket. Dette kan du gjøre under dine innstillinger.
+                    </Normaltekst>
+                </div>
+                <div className="TermsOfUse__buttons">
+                    <Hovedknapp
+                        onClick={this.onAcceptTerms}
+                        spinner={this.props.isCreating}
+                        disabled={this.props.isCreating}
+                    >
+                            Jeg samtykker
+                    </Hovedknapp>
+                    <Flatknapp onClick={this.onCancelClick}>
+                            Avbryt
+                    </Flatknapp>
+                </div>
+            </div>
         );
     }
 }
 
+TermsOfUse.defaultProps = {
+    redirectPage: undefined,
+    history: undefined
+};
+
 TermsOfUse.propTypes = {
     setUserTermsAccepted: PropTypes.func.isRequired,
     createUser: PropTypes.func.isRequired,
-    hideModal: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
     isCreating: PropTypes.bool.isRequired,
     termsAccepted: PropTypes.bool.isRequired,
-    showUserTermsRequiredMessage: PropTypes.bool.isRequired
+    showUserTermsRequiredMessage: PropTypes.bool.isRequired,
+    redirectPage: PropTypes.string,
+    history: PropTypes.shape({
+        push: PropTypes.func
+    })
 };
 
 const mapStateToProps = (state) => ({
@@ -137,8 +142,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
     setUserTermsAccepted: (termsAccepted) => dispatch({ type: SET_USER_TERMS_ACCEPTED, termsAccepted }),
-    createUser: (email) => dispatch({ type: CREATE_USER, email }),
-    hideModal: () => dispatch({ type: HIDE_TERMS_OF_USE_MODAL })
+    createUser: (email) => dispatch({ type: CREATE_USER, email })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TermsOfUse);

--- a/src/user/TermsOfUse.js
+++ b/src/user/TermsOfUse.js
@@ -25,7 +25,7 @@ class TermsOfUse extends React.Component {
             this.props.createUser(this.state.email);
 
             if (this.props.redirectPage !== undefined && this.props.termsAccepted) {
-                this.props.history.push(this.props.redirectPage);
+                this.props.history.replace(this.props.redirectPage);
             }
         }
     };
@@ -130,7 +130,7 @@ TermsOfUse.propTypes = {
     showUserTermsRequiredMessage: PropTypes.bool.isRequired,
     redirectPage: PropTypes.string,
     history: PropTypes.shape({
-        push: PropTypes.func
+        replace: PropTypes.func
     })
 };
 

--- a/src/user/TermsOfUseModal.js
+++ b/src/user/TermsOfUseModal.js
@@ -1,0 +1,37 @@
+import Modal from 'nav-frontend-modal';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { HIDE_TERMS_OF_USE_MODAL } from './userReducer';
+import TermsOfUse from './TermsOfUse';
+
+class TermsOfUseModal extends React.Component {
+    closeModal = () => {
+        this.props.hideModal();
+    };
+
+    render() {
+        return (
+            <Modal
+                isOpen
+                onRequestClose={this.closeModal}
+                contentLabel="Ta i bruk innloggede tjenester"
+                appElement={document.getElementById('app')}
+            >
+                <TermsOfUse
+                    onCancel={this.closeModal}
+                />
+            </Modal>
+        );
+    }
+}
+
+TermsOfUseModal.propTypes = {
+    hideModal: PropTypes.func.isRequired
+};
+
+const mapDispatchToProps = (dispatch) => ({
+    hideModal: () => dispatch({ type: HIDE_TERMS_OF_USE_MODAL })
+});
+
+export default connect(null, mapDispatchToProps)(TermsOfUseModal);

--- a/src/user/TermsOfUsePage.js
+++ b/src/user/TermsOfUsePage.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TermsOfUse from './TermsOfUse';
+import './TermsOfUsePage.less';
+import PageHeader from '../common/pageHeader/PageHeader';
+
+export default class TermsOfUsePage extends React.Component {
+    onCancelClick = () => {
+        window.location.href = 'https://arbeidsplassen.nav.no';
+    };
+
+    render() {
+        return (
+            <div>
+                <PageHeader
+                    title="Samtykke"
+                    backUrl="https://arbeidsplassen-q.nav.no"
+                    backLabel="Til forsiden"
+                    isInternalRedirect={false}
+                />
+                <div className="TermsOfUsePage">
+                    <TermsOfUse
+                        onCancel={this.onCancelClick}
+                        redirectPage="/"
+                        history={this.props.history}
+                    />
+                </div>
+            </div>
+        );
+    }
+}
+
+TermsOfUsePage.propTypes = {
+    history: PropTypes.shape({}).isRequired
+};

--- a/src/user/TermsOfUsePage.js
+++ b/src/user/TermsOfUsePage.js
@@ -14,7 +14,7 @@ export default class TermsOfUsePage extends React.Component {
             <div>
                 <PageHeader
                     title="Samtykke"
-                    backUrl="https://arbeidsplassen-q.nav.no"
+                    backUrl="https://arbeidsplassen.nav.no"
                     backLabel="Til forsiden"
                     isInternalRedirect={false}
                 />

--- a/src/user/TermsOfUsePage.js
+++ b/src/user/TermsOfUsePage.js
@@ -1,10 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import TermsOfUse from './TermsOfUse';
 import './TermsOfUsePage.less';
 import PageHeader from '../common/pageHeader/PageHeader';
 
-export default class TermsOfUsePage extends React.Component {
+class TermsOfUsePage extends React.Component {
+    componentWillUpdate(nextProps) {
+        if (nextProps.user !== undefined) {
+            this.props.history.replace('/');
+        }
+    }
+
     onCancelClick = () => {
         window.location.href = 'https://arbeidsplassen.nav.no';
     };
@@ -31,5 +38,13 @@ export default class TermsOfUsePage extends React.Component {
 }
 
 TermsOfUsePage.propTypes = {
-    history: PropTypes.shape({}).isRequired
+    history: PropTypes.shape({
+        replace: PropTypes.func
+    }).isRequired
 };
+
+const mapStateToProps = (state) => ({
+    user: state.user.user
+});
+
+export default connect(mapStateToProps)(TermsOfUsePage);

--- a/src/user/TermsOfUsePage.less
+++ b/src/user/TermsOfUsePage.less
@@ -1,0 +1,12 @@
+@import "../variables";
+
+.TermsOfUsePage {
+  max-width: 41rem;
+  margin: 2.5rem auto;
+  background-color: #ffffff;
+  padding: 2rem;
+
+  .TermsOfUse {
+    padding: 0!important;
+  }
+}

--- a/src/user/userReducer.js
+++ b/src/user/userReducer.js
@@ -11,6 +11,7 @@ export const HIDE_TERMS_OF_USE_MODAL = 'HIDE_TERMS_OF_USE_MODAL';
 export const FETCH_USER_BEGIN = 'FETCH_USER_BEGIN';
 export const FETCH_USER_SUCCESS = 'FETCH_USER_SUCCESS';
 export const FETCH_USER_FAILURE = 'FETCH_USER_FAILURE';
+export const USER_NOT_FOUND = 'USER_NOT_FOUND';
 
 export const CREATE_USER = 'CREATE_USER';
 export const CREATE_USER_BEGIN = 'CREATE_USER_BEGIN';
@@ -187,6 +188,11 @@ export default function authorizationReducer(state = initialState, action) {
                 ...state,
                 showUserTermsRequiredMessage: true
             };
+        case USER_NOT_FOUND:
+            return {
+                ...state,
+                userNotFound: true
+            };
         default:
             return state;
     }
@@ -211,7 +217,9 @@ function* fetchUser() {
             yield put({ type: FETCH_USER_SUCCESS, response });
         } catch (e) {
             if (e instanceof SearchApiError) {
-                if (e.statusCode !== 404) {
+                if (e.statusCode === 404) {
+                    yield put({ type: USER_NOT_FOUND });
+                } else {
                     yield put({ type: FETCH_USER_FAILURE, error: e });
                 }
             } else {


### PR DESCRIPTION
- Når bruker kommer fra arbeidsplassen og ikke har samtykket tidligere, så skal samtykke-siden vises.
- Fra PAM-Portal redirectes brukeren til en url som kun brukes fra forsiden, og det sjekkes da om samtykket er godtatt. (Dette er ikke implementert i Pam-portal enda, så dette må gjøres når denne merges inn).

Jira: https://jira.adeo.no/browse/PAM-2226
Skisse: https://app.zeplin.io/project/598323bd8e79174fbfc9a5be/screen/5c0528ef9040c902332dfe43