### PR TITLE
Fikser api kall for lagrede søk

### DIFF
--- a/src/app/api/search/route.js
+++ b/src/app/api/search/route.js
@@ -4,11 +4,27 @@ import { getDefaultHeaders } from "@/app/_common/utils/fetch";
 
 export const dynamic = "force-dynamic";
 
+function parseSearchParams(entries) {
+    const searchParams = {};
+    for (const [key, value] of entries) {
+        if (searchParams[key]) {
+            if (Array.isArray(searchParams[key])) {
+                searchParams[key] = [...searchParams[key], value];
+            } else {
+                searchParams[key] = [searchParams[key], value];
+            }
+        } else {
+            searchParams[key] = value;
+        }
+    }
+    return searchParams;
+}
+
 /**
  * Note: This endpoint is used by pam-aduser
  */
 export async function GET(request) {
-    const searchParams = Object.fromEntries(request.nextUrl.searchParams);
+    const searchParams = parseSearchParams(request.nextUrl.searchParams.entries());
     const query = createQuery(searchParams);
     const body = elasticSearchRequestBody(toApiQuery(query));
     const res = await fetch(`${process.env.PAMSEARCHAPI_URL}/stillingsok/ad/_search`, {


### PR DESCRIPTION
Vi har fått en del tilbakemeldinger på at brukere ikke får e-postvarsel på lagrede søk, selv om de har sett at det faktisk er nye treff når de går inn å sjekker på Arbeidsplassen. Noen får varsel, mens andre ikke.

- Vi søker etter stillinger både fra `page.js` i stillingsøket og i `/api/search/route.js`
- Fant ut at `searchParams` i route.js og page.js ikke har samme oppbygning.
- Dette betyr at om man for eksempel har krysset av på flere steder eller yrker, så har vi bare utført et søk på det første stedet eller første yrket, når vi sjekker om det er nye treff på et lagret søk
- Denne pr-en sørger for at searchParams i route og page har samme oppbygning