### PR TITLE
Stillinger med bare fylke dukker opp når man velger kommune i gitt fylke

### DIFF
--- a/server/api/searchApiTemplates.js
+++ b/server/api/searchApiTemplates.js
@@ -211,7 +211,15 @@ function filterLocation(counties, municipals, countries, international = false) 
             if (c.municipals.length > 0) {
                 const mustObject = {
                     bool: {
-                        should: [],
+                        should: [{
+                            bool: {
+                                must_not: {
+                                    exists: {
+                                        field: "locationList.municipal.keyword"
+                                    }
+                                }
+                            }
+                        }],
                     },
                 };
 

--- a/src/modules/sok/components/searchForm/filters/Locations.jsx
+++ b/src/modules/sok/components/searchForm/filters/Locations.jsx
@@ -109,59 +109,69 @@ function Locations({ initialValues, updatedValues, query, dispatch }) {
         <Fieldset hideLegend legend="Velg fylke, kommune, land eller hjemmekontor" className="FilterModal__fieldset">
             <div>
                 {locationValues &&
-                    locationValues.map((location) => (
-                        <React.Fragment key={location.key}>
-                            <Checkbox
-                                name="location"
-                                value={location.key}
-                                onChange={handleCheckboxClick(location.key, location.type)}
-                                checked={
-                                    query.counties.includes(location.key) ||
-                                    (location.key === "UTLAND" && query.international === true)
-                                }
-                            >
-                                <span translate={location.key !== "UTLAND" ? "no" : undefined}>
-                                    {`${fixLocationName(location.key)} (${location.count})`}
-                                </span>
-                            </Checkbox>
-                            {(query.counties.includes(location.key) ||
-                                (location.key === "UTLAND" && query.international === true)) &&
-                                location.key !== "OSLO" &&
-                                location.key !== "SVALBARD" && (
-                                    <Fieldset
-                                        hideLegend
-                                        legend={`Områder i ${fixLocationName(location.key)}`}
-                                        className="FilterModal__sub-fieldset FilterModal__columns-3"
-                                    >
-                                        <div>
-                                            {location.subLocations &&
-                                                location.subLocations.map((subLocation) => (
-                                                    <Checkbox
-                                                        className={subLocation.count === 0 ? "Facet__zero__count" : ""}
-                                                        name="location"
-                                                        key={subLocation.key}
-                                                        value={subLocation.key}
-                                                        onChange={handleCheckboxClick(
-                                                            subLocation.key,
-                                                            subLocation.type,
-                                                        )}
-                                                        checked={
-                                                            query.municipals.includes(subLocation.key) ||
-                                                            query.countries.includes(subLocation.key)
-                                                        }
-                                                    >
-                                                        <span translate="no">
-                                                            {`${fixLocationName(subLocation.key, true)} (${
-                                                                subLocation.count
-                                                            })`}
-                                                        </span>
-                                                    </Checkbox>
-                                                ))}
-                                        </div>
-                                    </Fieldset>
-                                )}
-                        </React.Fragment>
-                    ))}
+                    locationValues.map((location) => {
+                        let countyLevelHitsCount =
+                            location.count - location.subLocations.reduce((sum, e) => sum + e.count, 0);
+                        if (countyLevelHitsCount < 0) countyLevelHitsCount = 0;
+
+                        return (
+                            <React.Fragment key={location.key}>
+                                <Checkbox
+                                    name="location"
+                                    value={location.key}
+                                    onChange={handleCheckboxClick(location.key, location.type)}
+                                    checked={
+                                        query.counties.includes(location.key) ||
+                                        (location.key === "UTLAND" && query.international === true)
+                                    }
+                                >
+                                    <span translate={location.key !== "UTLAND" ? "no" : undefined}>
+                                        {`${fixLocationName(location.key)} (${location.count})`}
+                                    </span>
+                                </Checkbox>
+                                {(query.counties.includes(location.key) ||
+                                    (location.key === "UTLAND" && query.international === true)) &&
+                                    location.key !== "OSLO" &&
+                                    location.key !== "SVALBARD" && (
+                                        <Fieldset
+                                            hideLegend
+                                            legend={`Områder i ${fixLocationName(location.key)}`}
+                                            className="FilterModal__sub-fieldset FilterModal__columns-3"
+                                        >
+                                            <div>
+                                                {location.subLocations &&
+                                                    location.subLocations.map((subLocation) => (
+                                                        <Checkbox
+                                                            className={
+                                                                subLocation.count + countyLevelHitsCount === 0
+                                                                    ? "Facet__zero__count"
+                                                                    : ""
+                                                            }
+                                                            name="location"
+                                                            key={subLocation.key}
+                                                            value={subLocation.key}
+                                                            onChange={handleCheckboxClick(
+                                                                subLocation.key,
+                                                                subLocation.type,
+                                                            )}
+                                                            checked={
+                                                                query.municipals.includes(subLocation.key) ||
+                                                                query.countries.includes(subLocation.key)
+                                                            }
+                                                        >
+                                                            <span translate="no">
+                                                                {`${fixLocationName(subLocation.key, true)} (${
+                                                                    subLocation.count + countyLevelHitsCount
+                                                                })`}
+                                                            </span>
+                                                        </Checkbox>
+                                                    ))}
+                                            </div>
+                                        </Fieldset>
+                                    )}
+                            </React.Fragment>
+                        );
+                    })}
 
                 <div className="RemoteFacet">
                     {homeOfficeValues &&


### PR DESCRIPTION
Annonser som kun har arbeidssted på fylkesnivå dukker ikke opp når man velger en spesifik kommune i det fylket, kun når man velger fylke. 

I følge NKS pleier arbeidsgivere å legge inn kun fylke når de vil at det skal dukke opp for alle kommuner i det fylket. Løser dette ved å legge på en "hvis kommune er valgt, sjekk for den kommunen PLUS de som kun har fylke, uten kommune" i søket. 

Relevant slack tråd: https://nav-it.slack.com/archives/C02PH6NPWKT/p1696404830519469?thread_ts=1696316986.062779&cid=C02PH6NPWKT 