### PR TITLE
Rename url params

### DIFF
--- a/src/app/(sok)/_utils/query.js
+++ b/src/app/(sok)/_utils/query.js
@@ -54,20 +54,19 @@ export function createQuery(searchParams) {
                 : defaultQuery.size,
         q: searchParams.q || defaultQuery.q,
         match: searchParams.match || defaultQuery.match,
-        municipals: asArray(searchParams["municipals[]"]) || defaultQuery.municipals,
-        counties: asArray(searchParams["counties[]"]) || defaultQuery.counties,
-        countries: asArray(searchParams["countries[]"]) || defaultQuery.countries,
+        municipals: asArray(searchParams.municipal) || defaultQuery.municipals,
+        counties: asArray(searchParams.county) || defaultQuery.counties,
+        countries: asArray(searchParams.country) || defaultQuery.countries,
         international: searchParams.international === "true",
-        remote: asArray(searchParams["remote[]"]) || defaultQuery.remote,
-        occupationFirstLevels: asArray(searchParams["occupationFirstLevels[]"]) || defaultQuery.occupationFirstLevels,
-        occupationSecondLevels:
-            asArray(searchParams["occupationSecondLevels[]"]) || defaultQuery.occupationSecondLevels,
+        remote: asArray(searchParams.remote) || defaultQuery.remote,
+        occupationFirstLevels: asArray(searchParams.occupationLevel1) || defaultQuery.occupationFirstLevels,
+        occupationSecondLevels: asArray(searchParams.occupationLevel2) || defaultQuery.occupationSecondLevels,
         published: searchParams.published || defaultQuery.published,
-        extent: asArray(searchParams["extent[]"]) || defaultQuery.extent,
-        engagementType: asArray(searchParams["engagementType[]"]) || defaultQuery.engagementType,
-        sector: asArray(searchParams["sector[]"]) || defaultQuery.sector,
-        education: asArray(searchParams["education[]"]) || defaultQuery.education,
-        workLanguage: asArray(searchParams["workLanguage[]"]) || defaultQuery.workLanguage,
+        extent: asArray(searchParams.extent) || defaultQuery.extent,
+        engagementType: asArray(searchParams.engagementType) || defaultQuery.engagementType,
+        sector: asArray(searchParams.sector) || defaultQuery.sector,
+        education: asArray(searchParams.education) || defaultQuery.education,
+        workLanguage: asArray(searchParams.workLanguage) || defaultQuery.workLanguage,
         sort: searchParams.sort || defaultQuery.sort,
         fields: searchParams.fields || defaultQuery.fields,
         v: searchParams.v || defaultQuery.v,
@@ -218,18 +217,36 @@ export function isSearchQueryEmpty(query) {
     return Object.keys(queryWithoutEmptyProperties).length === 0;
 }
 
+function getKeyName(key) {
+    switch (key) {
+        case "municipals":
+            return "municipal";
+        case "counties":
+            return "county";
+        case "countries":
+            return "country";
+        case "occupationFirstLevels":
+            return "occupationLevel1";
+        case "occupationSecondLevels":
+            return "occupationLevel2";
+        default:
+            return key;
+    }
+}
+
 /**
  * Takes a query object, f.ex {"q":"javascript","counties":["OSLO"]},
- * and returns an encoded query string, f.ex "?q=javascript&counties[]=OSLO".
+ * and returns an encoded query string, f.ex "?q=javascript&counties=OSLO".
  */
 export function stringifyQuery(query = {}) {
     const string = Object.keys(query)
         .map((key) => {
             const value = query[key];
+            const keyName = getKeyName(key);
             if (Array.isArray(value)) {
-                return value.map((val) => `${encodeURIComponent(key)}[]=${encodeURIComponent(val)}`).join("&");
+                return value.map((val) => `${encodeURIComponent(keyName)}=${encodeURIComponent(val)}`).join("&");
             }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`;
+            return `${encodeURIComponent(keyName)}=${encodeURIComponent(query[key])}`;
         })
         .filter((elem) => elem !== "")
         .join("&");

--- a/src/app/(sok)/_utils/searchParamsVersioning.js
+++ b/src/app/(sok)/_utils/searchParamsVersioning.js
@@ -1,7 +1,8 @@
 import { migrateToV1 } from "@/app/(sok)/_utils/versioning/version01";
+import { migrateToV2 } from "@/app/(sok)/_utils/versioning/version02";
 
 export const VERSION_QUERY_PARAM = "v";
-export const CURRENT_VERSION = 1;
+export const CURRENT_VERSION = 2;
 const FIRST_VERSION = 0;
 
 // Returns new search params if the searchParams have been migrated.
@@ -18,6 +19,11 @@ export function migrateSearchParams(searchParams) {
     if (version < 1) {
         newSearchParams = migrateToV1(newSearchParams);
         newVersion = 1;
+    }
+
+    if (version < 2) {
+        newSearchParams = migrateToV2(newSearchParams);
+        newVersion = 2;
     }
 
     newSearchParams[VERSION_QUERY_PARAM] = newVersion;

--- a/src/app/(sok)/_utils/versioning/version02.js
+++ b/src/app/(sok)/_utils/versioning/version02.js
@@ -1,5 +1,5 @@
 export function migrateToV2(searchParams) {
-    return {
+    const result = {
         ...searchParams,
         occupationLevel1: searchParams["occupationFirstLevels[]"],
         occupationLevel2: searchParams["occupationSecondLevels[]"],
@@ -13,4 +13,17 @@ export function migrateToV2(searchParams) {
         workLanguage: searchParams["workLanguage[]"],
         remote: searchParams["remote[]"],
     };
+    result.delete("occupationFirstLevels[]");
+    result.delete("occupationSecondLevels[]");
+    result.delete("municipals[]");
+    result.delete("counties[]");
+    result.delete("countries[]");
+    result.delete("extent[]");
+    result.delete("engagementType[]");
+    result.delete("sector[]");
+    result.delete("education[]");
+    result.delete("workLanguage[]");
+    result.delete("remote[]");
+
+    return result;
 }

--- a/src/app/(sok)/_utils/versioning/version02.js
+++ b/src/app/(sok)/_utils/versioning/version02.js
@@ -1,0 +1,16 @@
+export function migrateToV2(searchParams) {
+    return {
+        ...searchParams,
+        occupationLevel1: searchParams["occupationFirstLevels[]"],
+        occupationLevel2: searchParams["occupationSecondLevels[]"],
+        municipal: searchParams["municipals[]"],
+        county: searchParams["counties[]"],
+        country: searchParams["countries[]"],
+        extent: searchParams["extent[]"],
+        engagementType: searchParams["engagementType[]"],
+        sector: searchParams["sector[]"],
+        education: searchParams["education[]"],
+        workLanguage: searchParams["workLanguage[]"],
+        remote: searchParams["remote[]"],
+    };
+}


### PR DESCRIPTION
- I dag har vi noen søkeparametere som er i flertall og inneholder `[]`, for eksempel `counties[]`. Det er ingen teknisk grunn til at de skal være på dette formatet. 
- Det er en del endringer rundt søkeparametere om dagen, og det kan være en fordel etterhvert å gå over til å bruk standard [URLSearchParams api](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Men dette apiet vil encode `[]`, og url vil bare bli mindre lesbar, og det ønsker vi ikke. Dessuten er det normalt at søkeparametere er i entall, fordi det gir mer mening med apiet, f.eks `searchParams.getAll("county")`

Så denne pull requesten lager en ny versjon av søkeparametere og dropper `[]` i parametere og gjør om til entall

Eksempel før: `?counties[]=AKERSHUS&counties[]=AGDER&v=1`
Eksempel etter: `?county=AKERSHUS&county=AGDER&v=2`