### PR TITLE
Add support for migrating search params (support occupation changes)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
         "react/jsx-props-no-spreading": "off",
         "react/forbid-prop-types": "off",
         "object-shorthand": "off",
+        "no-use-before-define": "off",
         // defaultProps rule to be deprecated on function components
         // https://github.com/reactjs/rfcs/pull/107
         "react/require-default-props": [

--- a/src/app/(sok)/_utils/occupationChanges.js
+++ b/src/app/(sok)/_utils/occupationChanges.js
@@ -1,45 +1,19 @@
 /* eslint-disable no-restricted-syntax */
 
-// Format: Key : [Values]
+// changeOccupations is supposed to be in the format: Key:[Values]
 // Key = Old occupation
 // Values = New occupation/s
-const changedSearchParams = {
-    "Utdanning.Forskningsarbeid": ["Utdanning.Forskningsarbeid", "Bygg og anlegg.Andre ingeniører"],
-    "Utdanning.SFO, barne- og fritidsleder": [
-        "Helse og sosial.Miljøarbeidere",
-        "Helse og sosial.Ledere av omsorgstjenetser for barn",
-    ],
-    "Helse og sosial.Helse": [
-        "Helse og sosial.Vernepleier",
-        "Helse og sosial.Helse- og miljørådgivere",
-        "Helse og sosial.Helsesekretær",
-        "Helse og sosial.Andre helseyrker",
-        "Helse og sosial.Helsefagarbeider",
-        "Helse og sosial.Andre helseyrker",
-    ],
-    "Helse og sosial.Psykologer og terapeuter": [
-        "Helse og sosial.Fysioterapeut",
-        "Helse og sosial.Ernæringsfysiolog",
-        "Helse og sosial.Audiografer og logopeder",
-        "Helse og sosial.Ergoterapeut",
-        "Helse og sosial.Kiropraktor og osteopat",
-        "Helse og sosial.Psykolog",
-        "Helse og sosial.Radiograf og audiograf",
-        "Helse og sosial.Alternativ medisin",
-    ],
-    "Helse og sosial.Sosial": [
-        "Helse og sosial.Rådgivere innen sosiale fagfelt",
-        "Helse og sosial.Hjemmehjelper og personlig assistent",
-    ],
-    "Natur og miljø.Matproduksjon og næringsmiddelarbeid": ["Kontor og økonomi.Personal, arbeidsmiljø og rekruttering"],
-    "Kultur og kreative yrker.Journalistikk og litteratur": [
-        "Kultur og kreative yrker.Journalistikk, kommunikasjon og litteratur",
-    ],
-    "Kultur og kreative yrker.Museum, bibliotek": ["Kultur og kreative yrker.Museum, bibliotek, arkiv"],
-    "Utdanning.Barnehage": ["Utdanning.Førskolelærer", "Utdanning.Barnehage- og skolefritidsassistenter"],
-};
+function assertChangedOccupationsCorrectFormat(changedOccupations) {
+    for (const occupation in changedOccupations) {
+        if (!Array.isArray(changedOccupations[occupation])) {
+            throw new Error(`New occupations for ${occupation} must be an array`);
+        }
+    }
+}
 
-export function containsOldOccupations(searchParams, changedOccupations = changedSearchParams) {
+export function containsOldOccupations(searchParams, changedOccupations) {
+    assertChangedOccupationsCorrectFormat(changedOccupations);
+
     const firstLevels = getOccupationFirstLevels(searchParams);
     const secondLevels = getOccupationSecondLevels(searchParams);
 
@@ -56,7 +30,9 @@ export function containsOldOccupations(searchParams, changedOccupations = change
     return false;
 }
 
-export function rewriteOccupationSearchParams(searchParams, changedOccupations = changedSearchParams) {
+export function rewriteOccupationSearchParams(searchParams, changedOccupations) {
+    assertChangedOccupationsCorrectFormat(changedOccupations);
+
     const initialSecondLevels = getOccupationSecondLevels(searchParams);
     const onlyInFirstLevel = getOccupationsOnlyInFirstLevel(searchParams);
 

--- a/src/app/(sok)/_utils/occupationChanges.js
+++ b/src/app/(sok)/_utils/occupationChanges.js
@@ -1,0 +1,115 @@
+/* eslint-disable no-restricted-syntax */
+
+// Format: Key : [Values]
+// Key = Old occupation
+// Values = New occupation/s
+const changedSearchParams = {
+    "Utdanning.Forskningsarbeid": ["Utdanning.Forskningsarbeid", "Bygg og anlegg;Andre ingeniører"],
+    "Utdanning.SFO, barne- og fritidsleder": [
+        "Helse og sosial.Miljøarbeidere",
+        "Helse og sosial.Ledere av omsorgstjenetser for barn",
+    ],
+    "Helse og sosial.Helse": [
+        "Helse og sosial.Vernepleier",
+        "Helse og sosial.Helse- og miljørådgivere",
+        "Helse og sosial.Helsesekretær",
+        "Helse og sosial.Andre helseyrker",
+        "Helse og sosial.Helsefagarbeider",
+        "Helse og sosial.Andre helseyrker",
+    ],
+    "Helse og sosial.Psykologer og terapeuter": [
+        "Helse og sosial.Fysioterapeut",
+        "Helse og sosial.Ernæringsfysiolog",
+        "Helse og sosial.Audiografer og logopeder",
+        "Helse og sosial.Ergoterapeut",
+        "Helse og sosial.Kiropraktor og osteopat",
+        "Helse og sosial.Psykolog",
+        "Helse og sosial.Radiograf og audiograf",
+        "Helse og sosial.Alternativ medisin",
+    ],
+    "Helse og sosial.Sosial": [
+        "Helse og sosial.Rådgivere innen sosiale fagfelt",
+        "Helse og sosial.Hjemmehjelper og personlig assistent",
+    ],
+    "Natur og miljø.Matproduksjon og næringsmiddelarbeid": ["Kontor og økonomi.Personal, arbeidsmiljø og rekruttering"],
+    "Kultur og kreative yrker.Journalistikk og litteratur": [
+        "Kultur og kreative yrker.Journalistikk, kommunikasjon og litteratur",
+    ],
+    "Kultur og kreative yrker;Museum, bibliotek": ["Kultur og kreative yrker.Museum, bibliotek, arkiv"],
+    "Utdanning.Barnehage": ["Utdanning.Førskolelærer", "Utdanning.Barnehage- og skolefritidsassistenter"],
+};
+
+export function containsOldOccupations(searchParams, changedOccupations = changedSearchParams) {
+    const firstLevels = getOccupationFirstLevels(searchParams);
+    const secondLevels = getOccupationSecondLevels(searchParams);
+
+    if (firstLevels.length === 0 || secondLevels.length === 0) {
+        return false;
+    }
+
+    for (const secondLevel of secondLevels) {
+        if (getChangedSecondLevelOccupations(changedOccupations).includes(secondLevel)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export function rewriteOccupationSearchParams(searchParams, changedOccupations = changedSearchParams) {
+    const initialSecondLevels = getOccupationSecondLevels(searchParams);
+    const onlyInFirstLevel = getOccupationsOnlyInFirstLevel(searchParams);
+
+    const newSecondLevels = initialSecondLevels
+        .map((secondLevel) => {
+            if (getChangedSecondLevelOccupations(changedOccupations).includes(secondLevel)) {
+                return changedOccupations[secondLevel];
+            }
+            return secondLevel;
+        })
+        .flat();
+
+    const firstLevelsFromNewSecondLevels = newSecondLevels.map((secondLevel) => secondLevel.split(".")[0]);
+
+    const newFirstLevels = [...new Set([...onlyInFirstLevel, ...firstLevelsFromNewSecondLevels])];
+
+    return {
+        ...searchParams,
+        "occupationFirstLevels[]": newFirstLevels,
+        "occupationSecondLevels[]": newSecondLevels,
+    };
+}
+
+export function getOccupationsOnlyInFirstLevel(searchParams) {
+    const firstLevels = getOccupationFirstLevels(searchParams);
+    const secondLevels = getOccupationSecondLevels(searchParams);
+
+    return firstLevels.filter((firstLevel) => {
+        for (const secondLevel of secondLevels) {
+            if (secondLevel.indexOf(firstLevel) !== -1) {
+                return false;
+            }
+        }
+
+        return true;
+    });
+}
+
+function getOccupationFirstLevels(searchParams) {
+    return toArray(searchParams["occupationFirstLevels[]"]);
+}
+
+function getOccupationSecondLevels(searchParams) {
+    return toArray(searchParams["occupationSecondLevels[]"]);
+}
+
+function toArray(value) {
+    if (value === undefined) {
+        return [];
+    }
+    return Array.isArray(value) ? value : [value];
+}
+
+function getChangedSecondLevelOccupations(searchParams) {
+    return Object.keys(searchParams);
+}

--- a/src/app/(sok)/_utils/occupationChanges.js
+++ b/src/app/(sok)/_utils/occupationChanges.js
@@ -4,7 +4,7 @@
 // Key = Old occupation
 // Values = New occupation/s
 const changedSearchParams = {
-    "Utdanning.Forskningsarbeid": ["Utdanning.Forskningsarbeid", "Bygg og anlegg;Andre ingeniører"],
+    "Utdanning.Forskningsarbeid": ["Utdanning.Forskningsarbeid", "Bygg og anlegg.Andre ingeniører"],
     "Utdanning.SFO, barne- og fritidsleder": [
         "Helse og sosial.Miljøarbeidere",
         "Helse og sosial.Ledere av omsorgstjenetser for barn",
@@ -35,7 +35,7 @@ const changedSearchParams = {
     "Kultur og kreative yrker.Journalistikk og litteratur": [
         "Kultur og kreative yrker.Journalistikk, kommunikasjon og litteratur",
     ],
-    "Kultur og kreative yrker;Museum, bibliotek": ["Kultur og kreative yrker.Museum, bibliotek, arkiv"],
+    "Kultur og kreative yrker.Museum, bibliotek": ["Kultur og kreative yrker.Museum, bibliotek, arkiv"],
     "Utdanning.Barnehage": ["Utdanning.Førskolelærer", "Utdanning.Barnehage- og skolefritidsassistenter"],
 };
 

--- a/src/app/(sok)/_utils/occupationChanges.test.js
+++ b/src/app/(sok)/_utils/occupationChanges.test.js
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "vitest";
+import {
+    containsOldOccupations,
+    getOccupationsOnlyInFirstLevel,
+    rewriteOccupationSearchParams,
+} from "@/app/(sok)/_utils/occupationChanges";
+
+expect.extend({
+    toContainSameElements: (received, expected) => {
+        const { isNot } = this;
+        return {
+            pass: JSON.stringify(received.sort()) === JSON.stringify(expected.sort()),
+            message: () => `expected [${received}] to${isNot ? " not" : ""} contain the same elements as [${expected}]`,
+        };
+    },
+});
+
+const CHANGED_SEARCH_PARAMS = {
+    "Helse og sosial.Helse": ["Helse og sosial.Lege"],
+    "Utdanning.Forskningsarbeid": ["Bygg og anlegg.Andre ingeniører"],
+    "IT.Utvikler": ["IT.Frontendutvikler", "IT.Backendutvikler"],
+    "Utdanning.Barnehage": ["Utdanning.Barnehage", "Utdanning.Barnehageassistent"],
+};
+
+describe("containsOldOccupations", () => {
+    test("Detects old occupations", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": ["Helse og sosial"],
+            "occupationSecondLevels[]": ["Helse og sosial.Helse"],
+        };
+
+        const result = containsOldOccupations(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result).toBe(true);
+    });
+
+    test("Does not falsely detect changes", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": ["Helse og sosial"],
+            "occupationSecondLevels[]": ["Helse og sosial.Finnes ikke"],
+        };
+
+        const result = containsOldOccupations(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result).toBe(false);
+    });
+
+    test("Returns false when second level is not used", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": ["Helse og sosial"],
+        };
+
+        const result = containsOldOccupations(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result).toBe(false);
+    });
+
+    test("Returns false when nothing", () => {
+        const searchParams = {};
+
+        const result = containsOldOccupations(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result).toBe(false);
+    });
+});
+
+describe("rewriteOccupationSearchParams", () => {
+    test("Rewrites old second level occupation - one-to-one mapping", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": "Helse og sosial",
+            "occupationSecondLevels[]": "Helse og sosial.Helse",
+        };
+
+        const result = rewriteOccupationSearchParams(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result["occupationFirstLevels[]"]).toContainSameElements(["Helse og sosial"]);
+        expect(result["occupationSecondLevels[]"]).toContainSameElements(["Helse og sosial.Lege"]);
+    });
+
+    test("Rewrites old second level occupation - one-to-many mapping", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": "IT",
+            "occupationSecondLevels[]": "IT.Utvikler",
+        };
+
+        const result = rewriteOccupationSearchParams(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result["occupationFirstLevels[]"]).toContainSameElements(["IT"]);
+        expect(result["occupationSecondLevels[]"]).toContainSameElements(["IT.Frontendutvikler", "IT.Backendutvikler"]);
+    });
+
+    test("If first level is changed for a second level search, the old first level will be removed", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": "Utdanning",
+            "occupationSecondLevels[]": "Utdanning.Forskningsarbeid",
+        };
+
+        const result = rewriteOccupationSearchParams(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result["occupationFirstLevels[]"]).toContainSameElements(["Bygg og anlegg"]);
+        expect(result["occupationSecondLevels[]"]).toContainSameElements(["Bygg og anlegg.Andre ingeniører"]);
+    });
+
+    test("Will keep first level searches if not used in a second level search", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": ["Helse og sosial", "IT"],
+            "occupationSecondLevels[]": "Helse og sosial.Helse",
+        };
+
+        const result = rewriteOccupationSearchParams(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result["occupationFirstLevels[]"]).toContainSameElements(["Helse og sosial", "IT"]);
+        expect(result["occupationSecondLevels[]"]).toContainSameElements(["Helse og sosial.Lege"]);
+    });
+
+    test("Will keep second level searches if not changed", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": ["Helse og sosial", "IT"],
+            "occupationSecondLevels[]": ["Helse og sosial.Helse", "IT.Databaseadmin"],
+        };
+
+        const result = rewriteOccupationSearchParams(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result["occupationFirstLevels[]"]).toContainSameElements(["Helse og sosial", "IT"]);
+        expect(result["occupationSecondLevels[]"]).toContainSameElements(["Helse og sosial.Lege", "IT.Databaseadmin"]);
+    });
+
+    test("Will keep second level searches not changed", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": "Utdanning",
+            "occupationSecondLevels[]": "Utdanning.Barnehage",
+        };
+
+        const result = rewriteOccupationSearchParams(searchParams, CHANGED_SEARCH_PARAMS);
+
+        expect(result["occupationFirstLevels[]"]).toContainSameElements(["Utdanning"]);
+        expect(result["occupationSecondLevels[]"]).toContainSameElements([
+            "Utdanning.Barnehage",
+            "Utdanning.Barnehageassistent",
+        ]);
+    });
+});
+
+describe("getOccupationsOnlyInFirstLevel", () => {
+    test("Will find occupations only in first level", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": "IT",
+        };
+
+        const onlyFirstLevel = getOccupationsOnlyInFirstLevel(searchParams);
+
+        expect(onlyFirstLevel).toContainSameElements(["IT"]);
+    });
+
+    test("Will find occupations only in first level, when second level is used", () => {
+        const searchParams = {
+            "occupationFirstLevels[]": ["Helse og sosial", "IT"],
+            "occupationSecondLevels[]": "Helse og sosial.Helse",
+        };
+
+        const onlyFirstLevel = getOccupationsOnlyInFirstLevel(searchParams);
+
+        expect(onlyFirstLevel).toContainSameElements(["IT"]);
+    });
+});

