### PR TITLE
Catch error when trying to decode the percentage sign itself

### DIFF
--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -98,8 +98,8 @@ export function parseQueryString(queryString = "?") {
     parameters.forEach((parameter) => {
         const pair = parameter.split("=");
         if (pair[0] !== undefined && pair[0] !== "") {
-            let key = decodeURIComponent(pair[0]);
-            const val = pair[1] !== undefined ? decodeURIComponent(pair[1]) : "";
+            let key = pair[0];
+            const val = pair[1] !== undefined ? pair[1] : "";
 
             if (key === "international") {
                 object[key] = val === "true" ? true : "false";
@@ -148,15 +148,25 @@ export function stringifyQueryObject(object = {}) {
 }
 
 /**
- * Dekoder en url til den ikke lenger er kodet.
- * En kodet url er i dette tilfellet en url som inneholder '%'.
+ * After login, the redirect url back to this page may have been encoded several times.
+ * This function decodes url until it is no longer encoded.
+ * We assume that an encoded url contains '%', for example %20 (space)
  */
 export function decodeUrl(url) {
-    let decodedUrl = url;
-    while (decodedUrl.includes("%")) {
-        decodedUrl = decodeURIComponent(decodedUrl);
+    let successfullyDecodedUrl = url;
+    try {
+        while (successfullyDecodedUrl.includes("%")) {
+            const decodeAttempt = decodeURIComponent(successfullyDecodedUrl);
+            successfullyDecodedUrl = decodeAttempt;
+        }
+    } catch (e) {
+        // When url is fully decoded, it may try to decode again if the url
+        // contains the percentage sign itself, and this will throw an error.
+        // This can happen for example when searching for part-time job '?=50%'.
+        return successfullyDecodedUrl
     }
-    return decodedUrl;
+
+    return successfullyDecodedUrl;
 }
 
 export function extractParam(param, nullValue) {

--- a/src/context/AuthenticationProvider.js
+++ b/src/context/AuthenticationProvider.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { captureException } from "@sentry/browser";
 import { AD_USER_API, CONTEXT_PATH, LOGIN_URL, LOGOUT_URL, STILLINGSOK_URL } from "../environment";
-import { extractParam, parseQueryString, stringifyQueryObject } from "../components/utils";
+import { extractParam, stringifyQueryObject } from "../components/utils";
 
 export const AuthenticationContext = React.createContext({});
 
@@ -29,15 +29,15 @@ const allowedRedirectUrls = [
  */
 export function fixUrlAfterLogin() {
     if (window.location.pathname === `${CONTEXT_PATH}/stilling`) {
-        const { uuid, ...otherQueryParams } = parseQueryString(document.location.search);
+        const uuid = extractParam('uuid');
         window.history.replaceState(
             {},
             "",
-            `${CONTEXT_PATH}/stilling/${uuid}${stringifyQueryObject(otherQueryParams)}`
+            `${CONTEXT_PATH}/stilling/${uuid}`
         );
     } else if (window.location.pathname === `${CONTEXT_PATH}/intern`) {
-        const { uuid, ...otherQueryParams } = parseQueryString(document.location.search);
-        window.history.replaceState({}, "", `${CONTEXT_PATH}/intern/${uuid}${stringifyQueryObject(otherQueryParams)}`);
+        const uuid = extractParam('uuid');
+        window.history.replaceState({}, "", `${CONTEXT_PATH}/intern/${uuid}`);
     }
 }
 


### PR DESCRIPTION
Catch error when trying to decode the percentage sign itself. This caused issues in production when user where searching for part-time job, f.ex ?q=50%

How to reproduce this issue before this fix:
- Open https://arbeidsplassen.nav.no/stillinger
- In search box enter 50%
- Press enter
- Reload page, or open an ad and navigate back again
- It should crash app