### PR TITLE
WCAG 1.4.11: Adjust link focus color, so it has enough contrast

### DIFF
--- a/src/styles/link.less
+++ b/src/styles/link.less
@@ -1,0 +1,20 @@
+@import './variables';
+
+.link {
+  .link();
+}
+
+.link() {
+  color: @primaryPurple;
+  font-family: 'Source Sans Pro', Arial, sans-serif;
+
+  &:focus {
+    outline: none;
+    color: #fff;
+    background: @blueDarken;
+  }
+
+  &:hover {
+    text-decoration-line: none;
+  }
+}

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -4,7 +4,6 @@
 @import "../../node_modules/nav-frontend-paneler-style/src/index";
 @import "../../node_modules/nav-frontend-skjema-style/src/index";
 @import "../../node_modules/nav-frontend-grid-style/src/index";
-@import "../../node_modules/@navikt/arbeidsplassen-core/less/link/link";
 @import "../../node_modules/@navikt/arbeidsplassen-core/less/skjema/mixins";
 @import "../../node_modules/@navikt/arbeidsplassen-core/less/panel/panel";
 @import "../../node_modules/@navikt/arbeidsplassen-core/less/alertstripe/alertstripe";
@@ -14,6 +13,7 @@
 @import "./header";
 @import "./skiplink";
 @import "./button";
+@import "./link";
 
 html, body {
   height: 100%;

--- a/src/views/ad/adText/AdText.less
+++ b/src/views/ad/adText/AdText.less
@@ -1,6 +1,5 @@
 @import (reference) "../../../styles/variables";
-@import "../../../../node_modules/@navikt/arbeidsplassen-core/less/link/mixins";
-
+@import (reference) "../../../styles/link";
 
 .AdText {
   background: #fff;

--- a/src/views/ad/employerDetails/EmployerDetails.less
+++ b/src/views/ad/employerDetails/EmployerDetails.less
@@ -1,5 +1,5 @@
 @import (reference) "../../../styles/variables";
-@import "../../../../node_modules/@navikt/arbeidsplassen-core/less/link/mixins";
+@import (reference) "../../../styles/link";
 
 .EmployerDetails__h2 {
   margin: 4rem 0 1rem;


### PR DESCRIPTION
Old style, not enough contrast between orange background and purple text, when link gets focus:
<img width="250" alt="Skjermbilde 2022-04-27 kl  10 53 10" src="https://user-images.githubusercontent.com/29566394/165480955-d4466faa-593e-4d10-aa6b-01a135e583db.png">



New style with better contrast, as it is done in other apps:
<img width="250" alt="Skjermbilde 2022-04-27 kl  10 53 37" src="https://user-images.githubusercontent.com/29566394/165480915-496060c4-d218-4d79-ac39-5b590e2a7e1f.png">