--- a/src/app/(sok)/_utils/query.js
+++ b/src/app/(sok)/_utils/query.js
@@ -1,5 +1,6 @@
 import capitalizeFirstLetter from "@/app/_common/utils/capitalizeFirstLetter";
 import fixLocationName from "@/app/_common/utils/fixLocationName";
+import { CURRENT_VERSION } from "@/app/(sok)/_utils/searchParamsVersioning";
 
 export const SEARCH_CHUNK_SIZE = 25;
 export const ALLOWED_NUMBER_OF_RESULTS_PER_PAGE = [SEARCH_CHUNK_SIZE, SEARCH_CHUNK_SIZE * 4];
@@ -40,6 +41,7 @@ export const defaultQuery = {
     international: false,
     workLanguage: [],
     match: undefined,
+    v: CURRENT_VERSION,
 };
 
 // eslint-disable-next-line import/prefer-default-export
@@ -68,6 +70,7 @@ export function createQuery(searchParams) {
         workLanguage: asArray(searchParams["workLanguage[]"]) || defaultQuery.workLanguage,
         sort: searchParams.sort || defaultQuery.sort,
         fields: searchParams.fields || defaultQuery.fields,
+        v: searchParams.v || defaultQuery.v,
     };
 }
 

--- a/src/app/(sok)/_utils/query.js
+++ b/src/app/(sok)/_utils/query.js
@@ -1,6 +1,6 @@
 import capitalizeFirstLetter from "@/app/_common/utils/capitalizeFirstLetter";
 import fixLocationName from "@/app/_common/utils/fixLocationName";
