### PR TITLE
Bruker role="alertdialog"

### DIFF
--- a/src/components/modals/ConfirmationModal.js
+++ b/src/components/modals/ConfirmationModal.js
@@ -16,7 +16,7 @@ export default function ConfirmationModal({
     errorMessage
 }) {
     return (
-        <CustomModal onCloseClick={onCancel} title={title} appElement={document.getElementById("app")}>
+        <CustomModal role="alertdialog" onCloseClick={onCancel} title={title} appElement={document.getElementById("app")}>
             <div className="ConfirmationModal">
                 <div className="ConfirmationModal__message">
                     {children}

--- a/src/components/modals/CustomModal.js
+++ b/src/components/modals/CustomModal.js
@@ -3,14 +3,14 @@ import PropTypes from "prop-types";
 import Modal from "nav-frontend-modal";
 import "./CustomModal.less";
 
-function CustomModal({ title, children, onCloseClick }) {
+function CustomModal({ title, children, onCloseClick, ...props }) {
     return (
         <Modal
             className="CustomModal"
             isOpen
             onRequestClose={onCloseClick}
-            contentLabel={title}
             appElement={document.getElementById("app")}
+            {...props}
         >
             <h1 className="CustomModal__title">{title}</h1>
             {children}

--- a/src/components/modals/LoginModal.js
+++ b/src/components/modals/LoginModal.js
@@ -6,7 +6,7 @@ import "./LoginModal.less";
 
 function LoginModal({ onLoginClick, onCloseClick }) {
     return (
-        <CustomModal onCloseClick={onCloseClick} title="Du må logge inn">
+        <CustomModal role="alertdialog" onCloseClick={onCloseClick} title="Du må logge inn">
             <p className="LoginModal__message">Logg inn med MinID, BankID, BankID på mobil, Buypass eller Commfides.</p>
             <div className="LoginModal__buttons">
                 <Hovedknapp onClick={onLoginClick}>Logg inn</Hovedknapp>

--- a/src/views/savedSearches/modals/SearchIsEmptyModal.js
+++ b/src/views/savedSearches/modals/SearchIsEmptyModal.js
@@ -5,10 +5,10 @@ import CustomModal from "../../../components/modals/CustomModal";
 
 function SearchIsEmptyModal({ onClose }) {
     return (
-        <CustomModal onCloseClick={onClose} title="Velg søkekriterier først">
+        <CustomModal role="alertdialog" onCloseClick={onClose} title="Velg søkekriterier først">
             <p>Du må fylle inn søkeord eller kriterier for å kunne lagre.</p>
             <div>
-                <Hovedknapp onClick={onClose}>Lukk</Hovedknapp>
+                <Hovedknapp onClick={onClose}>Ok, gå tilbake</Hovedknapp>
             </div>
         </CustomModal>
     );


### PR DESCRIPTION
Add `role="alertdialog"` to error- and confirmation dialogs.

> The alertdialog role is used to notify users of urgent information that demands the user's immediate attention. Including role="alertdialog" on the element containing the dialog helps assistive technology identify the content as being grouped and separated from the rest of the page content. Examples include error messages that require confirmation and other action confirmation prompts. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role#description
