### PR TITLE
[PAM-3456] Do not use regexp for URL validation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,17 @@ export function formatISOString(isoString, format = 'DD.MM.YYYY') {
     return isoString;
 }
 
+export function userAgentIsInternetExplorer() {
+    const userAgent = window.navigator.userAgent;
+    return userAgent.indexOf('MSIE ') >= 0 || userAgent.indexOf('Trident/') >= 0;
+}
+
 export function isValidUrl(input) {
+    if (userAgentIsInternetExplorer()) {
+        // Gracefully degrade, 'new URL(..)' is unsupported in IE
+        return false;
+    }
+
     try {
         return new URL(input).protocol.startsWith('http');
     } catch (e) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,13 +21,11 @@ export function formatISOString(isoString, format = 'DD.MM.YYYY') {
 }
 
 export function isValidUrl(input) {
-    const pattern = new RegExp('^(https?:\\/\\/)' // protocol (requires http://or https://)
-        + '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,})' // domain name
-        + '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' // port and path
-        + '(\\?[;&a-z\\d%_.~+=-]*)?' // query string
-        + '(\\#[-a-z\\d_]*)?$', 'i'); // fragment locater
-
-    return pattern.test(input);
+    try {
+        return new URL(input).protocol.startsWith('http');
+    } catch (e) {
+        return false;
+    }
 }
 
 export function removeUndefinedOrEmptyString(obj) {


### PR DESCRIPTION
Universal URL matching is somewhat complex syntactically, so RegExp becomes messy and unreadable.
In addition, the current version has cases where it hangs the browser due to computational
complexity for certain inputs.

Instead, just parse the URL using browser built-in routines and check that protocol is either http
or https, to validate a link.