### PR TITLE
Søk på yrke, men ikke arbeidsgivers navn eller annonsetittel

### DIFF
--- a/src/app/(sok)/_utils/elasticSearchRequestBody.js
+++ b/src/app/(sok)/_utils/elasticSearchRequestBody.js
@@ -360,7 +360,7 @@ function mainQueryConjunctionTuning(q, searchFields) {
     let matchFields;
 
     if (searchFields === "occupation") {
-        matchFields = ["category_name_no^2", "title_no^1", "searchtags_no^0.3"];
+        matchFields = ["category_name_no^2", "searchtags_no^0.3"];
 
         return {
             bool: {

--- a/src/app/(sok)/_utils/elasticSearchRequestBody.js
+++ b/src/app/(sok)/_utils/elasticSearchRequestBody.js
@@ -361,6 +361,33 @@ function mainQueryConjunctionTuning(q, searchFields) {
 
     if (searchFields === "occupation") {
         matchFields = ["category_name_no^2", "title_no^1", "searchtags_no^0.3"];
+
+        return {
+            bool: {
+                must: {
+                    bool: {
+                        should: [
+                            {
+                                multi_match: {
+                                    query: q,
+                                    type: "cross_fields",
+                                    fields: matchFields,
+                                    operator: "and",
+                                    tie_breaker: 0.3,
+                                    analyzer: "norwegian",
+                                    zero_terms_query: "all",
+                                },
+                            },
+                        ],
+                    },
+                },
+                filter: {
+                    term: {
+                        status: "ACTIVE",
+                    },
+                },
+            },
+        };
     } else {
         matchFields = [
             "category_name_no^2",
@@ -371,85 +398,86 @@ function mainQueryConjunctionTuning(q, searchFields) {
             "adtext_no^0.2",
             "employerdescription_no^0.1",
         ];
-    }
-    return {
-        bool: {
-            must: {
-                bool: {
-                    should: [
-                        {
-                            multi_match: {
-                                query: q,
-                                type: "cross_fields",
-                                fields: matchFields,
-                                operator: "and",
-                                tie_breaker: 0.3,
-                                analyzer: "norwegian",
-                                zero_terms_query: "all",
-                            },
-                        },
-                        {
-                            match_phrase: {
-                                employername: {
+
+        return {
+            bool: {
+                must: {
+                    bool: {
+                        should: [
+                            {
+                                multi_match: {
                                     query: q,
-                                    slop: 0,
-                                    boost: 2,
-                                },
-                            },
-                        },
-                        {
-                            match: {
-                                id: {
-                                    query: q,
+                                    type: "cross_fields",
+                                    fields: matchFields,
                                     operator: "and",
-                                    boost: 1,
+                                    tie_breaker: 0.3,
+                                    analyzer: "norwegian",
+                                    zero_terms_query: "all",
                                 },
                             },
+                            {
+                                match_phrase: {
+                                    employername: {
+                                        query: q,
+                                        slop: 0,
+                                        boost: 2,
+                                    },
+                                },
+                            },
+                            {
+                                match: {
+                                    id: {
+                                        query: q,
+                                        operator: "and",
+                                        boost: 1,
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+                should: [
+                    {
+                        match_phrase: {
+                            title: {
+                                query: q,
+                                slop: 2,
+                            },
                         },
-                    ],
+                    },
+                    {
+                        constant_score: {
+                            filter: {
+                                match: {
+                                    "location.municipal": {
+                                        query: q,
+                                    },
+                                },
+                            },
+                            boost: 3,
+                        },
+                    },
+                    {
+                        constant_score: {
+                            filter: {
+                                match: {
+                                    "location.county": {
+                                        query: q,
+                                    },
+                                },
+                            },
+                            boost: 3,
+                        },
+                    },
+                ],
+                filter: {
+                    term: {
+                        status: "ACTIVE",
+                    },
                 },
             },
-            should: [
-                {
-                    match_phrase: {
-                        title: {
-                            query: q,
-                            slop: 2,
-                        },
-                    },
-                },
-                {
-                    constant_score: {
-                        filter: {
-                            match: {
-                                "location.municipal": {
-                                    query: q,
-                                },
-                            },
-                        },
-                        boost: 3,
-                    },
-                },
-                {
-                    constant_score: {
-                        filter: {
-                            match: {
-                                "location.county": {
-                                    query: q,
-                                },
-                            },
-                        },
-                        boost: 3,
-                    },
-                },
-            ],
-            filter: {
-                term: {
-                    status: "ACTIVE",
-                },
-            },
-        },
-    };
+        };
+    }
 }
 
 /* Generate main matching query object with classic/original OR match relevance model */


### PR DESCRIPTION
- Denne endringen gjør at når man nå velger et yrke fra forslagene som dukker opp i søkefeltet, så søker vi bare på yrkeskategori og search tags. 
- Tidligere søkte vi også på arbeidsgivers navn og annonsetittel. Dette ville da gi urelevante treff. For eksempel så ville søk på yrket `Lege` gi treff på pengeinnsamler for arbeidsgiveren Leger uten grenser.
- Søk på `Leger uten grenser` derimot vil virke som før, da dette ikke er et yrke man velger fra forslagene, og at vi da trigger et fullt tekst-søk på alle felter
