### PR TITLE
Dropper global override av bredden på modaler

### DIFF
--- a/src/common/components/modals/AlertModal.css
+++ b/src/common/components/modals/AlertModal.css
@@ -1,3 +1,8 @@
+.AlertModal {
+  max-width: 40rem;
+  width: 100%;
+}
+
 @media (min-width: 768px) {
   .AlertModal {
     padding: 1rem 2rem 2rem 2rem;

--- a/src/common/components/modals/CustomModal.css
+++ b/src/common/components/modals/CustomModal.css
@@ -1,3 +1,8 @@
+.CustomModal {
+  width: 100%;
+  max-width: 40rem;
+}
+
 @media (min-width: 768px) {
   .CustomModal {
     padding: 1rem 2rem 2rem 2rem;

--- a/src/common/styles/styles.css
+++ b/src/common/styles/styles.css
@@ -62,11 +62,6 @@ input::-ms-clear {
   display: none;
 }
 
-.ReactModal__Content {
-  width: 100%;
-  max-width: 40rem;
-}
-
 /**
 * Overrides
 */


### PR DESCRIPTION
Overriden på `.ReactModal__Content` vil neppe virke når vi tar i bruk nytt designsystem, så flytter derfor denne css-koden inn i klassene som settes som className på hver enkelt modal.