### PR TITLE
Error must be named "error", not "err"

### DIFF
--- a/src/modules/ad/components/Ad.jsx
+++ b/src/modules/ad/components/Ad.jsx
@@ -34,7 +34,7 @@ function Ad({ match }) {
                 dispatch({ type: FetchAction.RESOLVE, data });
             },
             (err) => {
-                dispatch({ type: FetchAction.REJECT, err });
+                dispatch({ type: FetchAction.REJECT, error: err });
             },
         );
     }


### PR DESCRIPTION
Fikser Sentry issues `TypeError: Cannot read properties of undefined (reading 'statusCode')`

Problemet var ikke stort, bare feil navngivning av en property.