### PR TITLE
[Bugfix] Vis spinner mens user og samtykke lastes

### DIFF
--- a/src/favourites/Favourites.js
+++ b/src/favourites/Favourites.js
@@ -42,36 +42,42 @@ class Favourites extends React.Component {
                     )}
                     {this.props.isAuthenticated === authenticationEnum.IS_AUTHENTICATED && (
                         <div>
-                            {!this.props.user && (
-                                <div className="UserSettings__main">
-                                    <div className="UserSettings__section">
-                                        <Row>
-                                            <Column xs="12">
-                                                <NoUser />
-                                            </Column>
-                                        </Row>
-                                    </div>
-                                </div>
-                            )}
-
-                            {this.props.user && (
+                            {(this.props.isFetchingUser || this.props.isFetchingFavourites) ? (
                                 <Row>
                                     <Column xs="12">
-                                        {this.props.isFetchingFavourites ? (
-                                            <div className="Favourites__main__spinner">
-                                                <DelayedSpinner />
-                                            </div>
-                                        ) : (
-                                            <div>
-                                                {this.props.favourites.length === 0 ? (
-                                                    <NoFavourites />
-                                                ) : (
-                                                    <FavouriteList />
-                                                )}
-                                            </div>
-                                        )}
+                                        <div className="Favourites__main__spinner">
+                                            <DelayedSpinner />
+                                        </div>
                                     </Column>
                                 </Row>
+                            ) : (
+                                <div>
+                                    {!this.props.user && (
+                                        <div className="UserSettings__main">
+                                            <div className="UserSettings__section">
+                                                <Row>
+                                                    <Column xs="12">
+                                                        <NoUser />
+                                                    </Column>
+                                                </Row>
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {this.props.user && (
+                                        <Row>
+                                            <Column xs="12">
+                                                <div>
+                                                    {this.props.favourites.length === 0 ? (
+                                                        <NoFavourites />
+                                                    ) : (
+                                                        <FavouriteList />
+                                                    )}
+                                                </div>
+                                            </Column>
+                                        </Row>
+                                    )}
+                                </div>
                             )}
                         </div>
                     )}
@@ -87,6 +93,7 @@ Favourites.defaultProps = {
 
 Favourites.propTypes = {
     user: PropTypes.shape(),
+    isFetchingUser: PropTypes.bool.isRequired,
     isAuthenticated: PropTypes.string.isRequired,
     isFetchingFavourites: PropTypes.bool.isRequired,
     totalElements: PropTypes.number.isRequired,
@@ -98,6 +105,7 @@ Favourites.propTypes = {
 
 const mapStateToProps = (state) => ({
     user: state.user.user,
+    isFetchingUser: state.user.isFetchingUser,
     isAuthenticated: state.authentication.isAuthenticated,
     favourites: state.favourites.favourites,
     totalElements: state.favourites.totalElements,

--- a/src/savedSearches/SavedSearches.js
+++ b/src/savedSearches/SavedSearches.js
@@ -43,37 +43,50 @@ class SavedSearches extends React.Component {
                     )}
                     {this.props.isAuthenticated === authenticationEnum.IS_AUTHENTICATED && (
                         <div>
-                            {!this.props.user && (
-                                <div className="UserSettings__main">
-                                    <div className="UserSettings__section">
+                            {(this.props.isFetchingUser || this.props.isFetching) ? (
+                                <Row>
+                                    <Column xs="12">
+                                        <div className="SavedSearches__main__spinner">
+                                            <DelayedSpinner />
+                                        </div>
+                                    </Column>
+                                </Row>
+                            ) : (
+                                <div>
+                                    {!this.props.user && (
+                                        <div className="UserSettings__main">
+                                            <div className="UserSettings__section">
+                                                <Row>
+                                                    <Column xs="12">
+                                                        <NoUser />
+                                                    </Column>
+                                                </Row>
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {this.props.user && (
                                         <Row>
                                             <Column xs="12">
-                                                <NoUser />
+                                                {this.props.isFetching ? (
+                                                    <div className="SavedSearches__main__spinner">
+                                                        <DelayedSpinner />
+                                                    </div>
+                                                ) : (
+                                                    <div>
+                                                        {this.props.savedSearches.length === 0 ? (
+                                                            <NoSavedSearches />
+                                                        ) : (
+                                                            <SavedSearchList />
+                                                        )}
+                                                    </div>
+                                                )}
                                             </Column>
                                         </Row>
-                                    </div>
+                                    )}
                                 </div>
                             )}
 
-                            {this.props.user && (
-                                <Row>
-                                    <Column xs="12">
-                                        {this.props.isFetching ? (
-                                            <div className="SavedSearches__main__spinner">
-                                                <DelayedSpinner />
-                                            </div>
-                                        ) : (
-                                            <div>
-                                                {this.props.savedSearches.length === 0 ? (
-                                                    <NoSavedSearches />
-                                                ) : (
-                                                    <SavedSearchList />
-                                                )}
-                                            </div>
-                                        )}
-                                    </Column>
-                                </Row>
-                            )}
                         </div>
                     )}
                 </Container>
@@ -91,6 +104,7 @@ SavedSearches.defaultProps = {
 
 SavedSearches.propTypes = {
     user: PropTypes.shape(),
+    isFetchingUser: PropTypes.bool.isRequired,
     isAuthenticated: PropTypes.string.isRequired,
     isFetching: PropTypes.bool.isRequired,
     totalElements: PropTypes.number.isRequired,
@@ -102,6 +116,7 @@ SavedSearches.propTypes = {
 
 const mapStateToProps = (state) => ({
     user: state.user.user,
+    isFetchingUser: state.user.isFetchingUser,
     isAuthenticated: state.authentication.isAuthenticated,
     savedSearches: state.savedSearches.savedSearches,
     totalElements: state.savedSearches.totalElements,

--- a/src/user/userReducer.js
+++ b/src/user/userReducer.js
@@ -11,6 +11,7 @@ export const HIDE_TERMS_OF_USE_MODAL = 'HIDE_TERMS_OF_USE_MODAL';
 export const FETCH_USER_BEGIN = 'FETCH_USER_BEGIN';
 export const FETCH_USER_SUCCESS = 'FETCH_USER_SUCCESS';
 export const FETCH_USER_FAILURE = 'FETCH_USER_FAILURE';
+export const FETCH_USER_FAILURE_NO_USER = 'FETCH_USER_FAILURE_NO_USER';
 
 export const CREATE_USER = 'CREATE_USER';
 export const CREATE_USER_BEGIN = 'CREATE_USER_BEGIN';
@@ -47,6 +48,7 @@ const TERMS_VERSION = 'sok_v1';
 
 const initialState = {
     user: undefined,
+    isFetchingUser: false,
     isCreating: false,
     isUpdating: false,
     isDeletingUser: false,
@@ -61,10 +63,23 @@ const initialState = {
 
 export default function authorizationReducer(state = initialState, action) {
     switch (action.type) {
+        case FETCH_USER_BEGIN:
+            return {
+                ...state,
+                user: action.response,
+                isFetchingUser: true
+            };
         case FETCH_USER_SUCCESS:
             return {
                 ...state,
-                user: action.response
+                user: action.response,
+                isFetchingUser: false
+            };
+        case FETCH_USER_FAILURE:
+        case FETCH_USER_FAILURE_NO_USER:
+            return {
+                ...state,
+                isFetchingUser: false
             };
         case CREATE_USER_BEGIN:
             return {
@@ -213,6 +228,8 @@ function* fetchUser() {
             if (e instanceof SearchApiError) {
                 if (e.statusCode !== 404) {
                     yield put({ type: FETCH_USER_FAILURE, error: e });
+                } else {
+                    yield put({ type: FETCH_USER_FAILURE_NO_USER });
                 }
             } else {
                 throw e;


### PR DESCRIPTION
Når bruker som er inne på CV eller Jobbprofil, klikker på Favoritter eller Lagrede søk, så vil de nå se  "Du har ikke samtykket til å bruke tjenesten" i ~1sekund, inntil vi har fått sjekket om bruker har samtykket.

Får å unngå at bruker ser denne teksten mens /user lastes, viser vi heller en spinner inntil fetch kall mot er ferdig