### PR TITLE
[Fix] Finetuning av CSP og sikkerhetsheadere

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -23,12 +23,16 @@ server.set('port', port);
 
 server.disable('x-powered-by');
 server.use(compression());
-server.use(helmet({ xssFilter: false }));
+// En del sikkerhets headere er allerede lagt i bigip, dropper de derfor her for å unngå duplkiate headere
+server.use(helmet({ xssFilter: false, hsts: false, noSniff: false, frameguard: false }));
 
 server.use(helmet.contentSecurityPolicy({
     directives: {
         defaultSrc: ["'none'"],
         scriptSrc: ["'self'", 'https://www.google-analytics.com'],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+        formAction: ["'self'"],
         styleSrc: ["'self'"],
         fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com'],
         imgSrc: ["'self'", 'data:', 'https://www.google-analytics.com'],


### PR DESCRIPTION
Siden en del sikkerhetsheadere allerede blir lagt til av nettverket, dropper vi å legge dem til i server.js koden. Slik unngår vi duplikate headere.

Finetuner også Content Secutiry Policy etter anbefallninger fra https://observatory.mozilla.org/analyze/arbeidsplassen.nav.no?third-party=false 