### PR TITLE
 Change classname from "Ad" to "JobPosting" trying to avoid problems with ad blockers

### DIFF
--- a/src/pages/ad/Ad.js
+++ b/src/pages/ad/Ad.js
@@ -78,16 +78,16 @@ const Ad = ({ match }) => {
     const isFinn = ad && ad._source && ad._source.source && ad._source.source.toLowerCase() === "finn";
 
     return (
-        <div className="Ad">
+        <div className="JobPosting">
             <AdBackLink />
 
             {status === FetchStatus.FAILURE && error.statusCode === 404 && <NotFound />}
             {status === FetchStatus.FAILURE && error.statusCode !== 404 && <ErrorMessage />}
             {status === FetchStatus.IS_FETCHING && <DelayedSpinner />}
             {status === FetchStatus.SUCCESS && (
-                <article className="Ad__flex">
-                    <div className="Ad__left">
-                        <H1WithAutoFocus className="Ad__h1">{ad._source.title}</H1WithAutoFocus>
+                <article className="JobPosting__flex">
+                    <div className="JobPosting__left">
+                        <H1WithAutoFocus className="JobPosting__h1">{ad._source.title}</H1WithAutoFocus>
 
                         {ad._source.status !== "ACTIVE" && <Tag>Stillingsannonsen er inaktiv.</Tag>}
 
@@ -102,7 +102,7 @@ const Ad = ({ match }) => {
                         )}
                     </div>
 
-                    <div className="Ad__right">
+                    <div className="JobPosting__right">
                         <HowToApply stilling={ad} showFavouriteButton={!isInternal} />
                         {!isFinn && (
                             <React.Fragment>

--- a/src/pages/ad/Ad.less
+++ b/src/pages/ad/Ad.less
@@ -1,6 +1,6 @@
 @import (reference) "../../styles/variables";
 
-.Ad {
+.JobPosting {
   margin: 2rem auto;
   max-width: 1156px;
   padding: 0 1rem;
@@ -11,31 +11,7 @@
   }
 }
 
-.Ad__flex {
-  @media (min-width: @screen-md-min) {
-    display: flex;
-  }
-}
-
-.Ad__left {
-  margin: 0 0 2rem 0;
-  @media (min-width: @screen-md-min) {
-    flex: 2;
-    padding-right: 6rem;
-  }
-
-  @media (min-width: @screen-lg-min) {
-    padding-right: 12rem;
-  }
-}
-
-.Ad__right {
-  @media (min-width: @screen-md-min) {
-    width: 340px;
-  }
-}
-
-.Ad__h1 {
+.JobPosting__h1 {
   margin: 0 0 1rem;
   font-size: 2rem;
   line-height: 1.2;
@@ -49,27 +25,50 @@
   }
 }
 
-.detail-section {
-  width: 100%;
-  margin-bottom: 2rem;
-  padding-bottom: 1.5rem;
+.JobPosting__h2 {
+  margin: 0 0 1rem 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  line-height: 1.33;
 
-  .detail-section__head {
-    margin: 0 0 1rem 0;
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    line-height: 1.33;
-
-    svg {
-      margin-right: 0.75rem;
-    }
+  svg {
+    margin-right: 0.75rem;
   }
 }
 
-.dl-flex {
+.JobPosting__flex {
+  @media (min-width: @screen-md-min) {
+    display: flex;
+  }
+}
 
+.JobPosting__left {
+  margin: 0 0 2rem 0;
+  @media (min-width: @screen-md-min) {
+    flex: 2;
+    padding-right: 6rem;
+  }
+
+  @media (min-width: @screen-lg-min) {
+    padding-right: 12rem;
+  }
+}
+
+.JobPosting__right {
+  @media (min-width: @screen-md-min) {
+    width: 340px;
+  }
+}
+
+.JobPosting__section {
+  width: 100%;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+}
+
+.JobPosting__dl {
   dd, dt {
     line-height: 1.33;
     font-size: 1.125rem;
@@ -85,8 +84,5 @@
     word-wrap: break-word;
     overflow-wrap: break-word;
     margin: 0 0 0.75rem 0;
-
   }
 }
-
-

--- a/src/pages/ad/adDetails/AdDetails.js
+++ b/src/pages/ad/adDetails/AdDetails.js
@@ -7,12 +7,12 @@ import HistoryIcon from "../../../components/icons/HistoryIcon";
 
 export default function AdDetails({ id, source }) {
     return (
-        <section className="detail-section">
-            <h2 className="detail-section__head">
+        <section className="JobPosting__section">
+            <h2 className="JobPosting__h2">
                 <HistoryIcon />
                 Om annonsen
             </h2>
-            <dl className="dl-flex">
+            <dl className="JobPosting__dl">
                 {source.updated && (
                     <React.Fragment>
                         <dt>Sist endret:</dt>

--- a/src/pages/ad/contactPerson/ContactPerson.js
+++ b/src/pages/ad/contactPerson/ContactPerson.js
@@ -5,12 +5,12 @@ import PersonIcon from "../../../components/icons/PersonIcon";
 export default function ContactPerson({ contactList }) {
     if (contactList && contactList.length > 0) {
         return (
-            <section className="detail-section">
-                <h2 className="detail-section__head">
+            <section className="JobPosting__section">
+                <h2 className="JobPosting__h2">
                     <PersonIcon />
                     Kontaktperson for stillingen
                 </h2>
-                <dl className="dl-flex">
+                <dl className="JobPosting__dl">
                     {contactList[0].name && (
                         <React.Fragment>
                             <dt>Kontaktperson:</dt>

--- a/src/pages/ad/employmentDetails/EmploymentDetails.js
+++ b/src/pages/ad/employmentDetails/EmploymentDetails.js
@@ -8,12 +8,12 @@ export default function EmploymentDetails({ stilling }) {
     const { properties } = stilling;
 
     return (
-        <section className="detail-section">
-            <h2 className="detail-section__head">
+        <section className="JobPosting__section">
+            <h2 className="JobPosting__h2">
                 <SuitcaseIcon />
                 Om stillingen
             </h2>
-            <dl className="dl-flex">
+            <dl className="JobPosting__dl">
                 {properties.positioncount && (
                     <React.Fragment>
                         <dt>Antall stillinger:</dt>

--- a/src/pages/ad/howToApply/HowToApply.js
+++ b/src/pages/ad/howToApply/HowToApply.js
@@ -33,12 +33,12 @@ export default function HowToApply({ stilling, showFavouriteButton }) {
 
     if (properties.applicationdue || properties.applicationemail || applicationUrl) {
         return (
-            <section className="detail-section">
-                <h2 className="detail-section__head">
+            <section className="JobPosting__section">
+                <h2 className="JobPosting__h2">
                     <CalendarIcon />
                     Søknad
                 </h2>
-                <dl className="dl-flex">
+                <dl className="JobPosting__dl">
                     {properties.applicationdue && (
                         <React.Fragment>
                             <dt>Søknadsfrist:</dt>

--- a/src/pages/ad/shareAd/ShareAd.js
+++ b/src/pages/ad/shareAd/ShareAd.js
@@ -13,8 +13,8 @@ export default function ShareAd({ source }) {
     const deviceType = new UAParser().getResult().device.type;
 
     return (
-        <section className="detail-section">
-            <h2 className="detail-section__head">
+        <section className="JobPosting__section">
+            <h2 className="JobPosting__h2">
                 <ShareIcon />
                 Del annonsen
             </h2>


### PR DESCRIPTION
**Problem**
Ad blocker blocked some content on our site. We found that Ad blocker removed content using classname with `.ads-`. 

**Solution**
Hopefully, to minify the risk of being blocked again, we rename classname from `.Ad` to `.JobPosting`. In addition we have also replaced the `.ads`- classname prefix with `.dsa-` in a previous request.