### PR TITLE
[PAM-3373] Support filtering on nested occupations field

### DIFF
--- a/server/api/searchApiConsumer.js
+++ b/server/api/searchApiConsumer.js
@@ -76,6 +76,7 @@ exports.fetchStilling = async (uuid) => {
         'location.latitude',
         'location.longitude',
         'location.county',
+        'occupationList',
         'properties.author',
         'properties.industry',
         'properties.keywords',

--- a/server/api/searchApiTemplates.js
+++ b/server/api/searchApiTemplates.js
@@ -164,9 +164,9 @@ function filterLocation(counties, municipals) {
         'locationList.municipal.keyword', 'locationList');
 }
 
-function filterOccupation(occupationLevel1, occupationLevel2) {
-    return filterNestedFacets(occupationLevel1, occupationLevel2,
-        'occupation_level1_facet', 'occupation_level2_facet');
+function filterOccupation(occupationFirstLevels, occupationSecondLevels) {
+    return filterNestedFacets(occupationFirstLevels, occupationSecondLevels,
+        'occupationList.level1', 'occupationList.level2', 'occupationList');
 }
 
 function filterSector(sector) {
@@ -573,7 +573,7 @@ exports.searchTemplate = (query) => {
                    }
                 }
             },
-            occupationFirstLevels: {
+            occupations: {
                 filter: {
                     bool: {
                         filter: [
@@ -587,16 +587,26 @@ exports.searchTemplate = (query) => {
                     }
                 },
                 aggs: {
-                    values: {
-                        terms: {
-                            size: 50,
-                            field: 'occupation_level1_facet'
+                    nestedOccupations: {
+                        nested: {
+                            path: 'occupationList',
                         },
                         aggs: {
-                            occupationSecondLevels: {
+                            occupationFirstLevels: {
                                 terms: {
-                                    size: 50,
-                                    field: 'occupation_level2_facet'
+                                    field: 'occupationList.level1',
+                                    size: 50
+                                },
+                                aggs: {
+                                    root_doc_count: {
+                                        reverse_nested: {}
+                                    },
+                                    occupationSecondLevels: {
+                                        terms: {
+                                            field: 'occupationList.level2',
+                                            size: 100
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -52,9 +52,9 @@ export async function fetchSearch(query = {}) {
                 count: municipal.doc_count
             }))
         })),
-        occupationFirstLevels: result.aggregations.occupationFirstLevels.values.buckets.map((firstLevel) => ({
+        occupationFirstLevels: result.aggregations.occupations.nestedOccupations.occupationFirstLevels.buckets.map((firstLevel) => ({
             key: firstLevel.key,
-            count: firstLevel.doc_count,
+            count: firstLevel.root_doc_count.doc_count,
             occupationSecondLevels: firstLevel.occupationSecondLevels.buckets.map((secondLevel) => ({
                 key: `${firstLevel.key}.${secondLevel.key}`,
                 label: secondLevel.key,


### PR DESCRIPTION
This commit adds support for aggregating and filtering on a new nested
occupation category field, with possibly multiple categories per ad.

Denne kan ikke merges før ny indeks er på plass. (Ny indeks vil være kompatibel med pam-stillingsok både med og uten disse endringene.)