### PR TITLE
Gjør om søk på yrkesforslag fra tekstsøk til filter

### DIFF
--- a/src/app/(sok)/_components/selectedFilters/SelectedFilters.jsx
+++ b/src/app/(sok)/_components/selectedFilters/SelectedFilters.jsx
@@ -21,6 +21,7 @@ import {
     SET_INTERNATIONAL,
     SET_PUBLISHED,
     SET_SEARCH_STRING,
+    REMOVE_OCCUPATION,
 } from "../../_utils/queryReducer";
 import { PublishedLabelsEnum } from "../../_utils/query";
 import SaveSearchButton from "../../../lagrede-sok/_components/SaveSearchButton";
@@ -92,6 +93,18 @@ function SelectedFilters({ query, queryDispatch }) {
             </Chips.Removable>,
         );
     }
+
+    chips.push(
+        ...query.occupations.map((value) => (
+            <Chips.Removable
+                variant="neutral"
+                key={`occupations-${value}`}
+                onClick={() => queryDispatch({ type: REMOVE_OCCUPATION, value })}
+            >
+                {value}
+            </Chips.Removable>
+        )),
+    );
 
     chips.push(
         ...query.municipals.map((value) => (

--- a/src/app/(sok)/_utils/elasticSearchRequestBody.js
+++ b/src/app/(sok)/_utils/elasticSearchRequestBody.js
@@ -394,6 +394,31 @@ function filterLocation(counties, municipals, countries, international = false) 
     return filter;
 }
 
+function filterJanzzOccupation(occupation) {
+    const filters = [];
+    if (occupation && occupation.length > 0) {
+        const filter = {
+            bool: {
+                should: [],
+            },
+        };
+        occupation.forEach((item) => {
+            filter.bool.should.push({
+                term: {
+                    category_styrk08_facet: item,
+                },
+            });
+            filter.bool.should.push({
+                term: {
+                    searchtags_facet: item,
+                },
+            });
+        });
+        filters.push(filter);
+    }
+    return filters;
+}
+
 function filterOccupation(occupationFirstLevels, occupationSecondLevels = []) {
     return filterNestedFacets(
         occupationFirstLevels,
@@ -425,41 +450,8 @@ function filterSector(sector) {
 }
 
 /* Experimental alternative relevance model with AND-logic and using cross-fields matching. */
-function mainQueryConjunctionTuning(q, searchFields) {
-    let matchFields;
-
-    if (searchFields === "occupation") {
-        matchFields = ["category_name_no^2", "searchtags_no^0.3"];
-
-        return {
-            bool: {
-                must: {
-                    bool: {
-                        should: [
-                            {
-                                multi_match: {
-                                    query: q,
-                                    type: "cross_fields",
-                                    fields: matchFields,
-                                    operator: "and",
-                                    tie_breaker: 0.3,
-                                    analyzer: "norwegian",
-                                    zero_terms_query: "all",
-                                },
-                            },
-                        ],
-                    },
-                },
-                filter: {
-                    term: {
-                        status: "ACTIVE",
-                    },
-                },
-            },
-        };
-    }
-
-    matchFields = [
+function mainQueryConjunctionTuning(q) {
+    const matchFields = [
         "category_name_no^2",
         "title_no^1",
         "keywords_no^0.8",
@@ -640,10 +632,10 @@ const elasticSearchRequestBody = (query) => {
         engagementType,
         sector,
         published,
+        occupations,
         occupationFirstLevels,
         occupationSecondLevels,
         international,
-        fields,
         operator,
     } = query;
     let { sort, q } = query;
@@ -665,10 +657,11 @@ const elasticSearchRequestBody = (query) => {
         from: from || 0,
         size: size && ALLOWED_NUMBER_OF_RESULTS_PER_PAGE.includes(size) ? size : SEARCH_CHUNK_SIZE,
         track_total_hits: true,
-        query: mainQueryTemplateFunc(q, fields),
+        query: mainQueryTemplateFunc(q),
         post_filter: {
             bool: {
                 filter: [
+                    ...filterJanzzOccupation(occupations),
                     ...filterNeedDriversLicense(needDriversLicense),
                     ...filterExtent(extent),
                     ...filterEducation(education),
@@ -724,6 +717,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterEducation(education),
@@ -750,6 +744,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterEducation(education),
@@ -789,6 +784,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterEducation(education),
@@ -811,6 +807,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterRemote(remote),
                             ...filterEducation(education),
@@ -833,6 +830,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterEducation(education),
                             ...filterWorkLanguage(workLanguage),
@@ -854,6 +852,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterRemote(remote),
@@ -876,6 +875,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterRemote(remote),
@@ -898,6 +898,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterExtent(extent),
                             ...filterEducation(education),
                             ...filterRemote(remote),
@@ -920,6 +921,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterEducation(education),
@@ -942,6 +944,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterEducation(education),
@@ -991,6 +994,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterEducation(education),
@@ -1039,6 +1043,7 @@ const elasticSearchRequestBody = (query) => {
                 filter: {
                     bool: {
                         filter: [
+                            ...filterJanzzOccupation(occupations),
                             ...filterNeedDriversLicense(needDriversLicense),
                             ...filterExtent(extent),
                             ...filterEducation(education),

--- a/src/app/(sok)/_utils/query.js
+++ b/src/app/(sok)/_utils/query.js
@@ -23,7 +23,6 @@ function asArray(value) {
 
 export const defaultQuery = {
     q: "",
-    fields: undefined,
     from: 0,
     size: SEARCH_CHUNK_SIZE,
     counties: [],
@@ -34,6 +33,7 @@ export const defaultQuery = {
     extent: [],
     remote: [],
     municipals: [],
+    occupations: [],
     occupationFirstLevels: [],
     occupationSecondLevels: [],
     published: undefined,
@@ -60,6 +60,7 @@ export function createQuery(searchParams) {
         countries: asArray(searchParams.country) || defaultQuery.countries,
         international: searchParams.international === "true",
         remote: asArray(searchParams.remote) || defaultQuery.remote,
+        occupations: asArray(searchParams.occupation) || defaultQuery.occupations,
         occupationFirstLevels: asArray(searchParams.occupationLevel1) || defaultQuery.occupationFirstLevels,
         occupationSecondLevels: asArray(searchParams.occupationLevel2) || defaultQuery.occupationSecondLevels,
         published: searchParams.published || defaultQuery.published,
@@ -70,7 +71,6 @@ export function createQuery(searchParams) {
         education: asArray(searchParams.education) || defaultQuery.education,
         workLanguage: asArray(searchParams.workLanguage) || defaultQuery.workLanguage,
         sort: searchParams.sort || defaultQuery.sort,
-        fields: searchParams.fields || defaultQuery.fields,
         v: searchParams.v || defaultQuery.v,
     };
 }
@@ -227,6 +227,8 @@ function getKeyName(key) {
             return "county";
         case "countries":
             return "country";
+        case "occupations":
+            return "occupation";
         case "occupationFirstLevels":
             return "occupationLevel1";
         case "occupationSecondLevels":

--- a/src/app/(sok)/_utils/queryReducer.js
+++ b/src/app/(sok)/_utils/queryReducer.js
@@ -7,6 +7,8 @@ export const ADD_COUNTY = "ADD_COUNTY";
 export const REMOVE_COUNTY = "REMOVE_COUNTY";
 export const ADD_COUNTRY = "ADD_COUNTRY";
 export const REMOVE_COUNTRY = "REMOVE_COUNTRY";
+export const ADD_OCCUPATION = "ADD_OCCUPATION";
+export const REMOVE_OCCUPATION = "REMOVE_OCCUPATION";
 export const ADD_OCCUPATION_FIRST_LEVEL = "ADD_OCCUPATION_FIRST_LEVEL";
 export const REMOVE_OCCUPATION_FIRST_LEVEL = "REMOVE_OCCUPATION_FIRST_LEVEL";
 export const ADD_OCCUPATION_SECOND_LEVEL = "ADD_OCCUPATION_SECOND_LEVEL";
@@ -32,17 +34,11 @@ export const SET_INTERNATIONAL = "SET_INTERNATIONAL";
 export const RESET = "RESET";
 export const SET_FROM_AND_SIZE = "SET_FROM_AND_SIZE";
 
-function getSort(previousSort, searchString, searchFields) {
-    if (previousSort !== "expires") {
-        if (searchFields === "occupation") {
-            return "published";
-        }
-        if (searchString) {
-            return "relevant";
-        }
-        return "";
+function getSort(previousSort, searchString) {
+    if (searchString) {
+        return "relevant";
     }
-    return previousSort;
+    return "";
 }
 
 export default function queryReducer(state, action) {
@@ -102,6 +98,21 @@ export default function queryReducer(state, action) {
             return {
                 ...queryState,
                 countries: queryState.countries.filter((obj) => obj !== action.value),
+            };
+        case ADD_OCCUPATION:
+            if (queryState.occupations.includes(action.value)) {
+                return queryState;
+            }
+            return {
+                ...queryState,
+                q: "",
+                sort: "",
+                occupations: [...queryState.occupations, action.value],
+            };
+        case REMOVE_OCCUPATION:
+            return {
+                ...queryState,
+                occupations: queryState.occupations.filter((obj) => obj !== action.value),
             };
         case ADD_OCCUPATION_FIRST_LEVEL:
             if (queryState.occupationFirstLevels.includes(action.value)) {
@@ -233,8 +244,8 @@ export default function queryReducer(state, action) {
             return {
                 ...queryState,
                 q: action.value,
-                fields: action.fields,
-                sort: getSort(queryState.sort, action.value, action.fields),
+                occupations: [],
+                sort: getSort(queryState.sort, action.value),
             };
         case SET_SORTING:
             return {

--- a/src/app/(sok)/_utils/queryReducer.js
+++ b/src/app/(sok)/_utils/queryReducer.js
@@ -107,7 +107,8 @@ export default function queryReducer(state, action) {
                 ...queryState,
                 q: "",
                 sort: "",
-                occupations: [...queryState.occupations, action.value],
+                // occupations: [...queryState.occupations, action.value],
+                occupations: [action.value],
             };
         case REMOVE_OCCUPATION:
             return {

--- a/src/app/(sok)/_utils/searchParamsVersioning.js
+++ b/src/app/(sok)/_utils/searchParamsVersioning.js
@@ -1,8 +1,9 @@
 import { migrateToV1 } from "@/app/(sok)/_utils/versioning/version01";
 import { migrateToV2 } from "@/app/(sok)/_utils/versioning/version02";
+import { migrateToV3 } from "@/app/(sok)/_utils/versioning/version03";
 
 export const VERSION_QUERY_PARAM = "v";
-export const CURRENT_VERSION = 2;
+export const CURRENT_VERSION = 3;
 const FIRST_VERSION = 0;
 
 // Returns new search params if the searchParams have been migrated.
@@ -24,6 +25,11 @@ export function migrateSearchParams(searchParams) {
     if (version < 2) {
         newSearchParams = migrateToV2(newSearchParams);
         newVersion = 2;
+    }
+
+    if (version < 3) {
+        newSearchParams = migrateToV3(newSearchParams);
+        newVersion = 3;
     }
 
     newSearchParams[VERSION_QUERY_PARAM] = newVersion;

--- a/src/app/(sok)/_utils/versioning/version03.js
+++ b/src/app/(sok)/_utils/versioning/version03.js
@@ -1,0 +1,14 @@
+export function migrateToV3(searchParams) {
+    if (searchParams.fields === "occupation") {
+        const result = {
+            ...searchParams,
+        };
+        result.occupation = searchParams.q;
+        delete result.q;
+        delete result.fields;
+
+        return result;
+    }
+
+    return searchParams;
+}

--- a/src/app/(sok)/_utils/versioning/version03.test.js
+++ b/src/app/(sok)/_utils/versioning/version03.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { migrateToV3 } from "@/app/(sok)/_utils/versioning/version03";
+
+describe("version03", () => {
+    test("Should migrate 'q' into 'occupation' if url also contains 'fields' parameter", () => {
+        const outdatedPattern = {
+            q: "Utvikler",
+            fields: "occupation",
+        };
+        const expectedResult = {
+            occupation: "Utvikler",
+        };
+        const migratedSearchParams = migrateToV3(outdatedPattern);
+        expect(migratedSearchParams).toEqual(expectedResult);
+    });
+
+    test("Should not migrate q if 'fields' parameter doesn't exist", () => {
+        const validSearchParams = {
+            q: "Utvikler",
+        };
+        const expectedResult = {
+            q: "Utvikler",
+        };
+
+        const migratedSearchParams = migrateToV3(validSearchParams);
+        expect(migratedSearchParams).toEqual(expectedResult);
+    });
+
+    test("Should not change or delete other parameters", () => {
+        const outdatedPattern = {
+            q: "Utvikler",
+            fields: "occupation",
+            validParameter: "test",
+        };
+        const expectedResult = {
+            occupation: "Utvikler",
+            validParameter: "test",
+        };
+        const migratedSearchParams = migrateToV3(outdatedPattern);
+        expect(migratedSearchParams).toEqual(expectedResult);
+    });
+});


### PR DESCRIPTION
- Gjør om slik at om man velger et yrkesforslag i søkeboksen, så filtrerer vi på dette yrket, i stedet for å utføre et tekstsøk
- Legger til rette for at man kan legge inn flere yrkesforslag senere når combobox for dette er på plass
- Legger til noen midlertidige workarounds slik at søkeboks forsetter å virke som i dag
- Migrerer gamle url-er, slik at `?q=Utvikler&fields=occupation` blir til `?occupation=Utvikler`

![Skjermbilde 2024-06-10 kl  12 22 52](https://github.com/navikt/pam-stillingsok/assets/29566394/8d3d285c-ad81-48cf-b049-283d0ed21c61)

