### PR TITLE
Fikser feilmelding hvis man forsøker å oppdatere et lagret søk som ikke finnnes lengre

### DIFF
--- a/src/app/lagrede-sok/_components/modal/NotFoundMessage.jsx
+++ b/src/app/lagrede-sok/_components/modal/NotFoundMessage.jsx
@@ -1,17 +1,24 @@
 import React from "react";
-import { Alert, Link as AkselLink, Modal } from "@navikt/ds-react";
-import Link from "next/link";
+import { BodyLong, Button, Modal } from "@navikt/ds-react";
 
-function NotFoundMessage() {
+function NotFoundMessage({ onClose }) {
     return (
-        <Modal.Body>
-            <Alert variant="warning" role="alert">
-                Det kan se ut som om du forsøker å oppdatere et lagret søk som ikke finnes lengre.{" "}
-                <AkselLink as={Link} href="/">
-                    Last siden på nytt uten det gamle søket.
-                </AkselLink>
-            </Alert>
-        </Modal.Body>
+        <>
+            <Modal.Body>
+                <BodyLong spacing>
+                    Det ser ut som om du forsøker å oppdatere et lagret søk som ikke finnes lengre. Forsøk å laste siden
+                    på nytt.
+                </BodyLong>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="primary" type="submit" as="a" href="/stillinger">
+                    Last siden på nytt
+                </Button>
+                <Button variant="secondary" type="submit" onClick={onClose}>
+                    Avbryt
+                </Button>
+            </Modal.Footer>
+        </>
     );
 }
 

--- a/src/app/lagrede-sok/_components/modal/SaveSearchModal.jsx
+++ b/src/app/lagrede-sok/_components/modal/SaveSearchModal.jsx
@@ -89,31 +89,35 @@ function SaveSearchModal({ onClose, onSaveSearchSuccess, formData, defaultFormMo
 
     return (
         <Modal onClose={onClose} header={{ heading: "Lagre søk" }} open width="medium" portal>
-            {showNotFoundError && <NotFoundMessage />}
+            {showNotFoundError ? (
+                <NotFoundMessage onClose={onClose} />
+            ) : (
+                <>
+                    {savedSearchUuid && !existingSavedSearch && (
+                        <HStack justify="center">
+                            <Loader size="xlarge" />
+                        </HStack>
+                    )}
 
-            {savedSearchUuid && !existingSavedSearch && (
-                <HStack justify="center">
-                    <Loader size="xlarge" />
-                </HStack>
+                    {shouldShowSavedSearchForm && (
+                        <SaveSearchForm
+                            existingSavedSearch={existingSavedSearch}
+                            formData={formData}
+                            defaultFormMode={defaultFormMode}
+                            onClose={onClose}
+                            onSuccess={handleSavedSearchFormSuccess}
+                        />
+                    )}
+
+                    {shouldShowRegisterEmailForm && (
+                        <RegisterEmailForm onClose={onClose} onSuccess={handleRegisterEmailSuccess} />
+                    )}
+
+                    {shouldShowSuccessMessage && <SuccessMessage onClose={onClose} />}
+
+                    {shouldShowConfirmEmailMessage && <ConfirmEmailMessage onClose={onClose} />}
+                </>
             )}
-
-            {shouldShowSavedSearchForm && (
-                <SaveSearchForm
-                    existingSavedSearch={existingSavedSearch}
-                    formData={formData}
-                    defaultFormMode={defaultFormMode}
-                    onClose={onClose}
-                    onSuccess={handleSavedSearchFormSuccess}
-                />
-            )}
-
-            {shouldShowRegisterEmailForm && (
-                <RegisterEmailForm onClose={onClose} onSuccess={handleRegisterEmailSuccess} />
-            )}
-
-            {shouldShowSuccessMessage && <SuccessMessage onClose={onClose} />}
-
-            {shouldShowConfirmEmailMessage && <ConfirmEmailMessage onClose={onClose} />}
         </Modal>
     );
 }


### PR DESCRIPTION
- Denne PR rydder opp i modalen for lagre søk, der man fikk feilmelding om at søk lengre ikke finnes, men at man likevel kunne endre det.

- Dette issuet skjer nok veldig sjelden,  men kan skje om man åpner en  gammel lenke til et lagret søk som man selv har slettet tidligere og forsøker å endre det. 

<img width="711" alt="Skjermbilde 2024-04-16 kl  09 55 55" src="https://github.com/navikt/pam-stillingsok/assets/29566394/8adbe3ff-15c1-472c-8551-85c5bc9ecf5f">
 