### PR TITLE
Legger til feilmeldinger for 400 Bad request

### DIFF
--- a/src/api/InterestAPI.js
+++ b/src/api/InterestAPI.js
@@ -32,7 +32,14 @@ async function post(url, query, toJson = true) {
     }
 
     if (response.status !== 200) {
-        throw new APIError(response.statusText, response.status);
+        let errorMsg;
+        try {
+            const errorJson = response.json();
+            errorMsg = errorJson.error_code || response.statusText;
+        } catch (parseError) {
+            errorMsg = response.statusText;
+        }
+        throw new APIError(errorMsg, response.status);
     }
 
     return toJson ? response.json() : response;

--- a/src/pages/interestForm/InterestForm.js
+++ b/src/pages/interestForm/InterestForm.js
@@ -187,6 +187,21 @@ const InterestForm = ({ match }) => {
         }
     };
 
+    const getErrorMessage = (error) => {
+        switch (error.message) {
+            case "invalid_name":
+                return "Feil, kunne ikke sende søknaden. Sjekk at navnet er skrevet riktig og forsøk igjen."
+            case "invalid_email":
+                return "Feil, kunne ikke sende søknaden. Sjekk at e-posten er skrevet riktig og forsøk igjen."
+            case "invalid_telephone":
+                return "Feil, kunne ikke sende søknaden. Sjekk at telefonnummeret er skrevet riktig og forsøk igjen."
+            case "invalid_about":
+                return "Feil, kunne ikke sende søknaden. Sjekk at teksten om deg selv ikke innholder ugyldige tegn eller er for lang og forsøk igjen."
+            default:
+                return "Feil, kunne ikke sende søknaden. Forsøk igjen"
+        }
+    }
+
     return (
         <div className="InterestForm">
             {status === FetchStatus.IS_FETCHING && <DelayedSpinner />}
@@ -406,7 +421,9 @@ const InterestForm = ({ match }) => {
                                 </p>
 
                                 {postInterestResponse.status === FetchStatus.FAILURE && (
-                                    <Alert>Det oppsto en feil ved sending. Forsøk igjen</Alert>
+                                    <Alert>
+                                        {getErrorMessage(postInterestResponse.error)}
+                                    </Alert>
                                 )}
 
                                 {postInterestResponse.status === FetchStatus.IS_FETCHING ? (


### PR DESCRIPTION
Legger til feilmeldinger hvis POST-kall mot Request URL: http://localhost:1333/interest-form/<id>/candidates feiler.

Forutsetter at backend sender response, med json body: 
```
{
   ...
   error_code: "invalid_soemthing",
   ...osv
}
```

Håndterer disse feilene
- invalid_name
- invalid_email
- invalid_telephone
- invalid_about