-import { CURRENT_VERSION } from "@/app/(sok)/_utils/searchParamsVersioning";
+import { CURRENT_VERSION, VERSION_QUERY_PARAM } from "@/app/(sok)/_utils/searchParamsVersioning";
 
 export const SEARCH_CHUNK_SIZE = 25;
 export const ALLOWED_NUMBER_OF_RESULTS_PER_PAGE = [SEARCH_CHUNK_SIZE, SEARCH_CHUNK_SIZE * 4];
@@ -91,6 +91,12 @@ export function removeUnwantedOrEmptySearchParameters(query) {
             newObj[prop] = value;
         }
     });
+
+    // If no other properties, remove the version property
+    // We don't want the url to show /stillinger?v=1
+    if (Object.keys(newObj).length === 1 && Object.hasOwn(newObj, VERSION_QUERY_PARAM)) {
+        return {};
+    }
 
     return newObj;
 }

--- a/src/app/(sok)/_utils/queryReducer.js
+++ b/src/app/(sok)/_utils/queryReducer.js
@@ -1,3 +1,4 @@
+import { CURRENT_VERSION, VERSION_QUERY_PARAM } from "@/app/(sok)/_utils/searchParamsVersioning";
 import { defaultQuery } from "./query";
 
 export const ADD_MUNICIPAL = "ADD_MUNICIPAL";
