### PR TITLE
[PAM-3007] Show expired banner for any ad status except ACTIVE

### DIFF
--- a/src/stilling/Stilling.js
+++ b/src/stilling/Stilling.js
@@ -105,7 +105,7 @@ class Stilling extends React.Component {
                                 </Row>
                                 <Row>
                                     <Column xs="12" md="8">
-                                        {!isFetchingStilling && stilling && stilling._source.status === 'INACTIVE' && (
+                                        {!isFetchingStilling && stilling && stilling._source.status !== 'ACTIVE' && (
                                             <Expired />
                                         )}
                                         {isFetchingStilling && cachedStilling && (


### PR DESCRIPTION
Sørger for at utløpt banner vises for alle inaktive statuser STOPPED,REJECTED,DELETED, i tillegg til INACTIVE.

Mulig vi skal fjerne DELETED-ads fra søkeindeksen fullstendig, jeg gjør det i annen task.

Vi bør trolig også sette meta-tag `<meta name="robots" content="noindex,nofollow"/>` i DOM for sidevisning av annonser som ikke lenger er aktive, altså når utløpt-banneren vises. Tips til hvordan få til det ? 