### PR TITLE
Track filter changed events

### DIFF
--- a/src/app/(sok)/_components/filters/Education.jsx
+++ b/src/app/(sok)/_components/filters/Education.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Checkbox, Fieldset } from "@navikt/ds-react";
 import { ADD_EDUCATION, REMOVE_EDUCATION } from "@/app/(sok)/_utils/queryReducer";
 import mergeCount from "@/app/(sok)/_components/utils/mergeCount";
-import { logSearchFilterAdded, logSearchFilterRemoved } from "@/app/_common/monitoring/amplitude";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 import moveCriteriaToBottom from "@/app/(sok)/_components/utils/moveFacetToBottom";
 import sortEducationValues from "@/app/(sok)/_components/utils/sortEducationValues";
 
@@ -13,14 +13,13 @@ function Education({ initialValues, updatedValues, query, dispatch }) {
     const values = mergeCount(sortedValues, updatedValues);
 
     function handleClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: ADD_EDUCATION, value });
-            logSearchFilterAdded({ education: value });
         } else {
             dispatch({ type: REMOVE_EDUCATION, value });
-            logSearchFilterRemoved({ education: value });
         }
+        logFilterChanged({ name: "education", value, checked });
     }
 
     const updateViewName = (key) => {

--- a/src/app/(sok)/_components/filters/Engagement.jsx
+++ b/src/app/(sok)/_components/filters/Engagement.jsx
@@ -5,7 +5,7 @@ import { ADD_ENGAGEMENT_TYPE, REMOVE_ENGAGEMENT_TYPE } from "@/app/(sok)/_utils/
 import moveCriteriaToBottom from "@/app/(sok)/_components/utils/moveFacetToBottom";
 import mergeCount from "@/app/(sok)/_components/utils/mergeCount";
 import sortValuesByFirstLetter from "@/app/(sok)/_components/utils/sortValuesByFirstLetter";
-import { logSearchFilterAdded, logSearchFilterRemoved } from "@/app/_common/monitoring/amplitude";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 
 /**
  * This ensures that 'Annet' is displayed as 'Ikke oppgitt' in the search filters.
@@ -26,14 +26,13 @@ function Engagement({ initialValues, updatedValues, query, dispatch }) {
     const values = mergeCount(sortedValues, updatedValues);
 
     function handleClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: ADD_ENGAGEMENT_TYPE, value });
-            logSearchFilterAdded({ ansettelsesform: value });
         } else {
             dispatch({ type: REMOVE_ENGAGEMENT_TYPE, value });
-            logSearchFilterRemoved({ ansettelsesform: value });
         }
+        logFilterChanged({ name: "engagementType", value, checked });
     }
 
     return (

--- a/src/app/(sok)/_components/filters/Extent.jsx
+++ b/src/app/(sok)/_components/filters/Extent.jsx
@@ -3,20 +3,19 @@ import React from "react";
 import { BodyShort, Checkbox, Fieldset } from "@navikt/ds-react";
 import { ADD_EXTENT, REMOVE_EXTENT } from "@/app/(sok)/_utils/queryReducer";
 import mergeCount from "@/app/(sok)/_components/utils/mergeCount";
-import { logSearchFilterAdded, logSearchFilterRemoved } from "@/app/_common/monitoring/amplitude";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 
 function Extent({ initialValues, updatedValues, query, dispatch }) {
     const values = mergeCount(initialValues, updatedValues);
 
     function handleClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: ADD_EXTENT, value });
-            logSearchFilterAdded({ extent: value });
         } else {
             dispatch({ type: REMOVE_EXTENT, value });
-            logSearchFilterRemoved({ extent: value });
         }
+        logFilterChanged({ name: "extent", value, checked });
     }
 
     function labelForExtent(item) {

--- a/src/app/(sok)/_components/filters/Locations.jsx
+++ b/src/app/(sok)/_components/filters/Locations.jsx
@@ -12,7 +12,7 @@ import {
     SET_INTERNATIONAL,
 } from "@/app/(sok)/_utils/queryReducer";
 import buildLocations from "@/app/(sok)/_components/utils/buildLocations";
-import { logSearchFilterAdded, logSearchFilterRemoved } from "@/app/_common/monitoring/amplitude";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 
 function Locations({ locations, query, dispatch, updatedValues }) {
     const locationValues = buildLocations(updatedValues.aggregations, locations);
@@ -20,28 +20,25 @@ function Locations({ locations, query, dispatch, updatedValues }) {
     function handleLocationClick(value, type, checked) {
         if (type === "county") {
             if (checked) {
-                logSearchFilterAdded({ sted: value });
                 dispatch({ type: ADD_COUNTY, value });
             } else {
                 dispatch({ type: REMOVE_COUNTY, value });
-                logSearchFilterRemoved({ sted: value });
             }
+            logFilterChanged({ name: "location", value, checked, level: "county" });
         } else if (type === "municipal") {
             if (checked) {
                 dispatch({ type: ADD_MUNICIPAL, value });
-                logSearchFilterAdded({ sted: value });
             } else {
                 dispatch({ type: REMOVE_MUNICIPAL, value });
-                logSearchFilterRemoved({ sted: value });
             }
+            logFilterChanged({ name: "location", value, checked, level: "municipal" });
         } else if (type === "country") {
             if (checked) {
                 dispatch({ type: ADD_COUNTRY, value });
-                logSearchFilterAdded({ sted: value });
             } else {
                 dispatch({ type: REMOVE_COUNTRY, value });
-                logSearchFilterRemoved({ sted: value });
             }
+            logFilterChanged({ name: "location", value, checked, level: "country" });
         } else if (type === "international") {
             if (query.international) {
                 query.countries.forEach((c) => {

--- a/src/app/(sok)/_components/filters/Occupations.jsx
+++ b/src/app/(sok)/_components/filters/Occupations.jsx
@@ -10,7 +10,7 @@ import {
 import moveCriteriaToBottom from "@/app/(sok)/_components/utils/moveFacetToBottom";
 import mergeCount from "@/app/(sok)/_components/utils/mergeCount";
 import sortValuesByFirstLetter from "@/app/(sok)/_components/utils/sortValuesByFirstLetter";
-import { logSearchFilterAdded, logSearchFilterRemoved } from "@/app/_common/monitoring/amplitude";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 
 const OCCUPATION_LEVEL_OTHER = "Uoppgitt/ ikke identifiserbare";
 
@@ -28,25 +28,23 @@ function Occupations({ initialValues, updatedValues, query, dispatch }) {
     const values = mergeCount(sortedValues, updatedValues, "occupationSecondLevels");
 
     function handleFirstLevelClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: ADD_OCCUPATION_FIRST_LEVEL, value });
-            logSearchFilterAdded({ yrke: value });
         } else {
             dispatch({ type: REMOVE_OCCUPATION_FIRST_LEVEL, value });
-            logSearchFilterRemoved({ yrke: value });
         }
+        logFilterChanged({ name: "occupation", value, checked, level: 1 });
     }
 
     function handleSecondLevelClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: ADD_OCCUPATION_SECOND_LEVEL, value });
-            logSearchFilterAdded({ yrke: value });
         } else {
             dispatch({ type: REMOVE_OCCUPATION_SECOND_LEVEL, value });
-            logSearchFilterRemoved({ yrke: value });
         }
+        logFilterChanged({ name: "occupation", value, checked, level: 2 });
     }
 
     /**

--- a/src/app/(sok)/_components/filters/Published.jsx
+++ b/src/app/(sok)/_components/filters/Published.jsx
@@ -5,18 +5,20 @@ import { SET_PUBLISHED } from "@/app/(sok)/_utils/queryReducer";
 import { PublishedLabelsEnum } from "@/app/(sok)/_utils/query";
 import mergeCount from "@/app/(sok)/_components/utils/mergeCount";
 import sortPublishedValues from "@/app/(sok)/_components/utils/sortPublishedValues";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 
 function Published({ dispatch, query, initialValues, updatedValues }) {
     const sortedValues = sortPublishedValues(initialValues);
     const values = mergeCount(sortedValues, updatedValues);
 
     function handleClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: SET_PUBLISHED, value });
         } else {
             dispatch({ type: SET_PUBLISHED, undefined });
         }
+        logFilterChanged({ name: "published", value, checked });
     }
 
     return (

--- a/src/app/(sok)/_components/filters/Remote.jsx
+++ b/src/app/(sok)/_components/filters/Remote.jsx
@@ -4,7 +4,7 @@ import { ADD_REMOTE, REMOVE_REMOTE } from "@/app/(sok)/_utils/queryReducer";
 import moveCriteriaToBottom from "@/app/(sok)/_components/utils/moveFacetToBottom";
 import mergeCount from "@/app/(sok)/_components/utils/mergeCount";
 import sortRemoteValues from "@/app/(sok)/_components/utils/sortRemoteValues";
-import { logSearchFilterAdded, logSearchFilterRemoved } from "@/app/_common/monitoring/amplitude";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 
 function Remote({ initialValues, updatedValues, query, dispatch }) {
     const sortedValuesByFirstLetter = sortRemoteValues(initialValues);
@@ -23,14 +23,13 @@ function Remote({ initialValues, updatedValues, query, dispatch }) {
     }
 
     function handleClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: ADD_REMOTE, value });
-            logSearchFilterAdded({ remote: value });
         } else {
             dispatch({ type: REMOVE_REMOTE, value });
-            logSearchFilterRemoved({ remote: value });
         }
+        logFilterChanged({ name: "remote", value, checked });
     }
 
     return (

--- a/src/app/(sok)/_components/filters/Sector.jsx
+++ b/src/app/(sok)/_components/filters/Sector.jsx
@@ -5,7 +5,7 @@ import { ADD_SECTOR, REMOVE_SECTOR } from "@/app/(sok)/_utils/queryReducer";
 import moveCriteriaToBottom from "@/app/(sok)/_components/utils/moveFacetToBottom";
 import mergeCount from "@/app/(sok)/_components/utils/mergeCount";
 import sortValuesByFirstLetter from "@/app/(sok)/_components/utils/sortValuesByFirstLetter";
-import { logSearchFilterAdded, logSearchFilterRemoved } from "@/app/_common/monitoring/amplitude";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 
 function Sector({ initialValues, updatedValues, query, dispatch }) {
     const sortedValuesByFirstLetter = sortValuesByFirstLetter(initialValues);
@@ -13,14 +13,13 @@ function Sector({ initialValues, updatedValues, query, dispatch }) {
     const values = mergeCount(sortedValues, updatedValues);
 
     function handleClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: ADD_SECTOR, value });
-            logSearchFilterAdded({ sektor: value });
         } else {
             dispatch({ type: REMOVE_SECTOR, value });
-            logSearchFilterRemoved({ sektor: value });
         }
+        logFilterChanged({ name: "sector", value, checked });
     }
 
     return (

--- a/src/app/(sok)/_components/filters/WorkLanguage.jsx
+++ b/src/app/(sok)/_components/filters/WorkLanguage.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { BodyShort, Checkbox, Fieldset } from "@navikt/ds-react";
 import { ADD_WORKLANGUAGE, REMOVE_WORKLANGUAGE } from "@/app/(sok)/_utils/queryReducer";
 import mergeCount from "@/app/(sok)/_components/utils/mergeCount";
-import { logSearchFilterAdded, logSearchFilterRemoved } from "@/app/_common/monitoring/amplitude";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 import moveCriteriaToBottom from "@/app/(sok)/_components/utils/moveFacetToBottom";
 
 function WorkLanguage({ initialValues, updatedValues, query, dispatch, hideLegend = false }) {
@@ -11,14 +11,13 @@ function WorkLanguage({ initialValues, updatedValues, query, dispatch, hideLegen
     const values = mergeCount(sortedValues, updatedValues);
 
     function handleClick(e) {
-        const { value } = e.target;
-        if (e.target.checked) {
+        const { value, checked } = e.target;
+        if (checked) {
             dispatch({ type: ADD_WORKLANGUAGE, value });
-            logSearchFilterAdded({ arbeidsspraak: value });
         } else {
             dispatch({ type: REMOVE_WORKLANGUAGE, value });
-            logSearchFilterRemoved({ arbeidsspraak: value });
         }
+        logFilterChanged({ name: "workLanguage", value, checked });
     }
 
     return (

--- a/src/app/_common/monitoring/amplitude.js
+++ b/src/app/_common/monitoring/amplitude.js
@@ -34,12 +34,8 @@ const logAmplitudeEvent = (event, data) => {
     amplitude.track(event, enrichData(data));
 };
 
-export const logSearchFilterAdded = (data) => {
-    amplitude.track("Søkefilter lagt til", enrichData(data));
-};
-
-export const logSearchFilterRemoved = (data) => {
-    amplitude.track("Søkefilter fjernet", enrichData(data));
+export const logFilterChanged = (data) => {
+    amplitude.track("Filter Changed", enrichData(data));
 };
 
 export function logStillingVisning(adData) {


### PR DESCRIPTION
- Følger Amplitude sin navngivning for events `[Noun] + [Past Tense Verb]`
- Slår sammen eventene for  added/removed til changed, slik at det også kan passe bedre med andre varianter, slik som select, radio osv, hvor det nødvendigvis ikke går an å slette verdi. For checkbox sender vi med `checked`, om man vil vite om filter ble krysset av eller på
- På yrke og sted sendes også med hvilke nivå man endret et filter, slik at man kan filtrere ut f.eks bare endringer av fylker under sted