### PR TITLE
Unngår at "arbeidsplassen.no" blir oversatt av google translate

### DIFF
--- a/src/modules/auth/components/RequiresAuthentication.js
+++ b/src/modules/auth/components/RequiresAuthentication.js
@@ -26,12 +26,12 @@ function RequiresAuthentication({ children, onCancel, onLogin }) {
                     Du må logge inn først
                 </Heading>
                 <BodyLong className="LoginRequiredMessage__text mb-2">
-                    Du bruker BankID for å logge inn på arbeidsplassen.no
+                    Du bruker BankID for å logge inn på <span translate="no">arbeidsplassen.no</span>
                 </BodyLong>
                 <div className="mb-2">
                     <LoginBubble />
                 </div>
-                
+
                 <div className="login-buttons-wrapper">
                     {onLogin ? (
                         <Button variant="primary" icon={<EnterIcon aria-hidden="true" />} onClick={onLogin}>
@@ -42,14 +42,12 @@ function RequiresAuthentication({ children, onCancel, onLogin }) {
                             Logg inn
                         </Button>
                     )}
-                    
-                    
+
                     {onCancel && (
                         <Button variant="secondary" onClick={onCancel}>
                             Avbryt
                         </Button>
                     )}
-                    
                 </div>
             </section>
         );


### PR DESCRIPTION
Det er mange som bruker Google translate i stillingsøket. Og ikke alle oversettelser er like bra. Unngår at `arbeidsplassen.no` blir oversatt til noe annet, da dette ikke gir mening

<img width="630" alt="Skjermbilde 2023-05-11 kl  09 42 35" src="https://github.com/navikt/pam-stillingsok/assets/29566394/7a31dc11-d3a4-4a92-b3f8-339ae0f37f57">
