### PR TITLE
[PAM-3432]: Setter filtere default lukket på mobil

### DIFF
--- a/src/common/topMenu/TopMenu.js
+++ b/src/common/topMenu/TopMenu.js
@@ -6,9 +6,9 @@ import { LOGIN_URL, LOGOUT_URL } from '../../fasitProperties';
 import { authenticationEnum } from '../../authentication/authenticationReducer';
 import { getRedirect } from '../../redirect';
 import { isMobile } from '../../utils';
-import { SET_FACET_PANELS_INITIAL_CLOSED } from '../../search/searchReducer';
+import { SET_FACET_PANELS_INITIAL_OPEN } from '../../search/searchReducer';
 
-const TopMenu = ({ isAuthenticated, closeFacetPanels }) => {
+const TopMenu = ({ isAuthenticated, setFacetPanelsOpen }) => {
     const login = (role) => {
         if (role === 'personbruker') {
             window.location.href = `${LOGIN_URL}${getRedirect()}`;
@@ -24,7 +24,8 @@ const TopMenu = ({ isAuthenticated, closeFacetPanels }) => {
     const authenticationStatus = (status) => {
         if (status === authenticationEnum.IS_AUTHENTICATED) {
             return AuthStatus.IS_AUTHENTICATED;
-        } if (status === authenticationEnum.NOT_AUTHENTICATED) {
+        }
+        if (status === authenticationEnum.NOT_AUTHENTICATED) {
             return AuthStatus.NOT_AUTHENTICATED;
         }
         return AuthStatus.UNKNOWN;
@@ -35,10 +36,8 @@ const TopMenu = ({ isAuthenticated, closeFacetPanels }) => {
             <Header
                 validerNavigasjon={{
                     redirectTillates: () => {
-                        // Close facet panels if on mobile, and return true to complete the redirect
-                        if (isMobile) {
-                            closeFacetPanels();
-                        }
+                        // Reset state of facet panel (closed if on mobile) and return true to complete the redirect
+                        setFacetPanelsOpen(!isMobile());
                         return true;
                     }
                 }}
@@ -56,7 +55,7 @@ const TopMenu = ({ isAuthenticated, closeFacetPanels }) => {
 
 TopMenu.propTypes = {
     isAuthenticated: PropTypes.string.isRequired,
-    closeFacetPanels: PropTypes.func.isRequired
+    setFacetPanelsOpen: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state) => ({
@@ -64,7 +63,7 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-    closeFacetPanels: () => dispatch({ type: SET_FACET_PANELS_INITIAL_CLOSED })
+    setFacetPanelsOpen: (isOpen) => dispatch({ type: SET_FACET_PANELS_INITIAL_OPEN, isOpen })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TopMenu);

--- a/src/common/topMenu/TopMenu.js
+++ b/src/common/topMenu/TopMenu.js
@@ -5,8 +5,10 @@ import { PersonbrukerApplikasjon, Header, AuthStatus } from 'pam-frontend-header
 import { LOGIN_URL, LOGOUT_URL } from '../../fasitProperties';
 import { authenticationEnum } from '../../authentication/authenticationReducer';
 import { getRedirect } from '../../redirect';
+import { isMobile } from '../../utils';
+import { SET_FACET_PANELS_INITIAL_CLOSED } from '../../search/searchReducer';
 
-const TopMenu = ({ isAuthenticated }) => {
+const TopMenu = ({ isAuthenticated, closeFacetPanels }) => {
     const login = (role) => {
         if (role === 'personbruker') {
             window.location.href = `${LOGIN_URL}${getRedirect()}`;
@@ -22,19 +24,27 @@ const TopMenu = ({ isAuthenticated }) => {
     const authenticationStatus = (status) => {
         if (status === authenticationEnum.IS_AUTHENTICATED) {
             return AuthStatus.IS_AUTHENTICATED;
-        } else if (status === authenticationEnum.NOT_AUTHENTICATED) {
+        } if (status === authenticationEnum.NOT_AUTHENTICATED) {
             return AuthStatus.NOT_AUTHENTICATED;
-        } else {
-            return AuthStatus.UNKNOWN;
         }
+        return AuthStatus.UNKNOWN;
     };
 
     return (
         <div className="no-print">
             <Header
+                validerNavigasjon={{
+                    redirectTillates: () => {
+                        // Close facet panels if on mobile, and return true to complete the redirect
+                        if (isMobile) {
+                            closeFacetPanels();
+                        }
+                        return true;
+                    }
+                }}
                 onLoginClick={login}
                 onLogoutClick={logout}
-                useMenu='personbruker'
+                useMenu="personbruker"
                 authenticationStatus={authenticationStatus(isAuthenticated)}
                 applikasjon={PersonbrukerApplikasjon.STILLINGSSOK}
                 visInnstillinger
@@ -45,11 +55,16 @@ const TopMenu = ({ isAuthenticated }) => {
 };
 
 TopMenu.propTypes = {
-    isAuthenticated: PropTypes.string.isRequired
+    isAuthenticated: PropTypes.string.isRequired,
+    closeFacetPanels: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state) => ({
     isAuthenticated: state.authentication.isAuthenticated
 });
 
-export default connect(mapStateToProps)(TopMenu);
+const mapDispatchToProps = (dispatch) => ({
+    closeFacetPanels: () => dispatch({ type: SET_FACET_PANELS_INITIAL_CLOSED })
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TopMenu);

--- a/src/search/facets/counties/Counties.js
+++ b/src/search/facets/counties/Counties.js
@@ -12,7 +12,8 @@ import {
     CHECK_COUNTY,
     CHECK_MUNICIPAL,
     UNCHECK_COUNTY,
-    UNCHECK_MUNICIPAL
+    UNCHECK_MUNICIPAL,
+    TOGGLE_COUNTIES_PANEL_OPEN
 } from './countiesReducer';
 
 class Counties extends React.Component {
@@ -38,13 +39,15 @@ class Counties extends React.Component {
 
     render() {
         const {
-            counties, checkedCounties, checkedMunicipals, deprecatedCounties, deprecatedMunicipals
+            counties, checkedCounties, checkedMunicipals, deprecatedCounties, deprecatedMunicipals, togglePanelOpen,
+            panelOpen
         } = this.props;
         return (
             <Ekspanderbartpanel
                 tittel={toFacetTitleWithCount('Område', checkedCounties.length + checkedMunicipals.length)}
                 className="Counties ekspanderbartPanel--green"
-                apen
+                onClick={togglePanelOpen}
+                apen={panelOpen}
             >
                 <div
                     role="group"
@@ -132,7 +135,9 @@ Counties.propTypes = {
     uncheckCounty: PropTypes.func.isRequired,
     checkMunicipal: PropTypes.func.isRequired,
     uncheckMunicipal: PropTypes.func.isRequired,
-    search: PropTypes.func.isRequired
+    search: PropTypes.func.isRequired,
+    togglePanelOpen: PropTypes.func.isRequired,
+    panelOpen: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state) => ({
@@ -140,7 +145,8 @@ const mapStateToProps = (state) => ({
     checkedCounties: state.counties.checkedCounties,
     checkedMunicipals: state.counties.checkedMunicipals,
     deprecatedCounties: state.counties.deprecatedCounties,
-    deprecatedMunicipals: state.counties.deprecatedMunicipals
+    deprecatedMunicipals: state.counties.deprecatedMunicipals,
+    panelOpen: state.counties.countiesPanelOpen
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -148,8 +154,8 @@ const mapDispatchToProps = (dispatch) => ({
     checkCounty: (county) => dispatch({ type: CHECK_COUNTY, county }),
     uncheckCounty: (county) => dispatch({ type: UNCHECK_COUNTY, county }),
     checkMunicipal: (municipal) => dispatch({ type: CHECK_MUNICIPAL, municipal }),
-    uncheckMunicipal: (municipal) => dispatch({ type: UNCHECK_MUNICIPAL, municipal })
+    uncheckMunicipal: (municipal) => dispatch({ type: UNCHECK_MUNICIPAL, municipal }),
+    togglePanelOpen: () => dispatch({ type: TOGGLE_COUNTIES_PANEL_OPEN })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Counties);
-

--- a/src/search/facets/counties/countiesReducer.js
+++ b/src/search/facets/counties/countiesReducer.js
@@ -1,19 +1,26 @@
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSearchesReducer';
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
-import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
+import {
+    FETCH_INITIAL_FACETS_SUCCESS,
+    RESET_SEARCH,
+    SEARCH_SUCCESS,
+    SET_FACET_PANELS_INITIAL_CLOSED
+} from '../../searchReducer';
 import { findDeprecatedFacets } from '../utils';
 
 export const CHECK_COUNTY = 'CHECK_COUNTY';
 export const UNCHECK_COUNTY = 'UNCHECK_COUNTY';
 export const CHECK_MUNICIPAL = 'CHECK_MUNICIPAL';
 export const UNCHECK_MUNICIPAL = 'UNCHECK_MUNICIPAL';
+export const TOGGLE_COUNTIES_PANEL_OPEN = 'TOGGLE_COUNTIES_PANEL_OPEN';
 
 const initialState = {
     counties: [],
     checkedCounties: [],
     checkedMunicipals: [],
     deprecatedCounties: [],
-    deprecatedMunicipals: []
+    deprecatedMunicipals: [],
+    countiesPanelOpen: true
 };
 
 function uncheckMunicipalsInCounty(state, county) {
@@ -111,6 +118,16 @@ export default function countiesReducer(state = initialState, action) {
             return {
                 ...state,
                 checkedMunicipals: state.checkedMunicipals.filter((m) => (m !== action.municipal))
+            };
+        case TOGGLE_COUNTIES_PANEL_OPEN:
+            return {
+                ...state,
+                countiesPanelOpen: !state.countiesPanelOpen
+            };
+        case SET_FACET_PANELS_INITIAL_CLOSED:
+            return {
+                ...state,
+                countiesPanelOpen: false
             };
         default:
             return state;

--- a/src/search/facets/counties/countiesReducer.js
+++ b/src/search/facets/counties/countiesReducer.js
@@ -4,7 +4,7 @@ import {
     FETCH_INITIAL_FACETS_SUCCESS,
     RESET_SEARCH,
     SEARCH_SUCCESS,
-    SET_FACET_PANELS_INITIAL_CLOSED
+    SET_FACET_PANELS_INITIAL_OPEN
 } from '../../searchReducer';
 import { findDeprecatedFacets } from '../utils';
 
@@ -124,10 +124,10 @@ export default function countiesReducer(state = initialState, action) {
                 ...state,
                 countiesPanelOpen: !state.countiesPanelOpen
             };
-        case SET_FACET_PANELS_INITIAL_CLOSED:
+        case SET_FACET_PANELS_INITIAL_OPEN:
             return {
                 ...state,
-                countiesPanelOpen: false
+                countiesPanelOpen: action.isOpen
             };
         default:
             return state;

--- a/src/search/facets/countries/Countries.js
+++ b/src/search/facets/countries/Countries.js
@@ -9,7 +9,8 @@ import { SEARCH } from '../../searchReducer';
 import { toFacetTitleWithCount } from '../utils';
 import {
     CHECK_COUNTRIES,
-    UNCHECK_COUNTRIES
+    UNCHECK_COUNTRIES,
+    TOGGLE_COUNTRIES_PANEL_OPEN
 } from './countriesReducer';
 import './Countries.less';
 
@@ -25,12 +26,13 @@ class Countries extends React.Component {
     };
 
     render() {
-        const { countries, checkedCountries, deprecatedCountries } = this.props;
+        const { countries, checkedCountries, deprecatedCountries, togglePanelOpen, panelOpen } = this.props;
         return (
             <Ekspanderbartpanel
                 tittel={toFacetTitleWithCount('Land', checkedCountries.length)}
                 className="Countries ekspanderbartPanel--green"
-                apen
+                onClick={togglePanelOpen}
+                apen={panelOpen}
             >
                 <div
                     role="group"
@@ -81,19 +83,23 @@ Countries.propTypes = {
     deprecatedCountries: PropTypes.arrayOf(PropTypes.string).isRequired,
     checkCountries: PropTypes.func.isRequired,
     uncheckCountries: PropTypes.func.isRequired,
-    search: PropTypes.func.isRequired
+    search: PropTypes.func.isRequired,
+    togglePanelOpen: PropTypes.func.isRequired,
+    panelOpen: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state) => ({
     countries: state.countries.countries,
     checkedCountries: state.countries.checkedCountries,
-    deprecatedCountries: state.countries.deprecatedCountries
+    deprecatedCountries: state.countries.deprecatedCountries,
+    panelOpen: state.countries.countriesPanelOpen
 });
 
 const mapDispatchToProps = (dispatch) => ({
     search: () => dispatch({ type: SEARCH }),
     checkCountries: (value) => dispatch({ type: CHECK_COUNTRIES, value }),
-    uncheckCountries: (value) => dispatch({ type: UNCHECK_COUNTRIES, value })
+    uncheckCountries: (value) => dispatch({ type: UNCHECK_COUNTRIES, value }),
+    togglePanelOpen: () => dispatch({ type: TOGGLE_COUNTRIES_PANEL_OPEN })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Countries);

--- a/src/search/facets/countries/countriesReducer.js
+++ b/src/search/facets/countries/countriesReducer.js
@@ -4,7 +4,7 @@ import {
     FETCH_INITIAL_FACETS_SUCCESS,
     RESET_SEARCH,
     SEARCH_SUCCESS,
-    SET_FACET_PANELS_INITIAL_CLOSED
+    SET_FACET_PANELS_INITIAL_OPEN
 } from '../../searchReducer';
 import { findDeprecatedFacets } from '../utils';
 
@@ -72,10 +72,10 @@ export default function countriesReducer(state = initialState, action) {
                 ...state,
                 countriesPanelOpen: !state.countriesPanelOpen
             };
-        case SET_FACET_PANELS_INITIAL_CLOSED:
+        case SET_FACET_PANELS_INITIAL_OPEN:
             return {
                 ...state,
-                countriesPanelOpen: false
+                countriesPanelOpen: action.isOpen
             };
         default:
             return state;

--- a/src/search/facets/countries/countriesReducer.js
+++ b/src/search/facets/countries/countriesReducer.js
@@ -1,15 +1,22 @@
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSearchesReducer';
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
-import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
+import {
+    FETCH_INITIAL_FACETS_SUCCESS,
+    RESET_SEARCH,
+    SEARCH_SUCCESS,
+    SET_FACET_PANELS_INITIAL_CLOSED
+} from '../../searchReducer';
 import { findDeprecatedFacets } from '../utils';
 
 export const CHECK_COUNTRIES = 'CHECK_COUNTRIES';
 export const UNCHECK_COUNTRIES = 'UNCHECK_COUNTRIES';
+export const TOGGLE_COUNTRIES_PANEL_OPEN = 'TOGGLE_COUNTRIES_PANEL_OPEN';
 
 const initialState = {
     countries: [],
     checkedCountries: [],
-    deprecatedCountries: []
+    deprecatedCountries: [],
+    countriesPanelOpen: true
 };
 
 export default function countriesReducer(state = initialState, action) {
@@ -59,6 +66,16 @@ export default function countriesReducer(state = initialState, action) {
             return {
                 ...state,
                 checkedCountries: state.checkedCountries.filter((m) => (m !== action.value))
+            };
+        case TOGGLE_COUNTRIES_PANEL_OPEN:
+            return {
+                ...state,
+                countriesPanelOpen: !state.countriesPanelOpen
+            };
+        case SET_FACET_PANELS_INITIAL_CLOSED:
+            return {
+                ...state,
+                countriesPanelOpen: false
             };
         default:
             return state;

--- a/src/search/facets/engagement/Engagement.js
+++ b/src/search/facets/engagement/Engagement.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { SEARCH } from '../../searchReducer';
 import './Engagement.less';
 import { toFacetTitleWithCount } from '../utils';
-import { CHECK_ENGAGEMENT_TYPE, UNCHECK_ENGAGEMENT_TYPE } from './engagementReducer';
+import { CHECK_ENGAGEMENT_TYPE, UNCHECK_ENGAGEMENT_TYPE, TOGGLE_ENGAGEMENT_PANEL_OPEN } from './engagementReducer';
 
 class Engagement extends React.Component {
     onEngagementClick = (e) => {
@@ -21,12 +21,13 @@ class Engagement extends React.Component {
     };
 
     render() {
-        const { engagementType, checkedEngagement, deprecatedEngagementType } = this.props;
+        const { engagementType, checkedEngagement, deprecatedEngagementType, togglePanelOpen, panelOpen } = this.props;
         return (
             <Ekspanderbartpanel
                 tittel={toFacetTitleWithCount('Ansettelsesform', checkedEngagement.length)}
                 className="Engagement ekspanderbartPanel--green"
-                apen
+                onClick={togglePanelOpen}
+                apen={panelOpen}
             >
                 <div
                     role="group"
@@ -77,19 +78,23 @@ Engagement.propTypes = {
     deprecatedEngagementType: PropTypes.arrayOf(PropTypes.string).isRequired,
     checkEngagement: PropTypes.func.isRequired,
     uncheckEngagement: PropTypes.func.isRequired,
-    search: PropTypes.func.isRequired
+    search: PropTypes.func.isRequired,
+    togglePanelOpen: PropTypes.func.isRequired,
+    panelOpen: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state) => ({
     engagementType: state.engagement.engagementType,
     checkedEngagement: state.engagement.checkedEngagementType,
-    deprecatedEngagementType: state.engagement.deprecatedEngagementType
+    deprecatedEngagementType: state.engagement.deprecatedEngagementType,
+    panelOpen: state.engagement.engagementPanelOpen
 });
 
 const mapDispatchToProps = (dispatch) => ({
     search: () => dispatch({ type: SEARCH }),
     checkEngagement: (value) => dispatch({ type: CHECK_ENGAGEMENT_TYPE, value }),
-    uncheckEngagement: (value) => dispatch({ type: UNCHECK_ENGAGEMENT_TYPE, value })
+    uncheckEngagement: (value) => dispatch({ type: UNCHECK_ENGAGEMENT_TYPE, value }),
+    togglePanelOpen: () => dispatch({ type: TOGGLE_ENGAGEMENT_PANEL_OPEN })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Engagement);

--- a/src/search/facets/engagement/engagementReducer.js
+++ b/src/search/facets/engagement/engagementReducer.js
@@ -1,15 +1,22 @@
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSearchesReducer';
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
-import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
+import {
+    FETCH_INITIAL_FACETS_SUCCESS,
+    RESET_SEARCH,
+    SEARCH_SUCCESS,
+    SET_FACET_PANELS_INITIAL_CLOSED
+} from '../../searchReducer';
 import { findDeprecatedFacets, moveFacetToBottom } from '../utils';
 
 export const CHECK_ENGAGEMENT_TYPE = 'CHECK_ENGAGEMENT_TYPE';
 export const UNCHECK_ENGAGEMENT_TYPE = 'UNCHECK_ENGAGEMENT_TYPE';
+export const TOGGLE_ENGAGEMENT_PANEL_OPEN = 'TOGGLE_ENGAGEMENT_PANEL_OPEN';
 
 const initialState = {
     engagementType: [],
     checkedEngagementType: [],
-    deprecatedEngagementType: []
+    deprecatedEngagementType: [],
+    engagementPanelOpen: true
 };
 
 export default function engagementReducer(state = initialState, action) {
@@ -60,6 +67,16 @@ export default function engagementReducer(state = initialState, action) {
             return {
                 ...state,
                 checkedEngagementType: state.checkedEngagementType.filter((m) => (m !== action.value))
+            };
+        case TOGGLE_ENGAGEMENT_PANEL_OPEN:
+            return {
+                ...state,
+                engagementPanelOpen: !state.engagementPanelOpen
+            };
+        case SET_FACET_PANELS_INITIAL_CLOSED:
+            return {
+                ...state,
+                engagementPanelOpen: false
             };
         default:
             return state;

--- a/src/search/facets/engagement/engagementReducer.js
+++ b/src/search/facets/engagement/engagementReducer.js
@@ -4,7 +4,7 @@ import {
     FETCH_INITIAL_FACETS_SUCCESS,
     RESET_SEARCH,
     SEARCH_SUCCESS,
-    SET_FACET_PANELS_INITIAL_CLOSED
+    SET_FACET_PANELS_INITIAL_OPEN
 } from '../../searchReducer';
 import { findDeprecatedFacets, moveFacetToBottom } from '../utils';
 
@@ -73,10 +73,10 @@ export default function engagementReducer(state = initialState, action) {
                 ...state,
                 engagementPanelOpen: !state.engagementPanelOpen
             };
-        case SET_FACET_PANELS_INITIAL_CLOSED:
+        case SET_FACET_PANELS_INITIAL_OPEN:
             return {
                 ...state,
-                engagementPanelOpen: false
+                engagementPanelOpen: action.isOpen
             };
         default:
             return state;

--- a/src/search/facets/extent/Extent.js
+++ b/src/search/facets/extent/Extent.js
@@ -8,7 +8,8 @@ import { SEARCH } from '../../searchReducer';
 import { toFacetTitleWithCount } from '../utils';
 import {
     CHECK_EXTENT,
-    UNCHECK_EXTENT
+    UNCHECK_EXTENT,
+    TOGGLE_EXTENT_PANEL_OPEN
 } from './extentReducer';
 import './Extent.less';
 
@@ -30,12 +31,13 @@ class Extent extends React.Component {
     );
 
     render() {
-        const { extent, checkedExtent, deprecatedExtent } = this.props;
+        const { extent, checkedExtent, deprecatedExtent, togglePanelOpen, panelOpen } = this.props;
         return (
             <Ekspanderbartpanel
                 tittel={toFacetTitleWithCount('Heltid/deltid', checkedExtent.length)}
                 className="Extent ekspanderbartPanel--green"
-                apen
+                onClick={togglePanelOpen}
+                apen={panelOpen}
             >
                 <div
                     role="group"
@@ -86,19 +88,23 @@ Extent.propTypes = {
     deprecatedExtent: PropTypes.arrayOf(PropTypes.string).isRequired,
     checkExtent: PropTypes.func.isRequired,
     uncheckExtent: PropTypes.func.isRequired,
-    search: PropTypes.func.isRequired
+    search: PropTypes.func.isRequired,
+    togglePanelOpen: PropTypes.func.isRequired,
+    panelOpen: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state) => ({
     extent: state.extent.extent,
     checkedExtent: state.extent.checkedExtent,
-    deprecatedExtent: state.extent.deprecatedExtent
+    deprecatedExtent: state.extent.deprecatedExtent,
+    panelOpen: state.extent.extentPanelOpen
 });
 
 const mapDispatchToProps = (dispatch) => ({
     search: () => dispatch({ type: SEARCH }),
     checkExtent: (value) => dispatch({ type: CHECK_EXTENT, value }),
-    uncheckExtent: (value) => dispatch({ type: UNCHECK_EXTENT, value })
+    uncheckExtent: (value) => dispatch({ type: UNCHECK_EXTENT, value }),
+    togglePanelOpen: () => dispatch({ type: TOGGLE_EXTENT_PANEL_OPEN })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Extent);

--- a/src/search/facets/extent/extentReducer.js
+++ b/src/search/facets/extent/extentReducer.js
@@ -1,15 +1,22 @@
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSearchesReducer';
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
-import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
+import {
+    FETCH_INITIAL_FACETS_SUCCESS,
+    RESET_SEARCH,
+    SEARCH_SUCCESS,
+    SET_FACET_PANELS_INITIAL_CLOSED
+} from '../../searchReducer';
 import { findDeprecatedFacets } from '../utils';
 
 export const CHECK_EXTENT = 'CHECK_EXTENT';
 export const UNCHECK_EXTENT = 'UNCHECK_EXTENT';
+export const TOGGLE_EXTENT_PANEL_OPEN = 'TOGGLE_EXTENT_PANEL_OPEN';
 
 const initialState = {
     extent: [],
     checkedExtent: [],
-    deprecatedExtent: []
+    deprecatedExtent: [],
+    extentPanelOpen: true
 };
 
 export default function extentReducer(state = initialState, action) {
@@ -59,6 +66,16 @@ export default function extentReducer(state = initialState, action) {
             return {
                 ...state,
                 checkedExtent: state.checkedExtent.filter((m) => (m !== action.value))
+            };
+        case TOGGLE_EXTENT_PANEL_OPEN:
+            return {
+                ...state,
+                extentPanelOpen: !state.extentPanelOpen
+            };
+        case SET_FACET_PANELS_INITIAL_CLOSED:
+            return {
+                ...state,
+                extentPanelOpen: false
             };
         default:
             return state;

--- a/src/search/facets/extent/extentReducer.js
+++ b/src/search/facets/extent/extentReducer.js
@@ -4,7 +4,7 @@ import {
     FETCH_INITIAL_FACETS_SUCCESS,
     RESET_SEARCH,
     SEARCH_SUCCESS,
-    SET_FACET_PANELS_INITIAL_CLOSED
+    SET_FACET_PANELS_INITIAL_OPEN
 } from '../../searchReducer';
 import { findDeprecatedFacets } from '../utils';
 
@@ -72,10 +72,10 @@ export default function extentReducer(state = initialState, action) {
                 ...state,
                 extentPanelOpen: !state.extentPanelOpen
             };
-        case SET_FACET_PANELS_INITIAL_CLOSED:
+        case SET_FACET_PANELS_INITIAL_OPEN:
             return {
                 ...state,
-                extentPanelOpen: false
+                extentPanelOpen: action.isOpen
             };
         default:
             return state;

--- a/src/search/facets/occupations/Occupations.js
+++ b/src/search/facets/occupations/Occupations.js
@@ -12,7 +12,8 @@ import {
     CHECK_SECOND_LEVEL,
     OCCUPATION_ANNET,
     UNCHECK_FIRST_LEVEL,
-    UNCHECK_SECOND_LEVEL
+    UNCHECK_SECOND_LEVEL,
+    TOGGLE_OCCUPATIONS_PANEL_OPEN
 } from './occupationsReducer';
 
 class Occupations extends React.Component {
@@ -39,13 +40,14 @@ class Occupations extends React.Component {
     render() {
         const {
             occupationFirstLevels, checkedFirstLevels, checkedSecondLevels, deprecatedFirstLevels,
-            deprecatedSecondLevels
+            deprecatedSecondLevels, togglePanelOpen, panelOpen
         } = this.props;
         return (
             <Ekspanderbartpanel
                 tittel={toFacetTitleWithCount('Yrke', checkedFirstLevels.length + checkedSecondLevels.length)}
                 className="Occupations ekspanderbartPanel--green"
-                apen
+                onClick={togglePanelOpen}
+                apen={panelOpen}
             >
                 <div
                     role="group"
@@ -135,7 +137,9 @@ Occupations.propTypes = {
     uncheckFirstLevel: PropTypes.func.isRequired,
     checkSecondLevel: PropTypes.func.isRequired,
     uncheckSecondLevel: PropTypes.func.isRequired,
-    search: PropTypes.func.isRequired
+    search: PropTypes.func.isRequired,
+    togglePanelOpen: PropTypes.func.isRequired,
+    panelOpen: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state) => ({
@@ -143,7 +147,8 @@ const mapStateToProps = (state) => ({
     checkedFirstLevels: state.occupations.checkedFirstLevels,
     checkedSecondLevels: state.occupations.checkedSecondLevels,
     deprecatedFirstLevels: state.occupations.deprecatedFirstLevels,
-    deprecatedSecondLevels: state.occupations.deprecatedSecondLevels
+    deprecatedSecondLevels: state.occupations.deprecatedSecondLevels,
+    panelOpen: state.occupations.occupationsPanelOpen
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -151,8 +156,8 @@ const mapDispatchToProps = (dispatch) => ({
     checkFirstLevel: (firstLevel) => dispatch({ type: CHECK_FIRST_LEVEL, firstLevel }),
     uncheckFirstLevel: (firstLevel) => dispatch({ type: UNCHECK_FIRST_LEVEL, firstLevel }),
     checkSecondLevel: (secondLevel) => dispatch({ type: CHECK_SECOND_LEVEL, secondLevel }),
-    uncheckSecondLevel: (secondLevel) => dispatch({ type: UNCHECK_SECOND_LEVEL, secondLevel })
+    uncheckSecondLevel: (secondLevel) => dispatch({ type: UNCHECK_SECOND_LEVEL, secondLevel }),
+    togglePanelOpen: () => dispatch({ type: TOGGLE_OCCUPATIONS_PANEL_OPEN })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Occupations);
-

--- a/src/search/facets/occupations/occupationsReducer.js
+++ b/src/search/facets/occupations/occupationsReducer.js
@@ -4,7 +4,7 @@ import {
     FETCH_INITIAL_FACETS_SUCCESS,
     RESET_SEARCH,
     SEARCH_SUCCESS,
-    SET_FACET_PANELS_INITIAL_CLOSED
+    SET_FACET_PANELS_INITIAL_OPEN
 } from '../../searchReducer';
 import { findDeprecatedFacets, moveFacetToBottom } from '../utils';
 
@@ -127,10 +127,10 @@ export default function occupations(state = initialState, action) {
                 ...state,
                 occupationsPanelOpen: !state.occupationsPanelOpen
             };
-        case SET_FACET_PANELS_INITIAL_CLOSED:
+        case SET_FACET_PANELS_INITIAL_OPEN:
             return {
                 ...state,
-                occupationsPanelOpen: false
+                occupationsPanelOpen: action.isOpen
             };
         default:
             return state;

--- a/src/search/facets/occupations/occupationsReducer.js
+++ b/src/search/facets/occupations/occupationsReducer.js
@@ -1,21 +1,27 @@
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSearchesReducer';
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
-import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
+import {
+    FETCH_INITIAL_FACETS_SUCCESS,
+    RESET_SEARCH,
+    SEARCH_SUCCESS,
+    SET_FACET_PANELS_INITIAL_CLOSED
+} from '../../searchReducer';
 import { findDeprecatedFacets, moveFacetToBottom } from '../utils';
 
 export const CHECK_FIRST_LEVEL = 'CHECK_FIRST_LEVEL';
 export const UNCHECK_FIRST_LEVEL = 'UNCHECK_FIRST_LEVEL';
 export const CHECK_SECOND_LEVEL = 'CHECK_SECOND_LEVEL';
 export const UNCHECK_SECOND_LEVEL = 'UNCHECK_SECOND_LEVEL';
-
 export const OCCUPATION_ANNET = 'Uoppgitt/ ikke identifiserbare';
+export const TOGGLE_OCCUPATIONS_PANEL_OPEN = 'TOGGLE_OCCUPATIONS_PANEL_OPEN';
 
 const initialState = {
     occupationFirstLevels: [],
     checkedFirstLevels: [],
     checkedSecondLevels: [],
     deprecatedFirstLevels: [],
-    deprecatedSecondLevels: []
+    deprecatedSecondLevels: [],
+    occupationsPanelOpen: true
 };
 
 function uncheckSecondsLevels(state, firstLevel) {
@@ -115,6 +121,16 @@ export default function occupations(state = initialState, action) {
             return {
                 ...state,
                 checkedSecondLevels: state.checkedSecondLevels.filter((m) => (m !== action.secondLevel))
+            };
+        case TOGGLE_OCCUPATIONS_PANEL_OPEN:
+            return {
+                ...state,
+                occupationsPanelOpen: !state.occupationsPanelOpen
+            };
+        case SET_FACET_PANELS_INITIAL_CLOSED:
+            return {
+                ...state,
+                occupationsPanelOpen: false
             };
         default:
             return state;

--- a/src/search/facets/published/Published.js
+++ b/src/search/facets/published/Published.js
@@ -5,7 +5,7 @@ import { Checkbox } from 'nav-frontend-skjema';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { SEARCH } from '../../searchReducer';
 import { toFacetTitleWithCount } from '../utils';
-import { SET_PUBLISHED } from './publishedReducer';
+import { SET_PUBLISHED, TOGGLE_PUBLISHED_PANEL_OPEN } from './publishedReducer';
 import './Published.less';
 
 const PublishedLabelsEnum = {
@@ -24,12 +24,13 @@ class Published extends React.Component {
     };
 
     render() {
-        const { published, checkedPublished } = this.props;
+        const { published, checkedPublished, togglePanelOpen, panelOpen } = this.props;
         return (
             <Ekspanderbartpanel
                 tittel={toFacetTitleWithCount('Publisert', checkedPublished ? 1 : 0)}
                 className="Published ekspanderbartPanel--green"
-                apen
+                onClick={togglePanelOpen}
+                apen={panelOpen}
             >
                 <div
                     role="group"
@@ -63,17 +64,21 @@ Published.propTypes = {
     })).isRequired,
     checkedPublished: PropTypes.string,
     setPublished: PropTypes.func.isRequired,
-    search: PropTypes.func.isRequired
+    search: PropTypes.func.isRequired,
+    togglePanelOpen: PropTypes.func.isRequired,
+    panelOpen: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state) => ({
     published: state.published.published,
-    checkedPublished: state.published.checkedPublished
+    checkedPublished: state.published.checkedPublished,
+    panelOpen: state.published.publishedPanelOpen
 });
 
 const mapDispatchToProps = (dispatch) => ({
     search: () => dispatch({ type: SEARCH }),
-    setPublished: (value) => dispatch({ type: SET_PUBLISHED, value })
+    setPublished: (value) => dispatch({ type: SET_PUBLISHED, value }),
+    togglePanelOpen: () => dispatch({ type: TOGGLE_PUBLISHED_PANEL_OPEN })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Published);

--- a/src/search/facets/published/publishedReducer.js
+++ b/src/search/facets/published/publishedReducer.js
@@ -1,12 +1,19 @@
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSearchesReducer';
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
-import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
+import {
+    FETCH_INITIAL_FACETS_SUCCESS,
+    RESET_SEARCH,
+    SEARCH_SUCCESS,
+    SET_FACET_PANELS_INITIAL_CLOSED
+} from '../../searchReducer';
 
 export const SET_PUBLISHED = 'SET_PUBLISHED';
+export const TOGGLE_PUBLISHED_PANEL_OPEN = 'TOGGLE_PUBLISHED_PANEL_OPEN';
 
 const initialState = {
     published: [],
-    checkedPublished: undefined
+    checkedPublished: undefined,
+    publishedPanelOpen: true
 };
 
 export default function publishedReducer(state = initialState, action) {
@@ -44,6 +51,16 @@ export default function publishedReducer(state = initialState, action) {
             return {
                 ...state,
                 checkedPublished: action.value
+            };
+        case TOGGLE_PUBLISHED_PANEL_OPEN:
+            return {
+                ...state,
+                publishedPanelOpen: !state.publishedPanelOpen
+            };
+        case SET_FACET_PANELS_INITIAL_CLOSED:
+            return {
+                ...state,
+                publishedPanelOpen: false
             };
         default:
             return state;

--- a/src/search/facets/published/publishedReducer.js
+++ b/src/search/facets/published/publishedReducer.js
@@ -4,7 +4,7 @@ import {
     FETCH_INITIAL_FACETS_SUCCESS,
     RESET_SEARCH,
     SEARCH_SUCCESS,
-    SET_FACET_PANELS_INITIAL_CLOSED
+    SET_FACET_PANELS_INITIAL_OPEN
 } from '../../searchReducer';
 
 export const SET_PUBLISHED = 'SET_PUBLISHED';
@@ -57,10 +57,10 @@ export default function publishedReducer(state = initialState, action) {
                 ...state,
                 publishedPanelOpen: !state.publishedPanelOpen
             };
-        case SET_FACET_PANELS_INITIAL_CLOSED:
+        case SET_FACET_PANELS_INITIAL_OPEN:
             return {
                 ...state,
-                publishedPanelOpen: false
+                publishedPanelOpen: action.isOpen
             };
         default:
             return state;

--- a/src/search/facets/sector/Sector.js
+++ b/src/search/facets/sector/Sector.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { SEARCH } from '../../searchReducer';
 import './Sector.less';
 import { toFacetTitleWithCount } from '../utils';
-import { CHECK_SECTOR, UNCHECK_SECTOR } from './sectorReducer';
+import { CHECK_SECTOR, UNCHECK_SECTOR, TOGGLE_SECTOR_PANEL_OPEN } from './sectorReducer';
 
 class Sector extends React.Component {
     onSectorClick = (e) => {
@@ -21,12 +21,13 @@ class Sector extends React.Component {
     };
 
     render() {
-        const { sector, checkedSector, deprecatedSector } = this.props;
+        const { sector, checkedSector, deprecatedSector, togglePanelOpen, panelOpen } = this.props;
         return (
             <Ekspanderbartpanel
                 tittel={toFacetTitleWithCount('Sektor', checkedSector.length)}
                 className="Sector ekspanderbartPanel--green"
-                apen
+                onClick={togglePanelOpen}
+                apen={panelOpen}
             >
                 <div
                     role="group"
@@ -75,19 +76,23 @@ Sector.propTypes = {
     deprecatedSector: PropTypes.arrayOf(PropTypes.string).isRequired,
     checkSector: PropTypes.func.isRequired,
     uncheckSector: PropTypes.func.isRequired,
-    search: PropTypes.func.isRequired
+    search: PropTypes.func.isRequired,
+    togglePanelOpen: PropTypes.func.isRequired,
+    panelOpen: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state) => ({
     sector: state.sector.sector,
     checkedSector: state.sector.checkedSector,
-    deprecatedSector: state.sector.deprecatedSector
+    deprecatedSector: state.sector.deprecatedSector,
+    panelOpen: state.sector.sectorPanelOpen
 });
 
 const mapDispatchToProps = (dispatch) => ({
     search: () => dispatch({ type: SEARCH }),
     checkSector: (value) => dispatch({ type: CHECK_SECTOR, value }),
-    uncheckSector: (value) => dispatch({ type: UNCHECK_SECTOR, value })
+    uncheckSector: (value) => dispatch({ type: UNCHECK_SECTOR, value }),
+    togglePanelOpen: () => dispatch({ type: TOGGLE_SECTOR_PANEL_OPEN })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Sector);

--- a/src/search/facets/sector/sectorReducer.js
+++ b/src/search/facets/sector/sectorReducer.js
@@ -4,7 +4,7 @@ import {
     FETCH_INITIAL_FACETS_SUCCESS,
     RESET_SEARCH,
     SEARCH_SUCCESS,
-    SET_FACET_PANELS_INITIAL_CLOSED
+    SET_FACET_PANELS_INITIAL_OPEN
 } from '../../searchReducer';
 import { findDeprecatedFacets, moveFacetToBottom } from '../utils';
 
@@ -72,10 +72,10 @@ export default function sectorReducer(state = initialState, action) {
                 ...state,
                 sectorPanelOpen: !state.sectorPanelOpen
             };
-        case SET_FACET_PANELS_INITIAL_CLOSED:
+        case SET_FACET_PANELS_INITIAL_OPEN:
             return {
                 ...state,
-                sectorPanelOpen: false
+                sectorPanelOpen: action.isOpen
             };
         default:
             return state;

--- a/src/search/facets/sector/sectorReducer.js
+++ b/src/search/facets/sector/sectorReducer.js
@@ -1,15 +1,22 @@
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../../../savedSearches/savedSearchesReducer';
 import { RESTORE_STATE_FROM_URL } from '../../../urlReducer';
-import { FETCH_INITIAL_FACETS_SUCCESS, RESET_SEARCH, SEARCH_SUCCESS } from '../../searchReducer';
+import {
+    FETCH_INITIAL_FACETS_SUCCESS,
+    RESET_SEARCH,
+    SEARCH_SUCCESS,
+    SET_FACET_PANELS_INITIAL_CLOSED
+} from '../../searchReducer';
 import { findDeprecatedFacets, moveFacetToBottom } from '../utils';
 
 export const CHECK_SECTOR = 'CHECK_SECTOR';
 export const UNCHECK_SECTOR = 'UNCHECK_SECTOR';
+export const TOGGLE_SECTOR_PANEL_OPEN = 'TOGGLE_SECTOR_PANEL_OPEN';
 
 const initialState = {
     sector: [],
     checkedSector: [],
-    deprecatedSector: []
+    deprecatedSector: [],
+    sectorPanelOpen: true
 };
 
 export default function sectorReducer(state = initialState, action) {
@@ -59,6 +66,16 @@ export default function sectorReducer(state = initialState, action) {
             return {
                 ...state,
                 checkedSector: state.checkedSector.filter((m) => (m !== action.value))
+            };
+        case TOGGLE_SECTOR_PANEL_OPEN:
+            return {
+                ...state,
+                sectorPanelOpen: !state.sectorPanelOpen
+            };
+        case SET_FACET_PANELS_INITIAL_CLOSED:
+            return {
+                ...state,
+                sectorPanelOpen: false
             };
         default:
             return state;

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -5,6 +5,7 @@ import { fetchSearch } from '../api/api';
 import SearchApiError from '../api/SearchApiError';
 import { RESTORE_STATE_FROM_SAVED_SEARCH } from '../savedSearches/savedSearchesReducer';
 import { RESTORE_STATE_FROM_URL } from '../urlReducer';
+import { isMobile } from '../utils';
 
 export const FETCH_INITIAL_FACETS_SUCCESS = 'FETCH_INITIAL_FACETS_SUCCESS';
 export const INITIAL_SEARCH = 'INITIAL_SEARCH';
@@ -18,6 +19,7 @@ export const RESET_FROM = 'RESET_FROM';
 export const LOAD_MORE = 'LOAD_MORE';
 export const LOAD_MORE_BEGIN = 'LOAD_MORE_BEGIN';
 export const LOAD_MORE_SUCCESS = 'LOAD_MORE_SUCCESS';
+export const SET_FACET_PANELS_INITIAL_CLOSED = 'SET_FACET_PANELS_INITIAL_CLOSED';
 
 export const PAGE_SIZE = 50;
 
@@ -152,6 +154,10 @@ function* initialSearch() {
             const query = toSearchQuery(state);
             if (Object.keys(query).length > 0) {
                 response = yield call(fetchSearch, query);
+            }
+
+            if (isMobile()) {
+                yield put({ type: SET_FACET_PANELS_INITIAL_CLOSED });
             }
 
             yield put({ type: SEARCH_SUCCESS, response });

--- a/src/search/searchReducer.js
+++ b/src/search/searchReducer.js
@@ -19,7 +19,7 @@ export const RESET_FROM = 'RESET_FROM';
 export const LOAD_MORE = 'LOAD_MORE';
 export const LOAD_MORE_BEGIN = 'LOAD_MORE_BEGIN';
 export const LOAD_MORE_SUCCESS = 'LOAD_MORE_SUCCESS';
-export const SET_FACET_PANELS_INITIAL_CLOSED = 'SET_FACET_PANELS_INITIAL_CLOSED';
+export const SET_FACET_PANELS_INITIAL_OPEN = 'SET_FACET_PANELS_INITIAL_OPEN';
 
 export const PAGE_SIZE = 50;
 
@@ -157,7 +157,7 @@ function* initialSearch() {
             }
 
             if (isMobile()) {
-                yield put({ type: SET_FACET_PANELS_INITIAL_CLOSED });
+                yield put({ type: SET_FACET_PANELS_INITIAL_OPEN, isOpen: false });
             }
 
             yield put({ type: SEARCH_SUCCESS, response });

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,3 +39,5 @@ export function removeUndefinedOrEmptyString(obj) {
     });
     return newObj;
 }
+
+export const isMobile = () => window.matchMedia('(max-width: 991px)').matches;


### PR DESCRIPTION
Oppførsel mobil:
- filterne er default lukket når man kommer inn på forsiden.
- Filtere bruker har åpnet, forblir åpnet etter man har sett på en stilling.
- Filtere bruker har åpnet lukker seg igjen hvis man navigerer bort fra forsiden i menyen og tilbake.