### PR TITLE
sentry: include release version for crash tracking

### DIFF
--- a/.nais/dev.json
+++ b/.nais/dev.json
@@ -20,5 +20,6 @@
     "cv-api-host": "pam-cv-api.dev-fss-pub.nais.io",
     "cv_api_audience": "dev-fss:teampam:pam-cv-api",
     "aduser_audience": "dev-gcp:teampam:pam-aduser",
-    "idporten_audience": "https://nav.no"
+    "idporten_audience": "https://nav.no",
+    "sentry_dsn": ""
 }

--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -65,6 +65,8 @@ spec:
       value: {{ cv_api_audience }}
     - name: IDPORTEN_AUDIENCE
       value: {{ idporten_audience }}
+    - name: SENTRY_DSN
+      value: {{ sentry_dsn }}
   accessPolicy:
     inbound:
       rules:

--- a/.nais/prod.json
+++ b/.nais/prod.json
@@ -12,5 +12,6 @@
     "cv-api-host": "pam-cv-api.prod-fss-pub.nais.io",
     "cv_api_audience": "prod-fss:teampam:pam-cv-api",
     "aduser_audience": "prod-gcp:teampam:pam-aduser",
-    "idporten_audience": "https://nav.no"
+    "idporten_audience": "https://nav.no",
+    "sentry_dsn": "https://76170ea4b79246638c1d9eb1c0e4fca9@sentry.gc.nav.no/37"
 }

--- a/server/server.js
+++ b/server/server.js
@@ -75,6 +75,18 @@ server.engine("html", mustacheExpress());
 
 server.use(bodyParser.json());
 
+const getAppVersion = () => {
+    // example: NAIS_APP_IMAGE=europe-north1-docker.pkg.dev/nais-management-233d/teampam/pam-stillingsok:23.256.125825
+    if (process.env.NAIS_APP_IMAGE) {
+        const splitted = process.env.NAIS_APP_IMAGE.split("/");
+        if (splitted.length > 0) {
+            const appVersion = splitted[splitted.length - 1].replace(":", "@");
+            return appVersion; // example: pam-stillingsok@23.256.125825
+        }
+    }
+    return "";
+};
+
 const properties = {
     PAM_CONTEXT_PATH: "/stillinger",
     INTEREST_API_URL: process.env.INTEREST_API_URL,
@@ -84,6 +96,7 @@ const properties = {
     PAM_VAR_SIDE_URL: process.env.PAM_VAR_SIDE_URL,
     PAM_JOBBTREFF_API_URL: process.env.PAM_JOBBTREFF_API_URL,
     AMPLITUDE_TOKEN: process.env.AMPLITUDE_TOKEN,
+    APP_VERSION: getAppVersion(),
 };
 
 const writeEnvironmentVariablesToFile = () => {
@@ -95,7 +108,8 @@ const writeEnvironmentVariablesToFile = () => {
         `window.__LOGOUT_URL__="${properties.LOGOUT_URL}";\n` +
         `window.__PAM_VAR_SIDE_URL__="${properties.PAM_VAR_SIDE_URL}";\n` +
         `window.__PAM_JOBBTREFF_API_URL__="${properties.PAM_JOBBTREFF_API_URL}";\n` +
-        `window.__AMPLITUDE_TOKEN__="${properties.AMPLITUDE_TOKEN}";\n`;
+        `window.__AMPLITUDE_TOKEN__="${properties.AMPLITUDE_TOKEN}";\n` +
+        `window.__APP_VERSION__="${properties.APP_VERSION}";\n`;
 
     fs.writeFile(path.resolve(rootDirectory, "dist/js/env.js"), fileContent, (err) => {
         if (err) throw err;

--- a/server/server.js
+++ b/server/server.js
@@ -96,6 +96,7 @@ const properties = {
     PAM_VAR_SIDE_URL: process.env.PAM_VAR_SIDE_URL,
     PAM_JOBBTREFF_API_URL: process.env.PAM_JOBBTREFF_API_URL,
     AMPLITUDE_TOKEN: process.env.AMPLITUDE_TOKEN,
+    SENTRY_DSN: process.env.SENTRY_DSN,
     APP_VERSION: getAppVersion(),
 };
 
@@ -109,6 +110,7 @@ const writeEnvironmentVariablesToFile = () => {
         `window.__PAM_VAR_SIDE_URL__="${properties.PAM_VAR_SIDE_URL}";\n` +
         `window.__PAM_JOBBTREFF_API_URL__="${properties.PAM_JOBBTREFF_API_URL}";\n` +
         `window.__AMPLITUDE_TOKEN__="${properties.AMPLITUDE_TOKEN}";\n` +
+        `window.__SENTRY_DSN__="${properties.SENTRY_DSN}";\n` +
         `window.__APP_VERSION__="${properties.APP_VERSION}";\n`;
 
     fs.writeFile(path.resolve(rootDirectory, "dist/js/env.js"), fileContent, (err) => {

--- a/src/common/tracking/sentry.js
+++ b/src/common/tracking/sentry.js
@@ -20,6 +20,7 @@ const ignoreTypeErrors = [
 export default function initSentry() {
     Sentry.init({
         dsn: "https://76170ea4b79246638c1d9eb1c0e4fca9@sentry.gc.nav.no/37",
+        release: window.__APP_VERSION__,
         allowUrls: ["arbeidsplassen.nav.no"],
         ignoreErrors: [...ignoreTypeErrors],
         autoSessionTracking: true,

--- a/src/common/tracking/sentry.js
+++ b/src/common/tracking/sentry.js
@@ -18,22 +18,24 @@ const ignoreTypeErrors = [
 ];
 
 export default function initSentry() {
-    Sentry.init({
-        dsn: "https://76170ea4b79246638c1d9eb1c0e4fca9@sentry.gc.nav.no/37",
-        release: window.__APP_VERSION__,
-        allowUrls: ["arbeidsplassen.nav.no"],
-        ignoreErrors: [...ignoreTypeErrors],
-        autoSessionTracking: true,
-        initialScope: {
-            tags: { sessionId: getSessionId() },
-            user: { id: getSessionId() },
-        },
-        beforeSend(event, hint) {
-            const error = hint.originalException;
-            if (error && error.statusCode !== undefined && ignoreStatusCodes.includes(error.statusCode)) {
-                return null; // event will be discarded
-            }
-            return event;
-        },
-    });
+    if (window.__SENTRY_DSN__) {
+        Sentry.init({
+            dsn: window.__SENTRY_DSN__,
+            release: window.__APP_VERSION__,
+            allowUrls: ["arbeidsplassen.nav.no"],
+            ignoreErrors: [...ignoreTypeErrors],
+            autoSessionTracking: true,
+            initialScope: {
+                tags: { sessionId: getSessionId() },
+                user: { id: getSessionId() },
+            },
+            beforeSend(event, hint) {
+                const error = hint.originalException;
+                if (error && error.statusCode !== undefined && ignoreStatusCodes.includes(error.statusCode)) {
+                    return null; // event will be discarded
+                }
+                return event;
+            },
+        });
+    }
 }


### PR DESCRIPTION
Dette legger til versjon nummer til sentry og da får vi crash report per release (e.g. hvor stor prosentandel av brukere kræsjer den releasen for)

Muligens lettere å lese koden hvis du ser på commits hver for seg istedenfor å se på alle endringene men er ikke mye uansett