### PR TITLE
[PAM-3007] Set 'noindex' robots directive for inactive ads

### DIFF
--- a/src/common/metaRobots.js
+++ b/src/common/metaRobots.js
@@ -1,0 +1,21 @@
+// Functions to set and remove head meta tag with robot directives
+
+export function setMetaRobotsTag(content) {
+    let metaRobots = document.querySelector('meta[name=robots]');
+
+    if (!metaRobots) {
+        metaRobots = document.createElement('meta');
+        metaRobots.setAttribute('name', 'robots');
+        metaRobots.setAttribute('content', content);
+        document.querySelector('head').appendChild(metaRobots);
+    } else {
+        metaRobots.setAttribute('content', content);
+    }
+}
+
+export function removeMetaRobotsTag() {
+    let metaRobots = document.querySelector('meta[name=robots]');
+    if (metaRobots) {
+        document.querySelector('head').removeChild(metaRobots);
+    }
+}

--- a/src/stilling/Stilling.js
+++ b/src/stilling/Stilling.js
@@ -56,8 +56,11 @@ class Stilling extends React.Component {
             this.hasSetTitle = true;
         }
 
-        if (!this.props.isFetchingStilling
-            && this.props.stilling && this.props.stilling._source.status !== 'ACTIVE') {
+        if ((this.props.error && this.props.error.statusCode === 404)
+            ||
+            (!this.props.isFetchingStilling
+             && this.props.stilling && this.props.stilling._source.status !== 'ACTIVE')) {
+
             setMetaRobotsTag('noindex');
         }
     }

--- a/src/stilling/Stilling.js
+++ b/src/stilling/Stilling.js
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 import { FlatButton } from '../common/button';
 import getEmployer from '../common/getEmployer';
 import getWorkLocation from '../common/getWorkLocation';
+import { setMetaRobotsTag, removeMetaRobotsTag } from '../common/metaRobots';
 import { CONTEXT_PATH } from '../fasitProperties';
 import FavouriteAlertStripe from '../favourites/alertstripe/FavouriteAlertStripe';
 import ToggleFavouriteButton from '../favourites/toggleFavoriteButton/ToggleFavouriteButton';
@@ -42,6 +43,10 @@ class Stilling extends React.Component {
         ga('send', 'pageview');
     }
 
+    componentWillUnmount() {
+        removeMetaRobotsTag();
+    }
+
     componentDidUpdate() {
         if (!this.hasSetTitle
             && this.props.stilling
@@ -49,6 +54,11 @@ class Stilling extends React.Component {
             && this.props.stilling._source.title) {
             document.title = this.props.stilling._source.title;
             this.hasSetTitle = true;
+        }
+
+        if (!this.props.isFetchingStilling
+            && this.props.stilling && this.props.stilling._source.status !== 'ACTIVE') {
+            setMetaRobotsTag('noindex');
         }
     }
 


### PR DESCRIPTION
Upon display of a single ad, check status, and let robots know if they should
index the content or not. Should cause Googlebot & friends to remove inactive and deleted
job ads from search results.