### PR TITLE
Add Nav-CallId

### DIFF
--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -3,6 +3,7 @@ import Search from "@/app/(sok)/_components/Search";
 import { defaultMetadataDescription, defaultOpenGraphImage, getMetadataTitle } from "@/app/layout";
 import { createQuery, defaultQuery, toApiQuery, toBrowserQuery, toReadableQuery } from "@/app/(sok)/_utils/query";
 import elasticSearchRequestBody from "@/app/(sok)/_utils/elasticSearchRequestBody";
+import { getDefaultHeaders } from "@/app/_common/utils/fetch";
 
 export async function generateMetadata({ searchParams }) {
     const query = createQuery(searchParams);
@@ -28,9 +29,7 @@ async function fetchElasticSearch(query) {
     const body = elasticSearchRequestBody(query);
     const res = await fetch(`${process.env.PAMSEARCHAPI_URL}/stillingsok/ad/_search`, {
         method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
+        headers: getDefaultHeaders(),
         body: JSON.stringify(body),
         next: { revalidate: 30 },
         // TODO: figure out how often this should be revalidated

--- a/src/app/_common/auth/auth.js
+++ b/src/app/_common/auth/auth.js
@@ -1,5 +1,6 @@
 import { getToken, requestTokenxOboToken, validateToken } from "@navikt/oasis";
 import { cookies, headers } from "next/headers";
+import { v4 as uuidv4, validate as uuidValidate } from "uuid";
 
 export async function getAdUserOboToken() {
     const token = getToken(headers());
@@ -42,10 +43,16 @@ export function getAdUserDefaultAuthHeadersWithCsrfToken(oboToken) {
 }
 
 export function getDefaultAuthHeaders(oboToken) {
-    const headers = new Headers();
+    let callId = headers().get("Nav-CallId");
+    if (!uuidValidate(callId)) {
+        callId = uuidv4();
+    }
 
-    headers.set("Content-Type", "application/json");
-    headers.set("Authorization", `Bearer ${oboToken}`);
+    const newHeaders = new Headers();
 
-    return headers;
+    newHeaders.set("Content-Type", "application/json");
+    newHeaders.set("Authorization", `Bearer ${oboToken}`);
+    newHeaders.set("Nav-CallId", callId);
+
+    return newHeaders;
 }

--- a/src/app/_common/auth/auth.js
+++ b/src/app/_common/auth/auth.js
@@ -1,6 +1,6 @@
 import { getToken, requestTokenxOboToken, validateToken } from "@navikt/oasis";
 import { cookies, headers } from "next/headers";
-import { addCallIdHeader } from "@/app/_common/monitoring/callId";
+import { getDefaultHeaders } from '@/app/_common/utils/fetch';
 
 export async function getAdUserOboToken() {
     const token = getToken(headers());
@@ -43,11 +43,9 @@ export function getAdUserDefaultAuthHeadersWithCsrfToken(oboToken) {
 }
 
 export function getDefaultAuthHeaders(oboToken) {
-    const newHeaders = new Headers();
+    const headers = getDefaultHeaders();
 
-    newHeaders.set("Content-Type", "application/json");
-    newHeaders.set("Authorization", `Bearer ${oboToken}`);
-    addCallIdHeader(newHeaders);
+    headers.set("Authorization", `Bearer ${oboToken}`);
 
-    return newHeaders;
+    return headers;
 }

--- a/src/app/_common/auth/auth.js
+++ b/src/app/_common/auth/auth.js
@@ -1,6 +1,6 @@
 import { getToken, requestTokenxOboToken, validateToken } from "@navikt/oasis";
 import { cookies, headers } from "next/headers";
-import { v4 as uuidv4, validate as uuidValidate } from "uuid";
+import { addCallIdHeader } from "@/app/_common/monitoring/callId";
 
 export async function getAdUserOboToken() {
     const token = getToken(headers());
@@ -43,16 +43,11 @@ export function getAdUserDefaultAuthHeadersWithCsrfToken(oboToken) {
 }
 
 export function getDefaultAuthHeaders(oboToken) {
-    let callId = headers().get("Nav-CallId");
-    if (!uuidValidate(callId)) {
-        callId = uuidv4();
-    }
-
     const newHeaders = new Headers();
 
     newHeaders.set("Content-Type", "application/json");
     newHeaders.set("Authorization", `Bearer ${oboToken}`);
-    newHeaders.set("Nav-CallId", callId);
+    addCallIdHeader(newHeaders);
 
     return newHeaders;
 }

--- a/src/app/_common/monitoring/callId.js
+++ b/src/app/_common/monitoring/callId.js
@@ -1,0 +1,16 @@
+import { headers } from "next/headers";
+import { v4 as uuidv4, validate as uuidValidate } from "uuid";
+
+export const NAV_CALL_ID_TAG = "Nav-CallId";
+
+export function getCallId() {
+    return headers().get(NAV_CALL_ID_TAG);
+}
+
+export function addCallIdHeader(requestHeaders) {
+    const existingCallId = headers().get(NAV_CALL_ID_TAG);
+
+    if (!uuidValidate(existingCallId)) {
+        requestHeaders.set(NAV_CALL_ID_TAG, uuidv4());
+    }
+}

--- a/src/app/_common/monitoring/callId.js
+++ b/src/app/_common/monitoring/callId.js
@@ -12,7 +12,3 @@ export function getCallId() {
     
     return callId;
 }
-
-export function addCallIdHeader(requestHeaders) {
-    requestHeaders.set(NAV_CALL_ID_TAG, getCallId());
-}

--- a/src/app/_common/monitoring/callId.js
+++ b/src/app/_common/monitoring/callId.js
@@ -4,13 +4,15 @@ import { v4 as uuidv4, validate as uuidValidate } from "uuid";
 export const NAV_CALL_ID_TAG = "Nav-CallId";
 
 export function getCallId() {
-    return headers().get(NAV_CALL_ID_TAG);
+    let callId = headers().get(NAV_CALL_ID_TAG);
+
+    if (!uuidValidate(callId)) {
+        callId = uuidv4();
+    }
+    
+    return callId;
 }
 
 export function addCallIdHeader(requestHeaders) {
-    const existingCallId = headers().get(NAV_CALL_ID_TAG);
-
-    if (!uuidValidate(existingCallId)) {
-        requestHeaders.set(NAV_CALL_ID_TAG, uuidv4());
-    }
+    requestHeaders.set(NAV_CALL_ID_TAG, getCallId());
 }

--- a/src/app/_common/utils/fetch.js
+++ b/src/app/_common/utils/fetch.js
@@ -1,0 +1,11 @@
+import { getCallId, NAV_CALL_ID_TAG } from '@/app/_common/monitoring/callId';
+
+export function getDefaultHeaders() {
+    const headers = new Headers();
+
+    headers.set("Content-Type", "application/json");
+    headers.set("Accept", "application/json");
+    headers.set(NAV_CALL_ID_TAG, getCallId());
+
+    return headers;
+}

--- a/src/app/_common/utils/logger.js
+++ b/src/app/_common/utils/logger.js
@@ -1,10 +1,8 @@
 import winston from "winston";
-import { headers } from "next/headers";
-
-const NAV_CALL_ID_TAG = "Nav-CallId";
+import { getCallId, NAV_CALL_ID_TAG } from "@/app/_common/monitoring/callId";
 
 const addCallId = winston.format((info) => {
-    info[NAV_CALL_ID_TAG] = headers().get(NAV_CALL_ID_TAG);
+    info[NAV_CALL_ID_TAG] = getCallId();
     return info;
 });
 

--- a/src/app/_common/utils/logger.js
+++ b/src/app/_common/utils/logger.js
@@ -1,7 +1,15 @@
 import winston from "winston";
+import { headers } from "next/headers";
+
+export const NAV_CALL_ID_TAG = "Nav-CallId";
+
+const addCallId = winston.format((info) => {
+    info[NAV_CALL_ID_TAG] = headers().get(NAV_CALL_ID_TAG);
+    return info;
+});
 
 const logger = winston.createLogger({
-    format: winston.format.json(),
+    format: winston.format.combine(addCallId(), winston.format.json()),
     transports: [new winston.transports.Console()],
 });
 

--- a/src/app/_common/utils/logger.js
+++ b/src/app/_common/utils/logger.js
@@ -1,7 +1,7 @@
 import winston from "winston";
 import { headers } from "next/headers";
 
-export const NAV_CALL_ID_TAG = "Nav-CallId";
+const NAV_CALL_ID_TAG = "Nav-CallId";
 
 const addCallId = winston.format((info) => {
     info[NAV_CALL_ID_TAG] = headers().get(NAV_CALL_ID_TAG);

--- a/src/app/api/search/route.js
+++ b/src/app/api/search/route.js
@@ -1,6 +1,7 @@
 import elasticSearchRequestBody from "@/app/(sok)/_utils/elasticSearchRequestBody";
 import simplifySearchResponse from "@/app/(sok)/_utils/simplifySearchResponse";
 import { createQuery, toApiQuery } from "@/app/(sok)/_utils/query";
+import { getDefaultHeaders } from "@/app/_common/utils/fetch";
 
 // Todo - test at denne fungere med aduser. Jeg tror aduser kaller dette endepunktet når email for lagrede søk skal sendes ut
 
@@ -13,9 +14,7 @@ export async function GET(request) {
     const body = elasticSearchRequestBody(toApiQuery(query));
     const res = await fetch(`${process.env.PAMSEARCHAPI_URL}/stillingsok/ad/_search`, {
         method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
+        headers: getDefaultHeaders(),
         body: JSON.stringify(body),
     });
 

--- a/src/app/api/suggestions/route.js
+++ b/src/app/api/suggestions/route.js
@@ -1,3 +1,5 @@
+import { getDefaultHeaders } from "@/app/_common/utils/fetch";
+
 const host = process.env.PAMSEARCHAPI_URL ? process.env.PAMSEARCHAPI_URL : "http://pam-search-api";
 
 function suggest(field, match) {
@@ -31,9 +33,7 @@ export async function POST(request) {
     const body = suggestionsTemplate(query.match, query.minLength);
     const res = await fetch(`${host}/stillingsok/ad/_search`, {
         method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
+        headers: getDefaultHeaders(),
         body: JSON.stringify(body),
     });
     const data = await res.json();

--- a/src/app/rapporter-annonse/[id]/page.jsx
+++ b/src/app/rapporter-annonse/[id]/page.jsx
@@ -2,6 +2,7 @@ import ReportAd from "./_components/ReportAd";
 import validateForm from "@/app/stilling/[id]/_components/validate";
 import { getMetadataTitle } from "@/app/layout";
 import { fetchAd } from "@/app/stilling/FetchAd";
+import { getDefaultHeaders } from "@/app/_common/utils/fetch";
 
 export const metadata = {
     title: getMetadataTitle("Rapporter annonse"),
@@ -48,9 +49,7 @@ export default async function Page({ params }) {
             const response = await fetch(`${process.env.PAMADUSER_URL}/api/v1/reportposting`, {
                 body: JSON.stringify(reportPostingData),
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
+                headers: getDefaultHeaders(),
             });
         } catch (err) {
             return {

--- a/src/app/stilling/FetchAd.js
+++ b/src/app/stilling/FetchAd.js
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { getDefaultHeaders } from "@/app/_common/utils/fetch";
 
 // Expose only necessary data to client
 const sourceIncludes = [
@@ -63,9 +64,7 @@ export async function fetchAd(id) {
     const res = await fetch(
         `${process.env.PAMSEARCHAPI_URL}/stillingsok/ad/ad/${id}?_source_includes=${sourceIncludes}`,
         {
-            headers: {
-                "Content-Type": "application/json",
-            },
+            headers: getDefaultHeaders(),
             next: { revalidate: 60 },
             // TODO: figure out how often this should be revalidated
         },

--- a/src/app/stilling/[id]/superrask-soknad/page.jsx
+++ b/src/app/stilling/[id]/superrask-soknad/page.jsx
@@ -1,14 +1,14 @@
 import { notFound } from "next/navigation";
-import { v4 as uuidv4 } from "uuid";
 import validateForm, { parseFormData } from "./_components/validateForm";
 import NewApplication from "./_components/NewApplication";
 import { getStillingDescription, getSuperraskTitle } from "../_components/getMetaData";
 import { defaultOpenGraphImage } from "@/app/layout";
 import { fetchAd } from "@/app/stilling/FetchAd";
+import { getDefaultHeaders } from "@/app/_common/utils/fetch";
 
 async function fetchApplicationForm(id) {
     const res = await fetch(`${process.env.INTEREST_API_URL}/application-form/${id}`, {
-        headers: { NAV_CALLID_FIELD: uuidv4() },
+        headers: getDefaultHeaders(),
         next: { revalidate: 30 },
     });
     if (res.status === 404) {
@@ -64,10 +64,7 @@ export default async function Page({ params }) {
             const response = await fetch(`${process.env.INTEREST_API_URL}/application-form/${params.id}/application`, {
                 body: JSON.stringify(application),
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    NAV_CALLID_FIELD: uuidv4(),
-                },
+                headers: getDefaultHeaders(),
             });
 
             if (response.status !== 200) {

--- a/src/app/trekk-soknad/[uuid]/[adUuid]/page.jsx
+++ b/src/app/trekk-soknad/[uuid]/[adUuid]/page.jsx
@@ -1,8 +1,8 @@
 import { notFound } from "next/navigation";
-import { v4 as uuidv4 } from "uuid";
 import WithdrawApplication from "./_components/WithdrawApplication";
 import { getMetadataTitle } from "@/app/layout";
 import { fetchAd } from "@/app/stilling/FetchAd";
+import { getDefaultHeaders } from "@/app/_common/utils/fetch";
 
 export const metadata = {
     title: getMetadataTitle("Trekk søknad"),
@@ -13,6 +13,7 @@ async function fetchApplicationExists(adUuid, uuid) {
     const res = await fetch(`${process.env.INTEREST_API_URL}/application-form/${adUuid}/application/${uuid}`, {
         method: "HEAD",
         cache: "no-store",
+        headers: getDefaultHeaders(),
     });
     if (res.status === 410 || res.status === 404) {
         notFound();
@@ -31,9 +32,7 @@ export default async function Page({ params }) {
         try {
             const res = await fetch(`${process.env.INTEREST_API_URL}/application-form/${adUuid}/application/${uuid}`, {
                 method: "DELETE",
-                headers: {
-                    NAV_CALLID_FIELD: uuidv4(),
-                },
+                headers: getDefaultHeaders(),
             });
 
             if (res.status !== 200 && res.status !== 204) {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { v4 as uuidv4, validate as uuidValidate } from "uuid";
+import { NAV_CALL_ID_TAG } from "@/app/_common/utils/logger";
 
 export function middleware(request) {
     const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
@@ -41,9 +42,9 @@ export function middleware(request) {
 }
 
 function addCallIdHeader(requestHeaders) {
-    const existingCallId = requestHeaders.get("Nav-CallId");
+    const existingCallId = requestHeaders.get(NAV_CALL_ID_TAG);
 
     if (!uuidValidate(existingCallId)) {
-        requestHeaders.set("Nav-CallId", uuidv4());
+        requestHeaders.set(NAV_CALL_ID_TAG, uuidv4());
     }
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { v4 as uuidv4, validate as uuidValidate } from "uuid";
-
-const NAV_CALL_ID_TAG = "Nav-CallId";
+import { addCallIdHeader } from "@/app/_common/monitoring/callId";
 
 export function middleware(request) {
     const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
@@ -40,12 +38,4 @@ export function middleware(request) {
     response.headers.set("Content-Security-Policy", contentSecurityPolicyHeaderValue);
 
     return response;
-}
-
-function addCallIdHeader(requestHeaders) {
-    const existingCallId = requestHeaders.get(NAV_CALL_ID_TAG);
-
-    if (!uuidValidate(existingCallId)) {
-        requestHeaders.set(NAV_CALL_ID_TAG, uuidv4());
-    }
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { v4 as uuidv4, validate as uuidValidate } from "uuid";
-import { NAV_CALL_ID_TAG } from "@/app/_common/utils/logger";
+
+const NAV_CALL_ID_TAG = "Nav-CallId";
 
 export function middleware(request) {
     const nonce = Buffer.from(crypto.randomUUID()).toString("base64");

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { v4 as uuidv4, validate as uuidValidate } from "uuid";
 
 export function middleware(request) {
     const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
@@ -27,6 +28,8 @@ export function middleware(request) {
     requestHeaders.set("x-nonce", nonce);
     requestHeaders.set("Content-Security-Policy", contentSecurityPolicyHeaderValue);
 
+    addCallIdHeader(requestHeaders);
+
     const response = NextResponse.next({
         request: {
             headers: requestHeaders,
@@ -35,4 +38,12 @@ export function middleware(request) {
     response.headers.set("Content-Security-Policy", contentSecurityPolicyHeaderValue);
 
     return response;
+}
+
+function addCallIdHeader(requestHeaders) {
+    const existingCallId = requestHeaders.get("Nav-CallId");
+
+    if (!uuidValidate(existingCallId)) {
+        requestHeaders.set("Nav-CallId", uuidv4());
+    }
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getCallId, NAV_CALL_ID_TAG } from '@/app/_common/monitoring/callId';
+import { getCallId, NAV_CALL_ID_TAG } from "@/app/_common/monitoring/callId";
 
 export function middleware(request) {
     const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
@@ -28,8 +28,6 @@ export function middleware(request) {
     requestHeaders.set("x-nonce", nonce);
     requestHeaders.set("Content-Security-Policy", contentSecurityPolicyHeaderValue);
     requestHeaders.set(NAV_CALL_ID_TAG, getCallId());
-
-    addCallIdHeader(requestHeaders);
 
     const response = NextResponse.next({
         request: {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { addCallIdHeader } from "@/app/_common/monitoring/callId";
+import { getCallId, NAV_CALL_ID_TAG } from '@/app/_common/monitoring/callId';
 
 export function middleware(request) {
     const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
@@ -27,6 +27,7 @@ export function middleware(request) {
     const requestHeaders = new Headers(request.headers);
     requestHeaders.set("x-nonce", nonce);
     requestHeaders.set("Content-Security-Policy", contentSecurityPolicyHeaderValue);
+    requestHeaders.set(NAV_CALL_ID_TAG, getCallId());
 
     addCallIdHeader(requestHeaders);
 


### PR DESCRIPTION
Adds a per request-unique call id to the headers in a middleware. The ID can then be read where needed (server side) using the `headers` function.

The header is propagated to all other backend calls and is included when logging.