### PR TITLE
Give select-box sufficient focus color and border

### DIFF
--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -76,7 +76,6 @@ input::-ms-clear {
   background: @primaryPurple;
 }
 
-.skjemaelement__input:focus, .skjemaelement__input:active {
-  border: none;
+.selectContainer .skjemaelement__input:focus {
+  box-shadow: 0 0 0 3px #062140;
 }
-


### PR DESCRIPTION
Change select so it get same focus as other form elements:
- Thicker border
- Use dark blue color

<img width="286" alt="Skjermbilde 2022-06-15 kl  09 02 53" src="https://user-images.githubusercontent.com/29566394/173764127-6e800439-2bf0-48c1-8c0e-8a31f93ecc20.png">
