### PR TITLE
local-dev: use proxy for interesse-api endpoint

### DIFF
--- a/runDev.sh
+++ b/runDev.sh
@@ -17,6 +17,6 @@ export ADUSER_AUDIENCE=local:teampam:pam-aduser
 export IDPORTEN_AUDIENCE=local-token-x-client-id
 export CV_API_AUDIENCE=local:teampam:pam-cv-api
 export ARBEIDSPLASSEN_URL=http://localhost:3000
-export INTEREST_API_URL=http://localhost:8080/interesse-api
+export INTEREST_API_URL=http://localhost:3000/interesse-api
 
 exec npm start

--- a/server/api/superraskApiProxy.js
+++ b/server/api/superraskApiProxy.js
@@ -1,0 +1,24 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+const isLocal =
+    (process.env.ARBEIDSPLASSEN_URL && process.env.ARBEIDSPLASSEN_URL.includes("localhost")) ||
+    process.env.IS_LOCAL === "true";
+
+const setUpSuperraskApi = (server) => {
+    if (isLocal) {
+        server.use(
+            "/interesse-api",
+            createProxyMiddleware({
+                target: "https://arbeidsplassen.intern.dev.nav.no",
+                changeOrigin: true,
+                headers: {
+                    "Access-Control-Allow-Origin": "*",
+                    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+                    "Access-Control-Allow-Headers": "X-Requested-With, content-type, Authorization",
+                },
+            }),
+        );
+    }
+};
+
+module.exports = setUpSuperraskApi;

--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,7 @@ const locationApiConsumer = require("./api/locationApiConsumer");
 const setUpProxyCvApi = require("./api/cvApiProxy");
 const { initializeTokenX, tokenIsValid } = require("./tokenX/tokenXUtils");
 const setUpAduserApiProxy = require("./api/userApiProxyConfig");
+const setUpSuperraskApi = require("./api/superraskApiProxy");
 const { logger } = require("./common/logger");
 
 /* eslint no-console: 0 */
@@ -141,6 +142,7 @@ const startServer = (htmlPages) => {
         }
     });
     setUpProxyCvApi(server);
+    setUpSuperraskApi(server);
 
     // Give users fallback locations from local file if aduser is unresponsive
     server.get(`${properties.PAM_CONTEXT_PATH}/api/locations`, (req, res) => {


### PR DESCRIPTION
Dette gjør det mulig å kjøre superrask lokalt, den vil proxy alle superrask (/interesse-api) requests til arbeidsplassen.intern.dev.nav.no