### PR TITLE
Endrer CPS headers slik at sentry er tillatt

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -73,7 +73,8 @@ server.use(helmet.contentSecurityPolicy({
         styleSrc: ["'self'", hotJarSources.UNSAFE[1]],
         fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com', ...hotJarSources.font],
         imgSrc: ["'self'", 'data:', 'https://www.google-analytics.com', ...hotJarSources.img],
-        connectSrc: ["'self'", process.env.PAMADUSER_URL, 'https://www.google-analytics.com', 'https://amplitude.nav.no', ...hotJarSources.connect],
+        connectSrc: ["'self'", process.env.PAMADUSER_URL, 'https://www.google-analytics.com',
+            'https://amplitude.nav.no', 'https://sentry.gc.nav.no', ...hotJarSources.connect],
         frameSrc: ["'self'", ...hotJarSources.frame]
     }
 }));


### PR DESCRIPTION
Legger til https://sentry.gc.nav.no i Content-Security-Policy sin connect-src slik at feilmeldinger som skal sendes til Sentry ikke blir blokkert av browser