### PR TITLE
Feature/expose ingresses

### DIFF
--- a/naiserator-dev.json
+++ b/naiserator-dev.json
@@ -1,6 +1,7 @@
 {
     "ingress": ["https://arbeidsplassen.dev.nav.no/stillinger", "https://arbeidsplassen.intern.dev.nav.no/stillinger", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/stilling",
-    "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/js", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/css"],
+    "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/js", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/css", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/images",
+        "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/isAuthenticated"],
     "pamaduser_url": "http://pam-aduser/aduser",
     "arbeidsplassen_url": "https://arbeidsplassen.intern.dev.nav.no",
     "pam_stillingsok_url": "https://arbeidsplassen.intern.dev.nav.no/stillinger",

--- a/naiserator-dev.json
+++ b/naiserator-dev.json
@@ -1,5 +1,5 @@
 {
-    "ingress": ["https://arbeidsplassen.dev.nav.no/stillinger", "https://arbeidsplassen.intern.dev.nav.no/stillinger"],
+    "ingress": ["https://arbeidsplassen.dev.nav.no/stillinger", "https://arbeidsplassen.intern.dev.nav.no/stillinger", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger"],
     "pamaduser_url": "http://pam-aduser/aduser",
     "arbeidsplassen_url": "https://arbeidsplassen.intern.dev.nav.no",
     "pam_stillingsok_url": "https://arbeidsplassen.intern.dev.nav.no/stillinger",

--- a/naiserator-dev.json
+++ b/naiserator-dev.json
@@ -1,7 +1,7 @@
 {
     "ingress": ["https://arbeidsplassen.dev.nav.no/stillinger", "https://arbeidsplassen.intern.dev.nav.no/stillinger", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/stilling",
     "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/js", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/css", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/images",
-        "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/isAuthenticated"],
+        "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/isAuthenticated", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/api"],
     "pamaduser_url": "http://pam-aduser/aduser",
     "arbeidsplassen_url": "https://arbeidsplassen.intern.dev.nav.no",
     "pam_stillingsok_url": "https://arbeidsplassen.intern.dev.nav.no/stillinger",

--- a/naiserator-dev.json
+++ b/naiserator-dev.json
@@ -1,5 +1,5 @@
 {
-    "ingress": ["https://arbeidsplassen.dev.nav.no/stillinger", "https://arbeidsplassen.intern.dev.nav.no/stillinger", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger"],
+    "ingress": ["https://arbeidsplassen.dev.nav.no/stillinger", "https://arbeidsplassen.intern.dev.nav.no/stillinger", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/stilling"],
     "pamaduser_url": "http://pam-aduser/aduser",
     "arbeidsplassen_url": "https://arbeidsplassen.intern.dev.nav.no",
     "pam_stillingsok_url": "https://arbeidsplassen.intern.dev.nav.no/stillinger",

--- a/naiserator-dev.json
+++ b/naiserator-dev.json
@@ -1,5 +1,6 @@
 {
-    "ingress": ["https://arbeidsplassen.dev.nav.no/stillinger", "https://arbeidsplassen.intern.dev.nav.no/stillinger", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/stilling"],
+    "ingress": ["https://arbeidsplassen.dev.nav.no/stillinger", "https://arbeidsplassen.intern.dev.nav.no/stillinger", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/stilling",
+    "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/js", "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/css"],
     "pamaduser_url": "http://pam-aduser/aduser",
     "arbeidsplassen_url": "https://arbeidsplassen.intern.dev.nav.no",
     "pam_stillingsok_url": "https://arbeidsplassen.intern.dev.nav.no/stillinger",


### PR DESCRIPTION
Her har jeg whitelistet alt som trengs for å vise  arbeidsplassen.ekstern.dev.no/stillinger/stilling/{uuid}. 

Jeg har ikke funnet noen lettfattelig måte å evnt blackliste èn URI (tenkte at selve arbeidsplassen.ekstern.dev.no/stillinger som er stillingssøket burde blacklistes for å ikke vise alle annonser i dev åpent, men at ingress ellers kunne vært arbeidsplassen.ekstern.dev.no/stillinger i stedet for arbeidsplassen.ekstern.dev.no/stillinger/stilling som i denne PR). Det hadde potensielt vært ryddigere, potensielt ikke. 