### PR TITLE
[Fix] Keep scroll position

### DIFF
--- a/src/common/debounce.js
+++ b/src/common/debounce.js
@@ -1,0 +1,12 @@
+function debounce(func, delay) {
+    let timeout;
+    return (...args) => {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => {
+            timeout = null;
+            func(...args);
+        }, delay);
+    };
+}
+
+export default debounce;

--- a/src/search/RestoreScroll.js
+++ b/src/search/RestoreScroll.js
@@ -1,13 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import debounce from '../common/debounce';
 
 export default class RestoreScroll extends React.Component {
+    constructor(props) {
+        super(props);
+        this.debounced = debounce(this.keepScrollPosition, 100);
+    }
+
     componentDidMount() {
         this.restoreScrollPosition();
+        window.addEventListener('scroll', this.debounced);
     }
 
     componentWillUnmount() {
-        this.keepScrollPosition();
+        window.removeEventListener('scroll', this.debounced);
+        this.debounced = null;
     }
 
     keepScrollPosition = () => {


### PR DESCRIPTION
Når man klikker på favoritt-stjernen, og deretter må logge inn, så mister man scroll position. Dette gjør det vansklig å finne igjen stillingen du skulle favorittmerke.

Gjør slik at man alltid husker scroll position og scroller ned igjen i treffliste når siden lastes inn på nytt. Slik kommer man tilbake til samme sted etter innlogging