### PR TITLE
[Bugfix] Unngå at teksten "Lagret søk: Kokk, Oslo" skyver sorteringsboksen ut av selve siden på mobil

### DIFF
--- a/src/search/Search.less
+++ b/src/search/Search.less
@@ -24,7 +24,7 @@
   }
 }
 
-@media (min-width: @screen-md-min) {
+@media (min-width: @screen-sm-min) {
   .Search__main__left__save-search,
   .Search__main__center__header {
     min-height: 4rem;
@@ -55,6 +55,12 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
+}
+
+@media (max-width: @screen-xs-max) {
+  .Search__main__center__header__right {
+    justify-content: space-between;
+  }
 }
 
 .SavedSearchExpandButton__chevron {
@@ -119,19 +125,19 @@
   }
 
   .Search__main__center__header {
-    display: flex;
     padding-top: 16px !important;
     padding-bottom: 16px !important;
-    align-items: center;
     margin-bottom: 10px;
   }
 
   .Search__main__center__header__right {
     margin-bottom: 0;
   }
+}
 
+@media (max-width: @screen-xs-max) {
   .Search__main__center__header__left {
-    flex: none;
+    margin-bottom: 1rem;
   }
 }
 


### PR DESCRIPTION
Hvis bruker har lagret et søk med en lang tittel vil teksten skyve sorteringsboksen og kompaktvisningsknappen mot høyre og ut av bildet. Flytter derfor teksten med navnet på det lagrede søket opp på en egen linje.

![lagret](https://user-images.githubusercontent.com/29566394/52110225-47532e80-2600-11e9-8d20-2817d5b498f4.png)
