### PR TITLE
Set focus to next item in result list when user click "Load more" button

### DIFF
--- a/src/pages/search/Search.js
+++ b/src/pages/search/Search.js
@@ -70,7 +70,7 @@ const Search = () => {
         initialSearchDispatch({ type: FetchAction.BEGIN });
 
         const promises = [
-            SearchAPI.search(), // An empty search aggregates search criteria across all ads
+            SearchAPI.search(toApiQuery(initialQuery)), // An empty search aggregates search criteria across all ads
             SearchAPI.getAndCache("api/locations") // Search criteria for locations are not aggregated, but based on a predefined list
         ];
 

--- a/src/pages/search/searchResult/SearchResult.js
+++ b/src/pages/search/searchResult/SearchResult.js
@@ -15,6 +15,10 @@ import FavouritesButton from "../../favourites/FavouritesButton";
 const SearchResult = ({ searchResponse, queryDispatch, query, loadMoreResults }) => {
     const { status, data } = searchResponse;
 
+    // If user clicked "Load more" in the search result, move focus from
+    // "Load more" button to the next item in the result list
+    const adToBeFocused = query.from > 0 ? data.ads[query.from] : undefined;
+
     return (
         <section id="resultat" aria-label="Søkeresultat" className="SearchResult">
             <SkipToCriteria />
@@ -34,6 +38,7 @@ const SearchResult = ({ searchResponse, queryDispatch, query, loadMoreResults })
                     {data.ads &&
                         data.ads.map((ad) => (
                             <SearchResultItem
+                                shouldAutoFocus={adToBeFocused && ad.uuid === adToBeFocused.uuid}
                                 key={ad.uuid}
                                 ad={ad}
                                 favouriteButton={
@@ -54,7 +59,7 @@ const SearchResult = ({ searchResponse, queryDispatch, query, loadMoreResults })
                             onLoadMoreClick={loadMoreResults}
                         />
 
-                        <a href="#top" className="SearchResult__skip-to-top link">
+                        <a href="#main-content" className="SearchResult__skip-to-top link">
                             <ArrowUpIcon ariaHidden={true} />
                             Til toppen
                         </a>

--- a/src/pages/search/searchResult/SearchResultItem.js
+++ b/src/pages/search/searchResult/SearchResultItem.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, {useLayoutEffect, useRef} from "react";
 import {Link} from "react-router-dom";
 import getEmployer from "../../../../server/common/getEmployer";
 import getWorkLocation from "../../../../server/common/getWorkLocation";
@@ -11,7 +11,8 @@ import Tag from "../../../components/tag/Tag";
 export default function SearchResultItem({
      ad,
      showExpired,
-     favouriteButton
+     favouriteButton,
+     shouldAutoFocus
  }) {
     const location = getWorkLocation(ad.properties.location, ad.locationList);
     const employer = getEmployer(ad);
@@ -19,9 +20,18 @@ export default function SearchResultItem({
     const published = formatDate(ad.published, "DD.MM.YYYY");
     const jobTitle = ad.properties.jobtitle && ad.title !== ad.properties.jobtitle ? ad.properties.jobtitle : undefined;
     const frist = ad.properties.applicationdue ? formatDate(ad.properties.applicationdue, "DD.MM.YYYY") : undefined;
+    const ref = useRef();
+
+    useLayoutEffect(() => {
+        if(shouldAutoFocus && ref.current) {
+            ref.current.focus();
+        }
+    }, [shouldAutoFocus])
 
     return (
         <article
+            ref={ref}
+            tabIndex={shouldAutoFocus ? -1 : undefined}
             className="SearchResultItem"
             aria-labelledby={`${ad.uuid}-h3 ${ad.uuid}-jobTitle ${ad.uuid}-employer ${ad.uuid}-location`}
         >
@@ -61,6 +71,10 @@ export default function SearchResultItem({
     );
 }
 
+SearchResultItem.defaultProps = {
+    shouldAutofocus: false
+};
+
 SearchResultItem.propTypes = {
     ad: PropTypes.shape({
         uuid: PropTypes.string,
@@ -73,7 +87,8 @@ SearchResultItem.propTypes = {
             applicationdue: PropTypes.string
         }),
         locationList: PropTypes.arrayOf(PropTypes.object)
-    }).isRequired
+    }).isRequired,
+    shouldAutofocus: PropTypes.bool
 };
 
 function LinkToAd({children, stilling, isFinn}) {

--- a/src/pages/search/searchResult/SearchResultsItem.less
+++ b/src/pages/search/searchResult/SearchResultsItem.less
@@ -3,6 +3,10 @@
 .SearchResultItem {
   padding: 2rem 1rem;
 
+  &:focus {
+    outline: none;
+  }
+
   &:nth-child(odd) {
     background-color: @gray1;
   }


### PR DESCRIPTION
Improves usability for screen reader and keyboard users. 

How it was before this fix:
- Since the new content is appended to the current result, above the load more button, user had to navigate 25 items upwards, to get to the newly loaded content. 

After fix:
- Focus is set to the next item in the content loaded.

<img width="782" alt="Skjermbilde 2022-05-05 kl  10 22 30" src="https://user-images.githubusercontent.com/29566394/166887365-c1508af3-4040-4a38-aa6f-7eb81ae723db.png">


