### PR TITLE
Fix amplitude error

### DIFF
--- a/src/modules/stilling/superrask-soknad/components/Form.jsx
+++ b/src/modules/stilling/superrask-soknad/components/Form.jsx
@@ -104,7 +104,13 @@ function Form({ ad, applicationForm, submitForm, pending, submitApiError, valida
                 </Heading>
                 <BodyLong className="mb-4">Vær nøye med å oppgi riktig informasjon.</BodyLong>
 
-                <TextField label="Navn" id="new-application-name" auto-complete="name" name="name" className="mb-4" />
+                <TextField
+                    label="Navn"
+                    id="new-application-name"
+                    auto-complete="name"
+                    name="fullname"
+                    className="mb-4"
+                />
 
                 <TextField
                     label="E-post"


### PR DESCRIPTION
Når man fyller inn superrask søknad, så kommer det feil i console:
```
Amplitude Logger [Error]: Converting circular structure to JSON
    --> starting at object with constructor 'HTMLInputElement'
    |     property '__reactFiber$4h3nkqvgrhk' -> object with constructor 'FiberNode'
    --- property 'stateNode' closes the circle
```
Klarte å isolere årsaken, og det virker som at om vi har en input med `name="name"` så får man feilen. Om jeg kaller det noe annet, så skjer det ikke. Vet ikke hvorfor. Men for å unngå feilen, så bare kaller jeg det `name="fullname"`, det er uansett full name det er snakk om.