### PR TITLE
Remove unused ingresses in dev

### DIFF
--- a/.nais/dev.yml
+++ b/.nais/dev.yml
@@ -1,12 +1,6 @@
 ingress:
   - "https://arbeidsplassen.intern.dev.nav.no/stillinger"
   - "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/stilling"
-  - "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/js"
-  - "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/css"
-  - "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/images"
-  - "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/isAuthenticated"
-  - "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/api"
-  - "https://arbeidsplassen.ekstern.dev.nav.no/stillinger/_next"
 arbeidsplassen_domain: "arbeidsplassen.intern.dev.nav.no"
 env:
   ADUSER_AUDIENCE: "dev-gcp:teampam:pam-aduser"


### PR DESCRIPTION
These are no longer needed. Static resources are served by CDN. Api us not used anymore, since everything is server actions.