### PR TITLE
Add jobbtreff banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ LOGOUTSERVICE_URL=http://localhost:9017/aduser
 PAM_STILLINGSOK_URL=http://localhost:8080/stillinger
 PAM_VAR_SIDE_URL=http://localhost:8080/stillingsregistrering
 PAM_INTERNAL_SEARCH_API_URL=http://localhost:9027
+PAM_JOBBTREFF_API_URL=http://localhost:8088/jobbtreff-promo
 AMPLITUDE_TOKEN=(Dev Token)
 ```
 

--- a/naiserator-dev.json
+++ b/naiserator-dev.json
@@ -8,5 +8,6 @@
   "pam_stillingsok_url": "https://arbeidsplassen.dev.nav.no/stillinger",
   "pam_var_side_url": "https://arbeidsplassen.dev.nav.no/stillingsregistrering",
   "pamsearchapi_url": "http://pam-search-api",
+  "pam_jobbtreff_api_url": "https://arbeidsplassen.dev.nav.no/jobbtreff",
   "amplitude_token": "3acd3a52e065d2d99856a12e7e9e1432"
 }

--- a/naiserator-prod.json
+++ b/naiserator-prod.json
@@ -9,5 +9,6 @@
   "pam_stillingsok_url": "https://arbeidsplassen.nav.no/stillinger",
   "pam_var_side_url": "https://arbeidsplassen.nav.no/stillingsregistrering",
   "pamsearchapi_url": "http://pam-search-api",
+  "pam_jobbtreff_api_url": "https://arbeidsplassen.nav.no/jobbtreff",
   "amplitude_token": "a7b3f00008ae250a08c3ebbc6bf718f9"
 }

--- a/runDev.sh
+++ b/runDev.sh
@@ -6,6 +6,7 @@ export LOGOUTSERVICE_URL=http://localhost:9017/aduser
 export PAM_STILLINGSOK_URL=http://localhost:8080/stillinger
 export PAM_VAR_SIDE_URL=http://localhost:8080/stillingsregistrering
 export PAM_INTERNAL_SEARCH_API_URL=http://localhost:9027
+export PAM_JOBBTREFF_API_URL=http://localhost:8088/jobbtreff-promo
 export AMPLITUDE_TOKEN=b6143dedf1d17c3e73d3ad440bf54e8b
 export NAIS_CLUSTER_NAME=local-dev
 exec npm start

--- a/server/server.js
+++ b/server/server.js
@@ -88,6 +88,7 @@ const fasitProperties = {
     LOGOUT_URL: process.env.LOGOUTSERVICE_URL,
     PAM_STILLINGSOK_URL: process.env.PAM_STILLINGSOK_URL,
     PAM_VAR_SIDE_URL: process.env.PAM_VAR_SIDE_URL,
+    PAM_JOBBTREFF_API_URL: process.env.PAM_JOBBTREFF_API_URL,
     AMPLITUDE_TOKEN: process.env.AMPLITUDE_TOKEN
 };
 
@@ -98,6 +99,7 @@ const writeEnvironmentVariablesToFile = () => {
         + `window.__LOGIN_URL__="${fasitProperties.LOGIN_URL}";\n`
         + `window.__LOGOUT_URL__="${fasitProperties.LOGOUT_URL}";\n`
         + `window.__PAM_VAR_SIDE_URL__="${fasitProperties.PAM_VAR_SIDE_URL}";\n`
+        + `window.__PAM_JOBBTREFF_API_URL__="${fasitProperties.PAM_JOBBTREFF_API_URL}";\n`
         + `window.__AMPLITUDE_TOKEN__="${fasitProperties.AMPLITUDE_TOKEN}";\n`
 
     fs.writeFile(path.resolve(rootDirectory, 'dist/js/env.js'), fileContent, (err) => {

--- a/src/api/EventAPI.js
+++ b/src/api/EventAPI.js
@@ -1,0 +1,30 @@
+import { CONTEXT_PATH, JOBBTREFF_API_URL } from "../environment";
+import APIError from "./APIError";
+
+async function get(url) {
+    let response;
+    try {
+        response = await fetch(url, {
+            method: "GET",
+            referrer: CONTEXT_PATH
+        });
+    } catch (e) {
+        throw new APIError(e.message, 0);
+    }
+
+    if (!(response.status >= 200 || response.status <= 299)) {
+        throw new APIError(response.statusText, response.status);
+    }
+
+    return response.json();
+}
+
+async function getNextEvent() {
+    return await get(`${JOBBTREFF_API_URL}/next`);
+}
+
+const EventAPI = {
+    getNextEvent
+};
+
+export default EventAPI;

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,5 +1,6 @@
 export const CONTEXT_PATH = __PAM_CONTEXT_PATH__;
 export const AD_USER_API = __PAM_AD_USER_API__;
 export const STILLINGSOK_URL = __PAM_STILLINGSOK_URL__;
+export const JOBBTREFF_API_URL = __PAM_JOBBTREFF_API_URL__;
 export const LOGIN_URL = __LOGIN_URL__;
 export const LOGOUT_URL = __LOGOUT_URL__;

--- a/src/pages/search/Search.js
+++ b/src/pages/search/Search.js
@@ -25,6 +25,7 @@ import "./Search.less";
 import { useHistory } from "react-router";
 import SearchResult from "./searchResult/SearchResult";
 import H1WithAutoFocus from "../../components/h1WithAutoFocus/H1WithAutoFocus";
+import EventBanner from "./event/EventBanner";
 
 const Search = () => {
     const { authenticationStatus } = useContext(AuthenticationContext);
@@ -146,13 +147,16 @@ const Search = () => {
             {initialSearchResponse.status === FetchStatus.IS_FETCHING && <LoadingScreen />}
             {initialSearchResponse.status === FetchStatus.SUCCESS && (
                 <div className="Search__flex-wrapper">
-                    <SearchForm
-                        query={query}
-                        dispatchQuery={queryDispatch}
-                        initialSearchResult={initialSearchResponse.data}
-                        searchResult={searchResponse.data}
-                        fetchSearch={fetchSearch}
-                    />
+                    <div>
+                        <SearchForm
+                            query={query}
+                            dispatchQuery={queryDispatch}
+                            initialSearchResult={initialSearchResponse.data}
+                            searchResult={searchResponse.data}
+                            fetchSearch={fetchSearch}
+                        />
+                        <EventBanner />
+                    </div>
                     <SearchResult
                         searchResponse={searchResponse}
                         query={query}

--- a/src/pages/search/event/EventBanner.js
+++ b/src/pages/search/event/EventBanner.js
@@ -1,0 +1,101 @@
+import "./EventBanner.less";
+import React, { useEffect } from "react";
+import { FetchAction, FetchStatus, useFetchReducer } from "../../../hooks/useFetchReducer";
+import EventAPI from "../../../api/EventAPI";
+import { captureException } from "@sentry/browser";
+
+function EventBanner() {
+    const [response, dispatch] = useFetchReducer();
+
+    useEffect(() => {
+        fetchNextEvent();
+    }, []);
+
+    function fetchNextEvent() {
+        dispatch({ type: FetchAction.BEGIN });
+        EventAPI.getNextEvent()
+            .then((response) => {
+                dispatch({ type: FetchAction.RESOLVE, data: response });
+            })
+            .catch((error) => {
+                captureException(error);
+                dispatch({ type: FetchAction.REJECT, error });
+            });
+    }
+
+    if (
+        response.status === FetchStatus.NOT_FETCHED ||
+        response.status === FetchStatus.IS_FETCHING ||
+        response.status === FetchStatus.FAILURE
+    ) {
+        return null;
+    }
+
+    // If there is no upcoming event, the response will be empty
+    if (response.data === undefined) {
+        return null;
+    }
+
+    const nextEvent = response.data;
+    const daysUntilNextEvent = calculateDaysUntilEvent(nextEvent);
+    const daysUntilNextEventText = getDaysUntilNextEventText(daysUntilNextEvent);
+
+    return (
+        <div className="EventBanner">
+            <div className="EventBanner--illustration">
+                <svg width="49" height="41" viewBox="0 0 49 41" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <rect x="8.59558" y="6.45667" width="30.3121" height="25.2471" rx="2" fill="#40C1AC" />
+                    <path d="M44.5468 25.3921V13.4698L31.858 19.1925L44.5468 25.3921Z" fill="#40C1AC" />
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M38.8063 16.0045V22.5978L31.9138 19.1693L38.8063 16.0045Z"
+                        fill="#3F868A"
+                    />
+                    <ellipse cx="8.43709" cy="31.6377" rx="8.43709" ry="8.3937" fill="#98F1D7" />
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M16.874 31.7023H10.5956C9.49101 31.7023 8.59558 30.8068 8.59558 29.7023V23.244C13.1821 23.3281 16.8742 27.0532 16.8742 31.6363C16.8742 31.6583 16.8741 31.6803 16.874 31.7023Z"
+                        fill="#3F868A"
+                    />
+                </svg>
+            </div>
+            <h5 className="EventBanner__title">Neste jobbtreff er {daysUntilNextEventText}</h5>
+            <a className="EventBanner--event-title-link link" href={`/jobbtreff/${nextEvent.id}`}>
+                {nextEvent.title}
+            </a>
+            <a className="EventBanner--events-info-link link" href="/jobbtreff/hvordan-delta">
+                Les om hvordan jobbtreff fungerer
+            </a>
+        </div>
+    );
+}
+
+const ONE_DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
+
+function calculateDaysUntilEvent(event) {
+    const today = new Date();
+    const eventDate = new Date(event.startTime);
+
+    // Reset hours, since we want to know if the next event is today, tomorrow, or in xx days. Not if it is in 0.57 days or similar.
+    today.setHours(0, 0, 0, 0);
+    eventDate.setHours(0, 0, 0, 0);
+
+    let millisecondsUntilNextEvent = Math.abs(eventDate - today);
+
+    return Math.round(millisecondsUntilNextEvent / ONE_DAY_IN_MILLISECONDS);
+}
+
+function getDaysUntilNextEventText(daysUntilNextEvent) {
+    switch (daysUntilNextEvent) {
+        case 0:
+            return "i dag";
+        case 1:
+            return "i morgen";
+        default:
+            return `om ${daysUntilNextEvent} dager`;
+    }
+}
+
+export default EventBanner;

--- a/src/pages/search/event/EventBanner.js
+++ b/src/pages/search/event/EventBanner.js
@@ -61,7 +61,7 @@ function EventBanner() {
                     />
                 </svg>
             </div>
-            <h5 className="EventBanner__title">Neste jobbtreff er {daysUntilNextEventText}</h5>
+            <h5 className="EventBanner__title">Neste jobbtreff er {daysUntilNextEventText}:</h5>
             <a className="EventBanner--event-title-link link" href={`/jobbtreff/${nextEvent.id}`}>
                 {nextEvent.title}
             </a>

--- a/src/pages/search/event/EventBanner.less
+++ b/src/pages/search/event/EventBanner.less
@@ -27,9 +27,11 @@
 .EventBanner--event-title-link {
     margin: 0.5rem calc(1rem + 49px) 0 0;
     display: block;
+    line-height: 1.5rem;
 }
 
 .EventBanner--events-info-link {
     margin-top: 1rem;
     display: block;
+    line-height: 1.5rem;
 }

--- a/src/pages/search/event/EventBanner.less
+++ b/src/pages/search/event/EventBanner.less
@@ -25,7 +25,7 @@
 }
 
 .EventBanner--event-title-link {
-    margin-top: 0.5rem;
+    margin: 0.5rem calc(1rem + 49px) 0 0;
     display: block;
 }
 

--- a/src/pages/search/event/EventBanner.less
+++ b/src/pages/search/event/EventBanner.less
@@ -1,0 +1,35 @@
+@import "../../../styles/variables";
+
+.EventBanner {
+    border: 4px solid @secondaryTurquoise;
+    padding: 1.5rem 1rem;
+    position: relative;
+}
+
+.EventBanner--illustration {
+    position: absolute;
+    top: 1.625rem;
+    right: 1rem;
+}
+
+.EventBanner__title {
+    font-weight: 700;
+    margin: 0 calc(1rem + 49px) 0 0;
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+
+    @media (min-width: @screen-sm-min) {
+        font-size: 1.25rem;
+        line-height: 1.5rem;
+    }
+}
+
+.EventBanner--event-title-link {
+    margin-top: 0.5rem;
+    display: block;
+}
+
+.EventBanner--events-info-link {
+    margin-top: 1rem;
+    display: block;
+}

--- a/src/pages/search/searchForm/filters/Locations.js
+++ b/src/pages/search/searchForm/filters/Locations.js
@@ -19,10 +19,8 @@ import buildHomeOfficeValues from "../utils/buildHomeOfficeValues";
 import mergeCount from "../utils/mergeCount";
 import { findUnknownSearchCriteriaValues } from "../utils/findUnknownSearchCriteriaValues";
 import findZeroCountLocationFacets from "../utils/findZeroCountLocationFacets";
-import { isMobile } from "../../../../components/utils";
 
 function Locations({ initialValues, updatedValues, query, dispatch }) {
-    const isOpenByDefault = !isMobile();
     const [locationValues, setLocationValues] = useState(buildLocations(initialValues));
     const [homeOfficeValues, setHomeOfficeValues] = useState(buildHomeOfficeValues(initialValues.aggregations.remote));
     const unknownCounties = findUnknownSearchCriteriaValues(query.counties, initialValues.locations);
@@ -108,7 +106,7 @@ function Locations({ initialValues, updatedValues, query, dispatch }) {
     const checkedLocations = [...query.countries, ...query.counties, ...query.municipals];
 
     return (
-        <CriteriaPanel panelId="locations-panel" title="Område" isOpenByDefault={isOpenByDefault}>
+        <CriteriaPanel panelId="locations-panel" title="Område">
             <fieldset className="CriteriaPanel__fieldset">
                 <legend>Velg fylke, kommune, land eller hjemmekontor</legend>
                 {locationValues &&


### PR DESCRIPTION
* Add a banner to promote the next upcoming jobbtreff, just below the search filters
* Fetches the next upcoming jobbtreff from the [https://github.com/navikt/pam-jobbtreff-api-proxy/](pam-jobbtreff-api-proxy) to avoid huge load on the jobbtreff API

The proxy:
* Caches events for 5 minutes
* Sets the response cache header to 5 minutes

[Link to design in Figma](https://www.figma.com/file/pPVBT8fBTXKW01vTIWvlit/Styleguide-for-arbeidsplassen?node-id=993%3A1288)

Desktop:
![jobbtreff-banner-desktop](https://user-images.githubusercontent.com/1564042/172850908-7a4f2151-fea3-44d5-92c1-81d20ea4a882.jpg)

Mobile:
![jobbtreff-banner-mobile](https://user-images.githubusercontent.com/1564042/172850929-dcb39259-776f-4784-a633-9fd1a540d61c.jpg)