@@ -49,6 +50,10 @@ export default function queryReducer(state, action) {
         from: 0,
         paginate: undefined,
     };
+
+    if (!Object.hasOwn(queryState, VERSION_QUERY_PARAM)) {
+        queryState.v = CURRENT_VERSION;
+    }
 
     switch (action.type) {
         case SET_INTERNATIONAL:

--- a/src/app/(sok)/_utils/searchParamsVersioning.js
+++ b/src/app/(sok)/_utils/searchParamsVersioning.js
@@ -1,4 +1,4 @@
-import { containsOldOccupations, rewriteOccupationSearchParams } from "@/app/(sok)/_utils/occupationChanges";
+import { migrateToV1 } from "@/app/(sok)/_utils/versioning/version01";
 
 export const VERSION_QUERY_PARAM = "v";
 export const CURRENT_VERSION = 1;
@@ -13,9 +13,14 @@ export function migrateSearchParams(searchParams) {
         return undefined;
     }
 
+    let newVersion = 0;
+
     if (version < 1) {
         newSearchParams = migrateToV1(newSearchParams);
+        newVersion = 1;
     }
+
+    newSearchParams[VERSION_QUERY_PARAM] = newVersion;
 
     return newSearchParams;
 }
@@ -32,18 +37,4 @@ function getCurrentVersion(searchParams) {
 
 function hasNoSearchParams(searchParams) {
     return Object.keys(searchParams).length === 0;
-}
-
-function migrateToV1(searchParams) {
-    let newSearchParams = searchParams;
-
-    // V1 changes some occupations to new ones.
-    // After changing, users might still access a search with their old occupations due to saved searches and bookmarks.
-    if (containsOldOccupations(searchParams)) {
-        newSearchParams = rewriteOccupationSearchParams(newSearchParams);
-    }
-
-    newSearchParams[VERSION_QUERY_PARAM] = 1;
-
-    return newSearchParams;
 }

--- a/src/app/(sok)/_utils/searchParamsVersioning.js
+++ b/src/app/(sok)/_utils/searchParamsVersioning.js
@@ -1,9 +1,8 @@
 import { containsOldOccupations, rewriteOccupationSearchParams } from "@/app/(sok)/_utils/occupationChanges";
 
 export const VERSION_QUERY_PARAM = "v";
-
+export const CURRENT_VERSION = 1;
 const FIRST_VERSION = 0;
-const CURRENT_VERSION = 1;
 
 // Returns new search params if the searchParams have been migrated.
 export function migrateSearchParams(searchParams) {

--- a/src/app/(sok)/_utils/searchParamsVersioning.js
+++ b/src/app/(sok)/_utils/searchParamsVersioning.js
@@ -1,0 +1,50 @@
+import { containsOldOccupations, rewriteOccupationSearchParams } from "@/app/(sok)/_utils/occupationChanges";
+
+export const VERSION_QUERY_PARAM = "v";
+
+const FIRST_VERSION = 0;
+const CURRENT_VERSION = 1;
+
+// Returns new search params if the searchParams have been migrated.
+export function migrateSearchParams(searchParams) {
+    let newSearchParams = searchParams;
+    const version = getCurrentVersion(searchParams);
+
+    if (version === CURRENT_VERSION) {
+        return undefined;
+    }
+
+    if (version < 1) {
+        newSearchParams = migrateToV1(newSearchParams);
+    }
+
+    return newSearchParams;
+}
+
+function getCurrentVersion(searchParams) {
+    if (hasNoSearchParams(searchParams)) {
+        return CURRENT_VERSION;
+    }
+
+    const version = searchParams[VERSION_QUERY_PARAM];
+
+    return version ? parseInt(version, 10) : FIRST_VERSION;
+}
+
+function hasNoSearchParams(searchParams) {
+    return Object.keys(searchParams).length === 0;
+}
+
+function migrateToV1(searchParams) {
+    let newSearchParams = searchParams;
+
+    // V1 changes some occupations to new ones.
+    // After changing, users might still access a search with their old occupations due to saved searches and bookmarks.
+    if (containsOldOccupations(searchParams)) {
+        newSearchParams = rewriteOccupationSearchParams(newSearchParams);
+    }
+
+    newSearchParams[VERSION_QUERY_PARAM] = 1;
+
+    return newSearchParams;
+}

--- a/src/app/(sok)/_utils/versioning/version01.js
+++ b/src/app/(sok)/_utils/versioning/version01.js
@@ -1,12 +1,48 @@
 import { containsOldOccupations, rewriteOccupationSearchParams } from "@/app/(sok)/_utils/occupationChanges";
 
+const changedOccupations = {
+    "Utdanning.Forskningsarbeid": ["Utdanning.Forskningsarbeid", "Bygg og anlegg.Andre ingeniører"],
+    "Utdanning.SFO, barne- og fritidsleder": [
+        "Helse og sosial.Miljøarbeidere",
+        "Helse og sosial.Ledere av omsorgstjenetser for barn",
+    ],
+    "Helse og sosial.Helse": [
+        "Helse og sosial.Vernepleier",
+        "Helse og sosial.Helse- og miljørådgivere",
+        "Helse og sosial.Helsesekretær",
+        "Helse og sosial.Andre helseyrker",
+        "Helse og sosial.Helsefagarbeider",
+        "Helse og sosial.Andre helseyrker",
+    ],
+    "Helse og sosial.Psykologer og terapeuter": [
+        "Helse og sosial.Fysioterapeut",
+        "Helse og sosial.Ernæringsfysiolog",
+        "Helse og sosial.Audiografer og logopeder",
+        "Helse og sosial.Ergoterapeut",
+        "Helse og sosial.Kiropraktor og osteopat",
+        "Helse og sosial.Psykolog",
+        "Helse og sosial.Radiograf og audiograf",
+        "Helse og sosial.Alternativ medisin",
+    ],
+    "Helse og sosial.Sosial": [
+        "Helse og sosial.Rådgivere innen sosiale fagfelt",
+        "Helse og sosial.Hjemmehjelper og personlig assistent",
+    ],
+    "Natur og miljø.Matproduksjon og næringsmiddelarbeid": ["Kontor og økonomi.Personal, arbeidsmiljø og rekruttering"],
+    "Kultur og kreative yrker.Journalistikk og litteratur": [
+        "Kultur og kreative yrker.Journalistikk, kommunikasjon og litteratur",
+    ],
+    "Kultur og kreative yrker.Museum, bibliotek": ["Kultur og kreative yrker.Museum, bibliotek, arkiv"],
+    "Utdanning.Barnehage": ["Utdanning.Førskolelærer", "Utdanning.Barnehage- og skolefritidsassistenter"],
+};
+
 export function migrateToV1(searchParams) {
     let newSearchParams = searchParams;
 
     // V1 changes some occupations to new ones.
     // After changing, users might still access a search with their old occupations due to saved searches and bookmarks.
-    if (containsOldOccupations(searchParams)) {
-        newSearchParams = rewriteOccupationSearchParams(newSearchParams);
+    if (containsOldOccupations(searchParams, changedOccupations)) {
+        newSearchParams = rewriteOccupationSearchParams(newSearchParams, changedOccupations);
     }
 
     return newSearchParams;

--- a/src/app/(sok)/_utils/versioning/version01.js
+++ b/src/app/(sok)/_utils/versioning/version01.js
@@ -1,0 +1,13 @@
+import { containsOldOccupations, rewriteOccupationSearchParams } from "@/app/(sok)/_utils/occupationChanges";
+
+export function migrateToV1(searchParams) {
+    let newSearchParams = searchParams;
+
+    // V1 changes some occupations to new ones.
+    // After changing, users might still access a search with their old occupations due to saved searches and bookmarks.
+    if (containsOldOccupations(searchParams)) {
+        newSearchParams = rewriteOccupationSearchParams(newSearchParams);
+    }
+
+    return newSearchParams;
+}

--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -7,7 +7,6 @@ import {
     toApiQuery,
     toBrowserQuery,
     toReadableQuery,
-    toSavedSearchQuery,
 } from "@/app/(sok)/_utils/query";
 import { fetchCachedElasticSearch } from "@/app/(sok)/_utils/fetchCachedElasticSearch";
 import * as actions from "@/app/_common/actions";
@@ -71,9 +70,13 @@ export default async function Page({ searchParams }) {
     if (containsOldOccupations(searchParams)) {
         const newSearchParams = rewriteOccupationSearchParams(searchParams);
 
-        // Create a new "saved search" url (does the same steps as done when a user saves a search)
-        const newBrowserQuery = stringifyQuery(toSavedSearchQuery(createQuery(newSearchParams)));
-        redirect(newBrowserQuery);
+        // Keep the saved parameter (it's removed in createQuery)
+        const newQuery = {
+            ...createQuery(newSearchParams),
+            saved: searchParams.saved,
+        };
+
+        redirect(stringifyQuery(toBrowserQuery(newQuery)));
     }
 
     const userPreferences = await actions.getUserPreferences();

--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -10,8 +10,8 @@ import {
 } from "@/app/(sok)/_utils/query";
 import { fetchCachedElasticSearch } from "@/app/(sok)/_utils/fetchCachedElasticSearch";
 import * as actions from "@/app/_common/actions";
-import { containsOldOccupations, rewriteOccupationSearchParams } from "@/app/(sok)/_utils/occupationChanges";
 import { redirect } from "next/navigation";
+import { migrateSearchParams } from "@/app/(sok)/_utils/searchParamsVersioning";
 
 export async function generateMetadata({ searchParams }) {
     const query = createQuery(searchParams);
@@ -66,17 +66,13 @@ async function fetchLocations() {
 }
 
 export default async function Page({ searchParams }) {
-    // After changing occupations, users might still access a search with their old occupations due to saved searches and bookmarks
-    if (containsOldOccupations(searchParams) && !searchParams.newOccupations) {
-        const newSearchParams = rewriteOccupationSearchParams(searchParams);
+    const newSearchParams = migrateSearchParams(searchParams);
 
-        // Keep the saved parameter (it's removed in createQuery)
+    if (newSearchParams !== undefined) {
         const newQuery = {
             ...createQuery(newSearchParams),
-            saved: searchParams.saved,
-            newOccupations: true,
+            saved: newSearchParams.saved,
         };
-
         redirect(stringifyQuery(toBrowserQuery(newQuery)));
     }
 

--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -67,13 +67,14 @@ async function fetchLocations() {
 
 export default async function Page({ searchParams }) {
     // After changing occupations, users might still access a search with their old occupations due to saved searches and bookmarks
-    if (containsOldOccupations(searchParams)) {
+    if (containsOldOccupations(searchParams) && !searchParams.newOccupations) {
         const newSearchParams = rewriteOccupationSearchParams(searchParams);
 
         // Keep the saved parameter (it's removed in createQuery)
         const newQuery = {
             ...createQuery(newSearchParams),
             saved: searchParams.saved,
+            newOccupations: true,
         };
 
         redirect(stringifyQuery(toBrowserQuery(newQuery)));

--- a/src/app/api/search/route.js
+++ b/src/app/api/search/route.js
@@ -1,6 +1,7 @@
 import elasticSearchRequestBody from "@/app/(sok)/_utils/elasticSearchRequestBody";
 import { createQuery, toApiQuery } from "@/app/(sok)/_utils/query";
 import { getDefaultHeaders } from "@/app/_common/utils/fetch";
+import { migrateSearchParams } from "@/app/(sok)/_utils/searchParamsVersioning";
 
 export const dynamic = "force-dynamic";
 
@@ -26,7 +27,8 @@ function parseSearchParams(entries) {
  */
 export async function GET(request) {
     const searchParams = parseSearchParams(request.nextUrl.searchParams);
-    const query = createQuery(searchParams);
+    const migratedSearchParams = migrateSearchParams(searchParams);
+    const query = createQuery(migratedSearchParams || searchParams);
     const body = elasticSearchRequestBody(toApiQuery(query));
     const res = await fetch(`${process.env.PAMSEARCHAPI_URL}/stillingsok/ad/_search`, {
         method: "POST",


### PR DESCRIPTION
When changing what styrk code we map to what occupation, saved searches and bookmarks will stop working. This PR adds version support to search params, which allows to change the occupation search params without breaking any saved searches or bookmarks.

Support for changed mapping is done by redirect the old filters to all the new categories. Ex.`Helse og Sosial.Sosial` has been divided into `Helse og sosial.Rådgivere innen sosiale fagfelt` and `Helse og sosial.Hjemmehjelper og personlig assistent`. To support this, both the new options will be selected when redirecting. This is done for both the `/stillinger` and the `/api/search` endpoints, however the search does not redirect, but rewrites the params silently.

A new query param has been added `v`, which will be set to `1` when selecting any filter or searching. This param is also saved in saved searches. This allows us to migrate when needed. Any search query without the version param will be considered version 0.

Changed occupations can be seen in [this PR](https://github.com/navikt/pam-styrk-yrkeskategori-mapper/pull/11).