### PR TITLE
Update alerts

### DIFF
--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -47,7 +47,7 @@ spec:
       expr: sum(rate(elastic_search_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.5
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor pam-search-api er treg"
+        action: "Sjekk loggene for å se hvorfor søket er tregt"
       labels:
         namespace: "teampam"
         severity: critical
@@ -56,7 +56,7 @@ spec:
       expr: sum(rate(suggestion_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.2
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor pam-search-api er treg"
+        action: "Sjekk loggene for å se hvorfor søkforslag er tregt"
       labels:
         namespace: "teampam"
         severity: critical
@@ -65,7 +65,7 @@ spec:
       expr: (100 * (sum(rate(aduser_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(aduser_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor så mange kall fra pam-stillingsok til pam-aduser feiler"
+        action: "Sjekk loggene for å se hvorfor så mange kall til pam-aduser feiler"
       labels:
         namespace: "teampam"
         severity: critical
@@ -74,7 +74,7 @@ spec:
       expr: (100 * (sum(rate(elastic_search_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(elastic_search_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor så mange kall fra pam-stillingsok til elastic search feiler"
+        action: "Sjekk loggene for å se hvorfor så mange kall til elastic search feiler"
       labels:
         namespace: "teampam"
         severity: critical
@@ -83,7 +83,7 @@ spec:
       expr: (100 * (sum(rate(suggestion_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(suggestion_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor så mange kall fra pam-stillingsok til elastic search suggestions feiler"
+        action: "Sjekk loggene for å se hvorfor så mange kall til elastic search suggestions feiler"
       labels:
         namespace: "teampam"
         severity: critical

--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -17,19 +17,21 @@ spec:
       labels:
         namespace: "teampam"
         severity: warning
+
     - alert: [pam-stillingsok] Høy andel HTTP serverfeil (5xx responser)
       expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"5.*", status!~"503", namespace="teampam", service="pam-stillingsok"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="teampam", service="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor {{ $labels.service }} returnerer HTTP feilresponser"
+        action: "Sjekk loggene for å se hvorfor {{ $labels.service }} returnerer HTTP feilresponser @hubba-devs"
       labels:
         namespace: "teampam"
         severity: critical
+
     - alert: [pam-stillingsok] Høy andel HTTP serverfeil (503 responser), er søket nede eller er det bare scraping?
       expr: sum(rate(nginx_ingress_controller_requests{host="arbeidsplassen.nav.no", path="/stillinger(/.*)?", status=~"503"}[5m])) > 12
       for: 10m
       annotations:
-        action: "Sjekk loggene for å se hvorfor {{ $labels.service }} returnerer HTTP feilresponser"
+        action: "Sjekk loggene for å se hvorfor {{ $labels.service }} returnerer HTTP feilresponser @hubba-devs"
       labels:
         namespace: "teampam"
         severity: critical
@@ -41,7 +43,7 @@ spec:
         action: "Sjekk loggene for å se hvorfor søket er tregt"
       labels:
         namespace: "teampam"
-        severity: critical
+        severity: warning
 
     - alert: [pam-stillingsok] Elastic search suggestions virker treg (over 200 ms gjennomsnittlig responstid)
       expr: sum(rate(suggestion_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.2
@@ -50,13 +52,13 @@ spec:
         action: "Sjekk loggene for å se hvorfor søkforslag er tregt"
       labels:
         namespace: "teampam"
-        severity: critical
+        severity: warning
 
     - alert: [pam-stillingsok] Ingen kall til elastic search på lang tid, er søket nede?
       expr: sum(rate(elastic_search_requests{app="pam-stillingsok"}[3m])) == 0
       for: 10m
       annotations:
-        action: "Sjekk loggene for å se om det er noe feil"
+        action: "Sjekk loggene for å se om det er noe feil  @hubba-devs"
       labels:
         namespace: "teampam"
         severity: critical
@@ -65,7 +67,7 @@ spec:
       expr: (100 * (sum(rate(aduser_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(aduser_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor så mange kall til pam-aduser feiler"
+        action: "Sjekk loggene for å se hvorfor så mange kall til pam-aduser feiler @hubba-devs"
       labels:
         namespace: "teampam"
         severity: critical
@@ -74,7 +76,7 @@ spec:
       expr: (100 * (sum(rate(elastic_search_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(elastic_search_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor så mange kall til elastic search feiler"
+        action: "Sjekk loggene for å se hvorfor så mange kall til elastic search feiler @hubba-devs"
       labels:
         namespace: "teampam"
         severity: critical
@@ -83,7 +85,7 @@ spec:
       expr: (100 * (sum(rate(suggestion_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(suggestion_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor så mange kall til elastic search suggestions feiler"
+        action: "Sjekk loggene for å se hvorfor så mange kall til elastic search suggestions feiler @hubba-devs"
       labels:
         namespace: "teampam"
         severity: critical

--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -42,3 +42,48 @@ spec:
       labels:
         namespace: "teampam"
         severity: critical
+
+    - alert: Elastic search virker treg (over 500 ms gjennomsnittlig responstid)
+      expr: sum(rate(elastic_search_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.5
+      for: 3m
+      annotations:
+        action: "Sjekk loggene for å se hvorfor pam-search-api er treg"
+      labels:
+        namespace: "teampam"
+        severity: critical
+
+    - alert: Elastic search suggestions virker treg (over 200 ms gjennomsnittlig responstid)
+      expr: sum(rate(suggestion_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.2
+      for: 3m
+      annotations:
+        action: "Sjekk loggene for å se hvorfor pam-search-api er treg"
+      labels:
+        namespace: "teampam"
+        severity: critical
+
+    - alert: Kall fra pam-stillingsok til pam-aduser feiler
+      expr: (100 * (sum(rate(aduser_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(aduser_requests{app="pam-stillingsok"}[3m])))) > 1
+      for: 3m
+      annotations:
+        action: "Sjekk loggene for å se hvorfor så mange kall fra pam-stillingsok til pam-aduser feiler"
+      labels:
+        namespace: "teampam"
+        severity: critical
+
+    - alert: Kall fra pam-stillingsok til elastic search feiler
+      expr: (100 * (sum(rate(elastic_search_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(elastic_search_requests{app="pam-stillingsok"}[3m])))) > 1
+      for: 3m
+      annotations:
+        action: "Sjekk loggene for å se hvorfor så mange kall fra pam-stillingsok til elastic search feiler"
+      labels:
+        namespace: "teampam"
+        severity: critical
+
+    - alert: Kall fra pam-stillingsok til elastic search suggestions feiler
+      expr: (100 * (sum(rate(suggestion_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(suggestion_requests{app="pam-stillingsok"}[3m])))) > 1
+      for: 3m
+      annotations:
+        action: "Sjekk loggene for å se hvorfor så mange kall fra pam-stillingsok til elastic search suggestions feiler"
+      labels:
+        namespace: "teampam"
+        severity: critical

--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -9,7 +9,7 @@ spec:
   groups:
   - name: "teampam stillingsok alerts"
     rules:
-    - alert: "pam-stillingsok er nede"
+    - alert: "[pam-stillingsok] er nede"
       expr: kube_deployment_status_replicas_available{deployment="pam-stillingsok"} == 0
       for: 2m
       annotations:
@@ -18,7 +18,7 @@ spec:
       labels:
         namespace: "teampam"
         severity: critical
-    - alert: "Mye feil i loggene"
+    - alert: "[pam-stillingsok] Mye feil i loggene"
       expr: (100 * sum(rate(log_messages_errors{app="pam-stillingsok"}[3m])) / sum(rate(log_messages_total{app="pam-stillingsok"}[3m]))) > 1
       for: 3m
       annotations:
@@ -26,7 +26,7 @@ spec:
       labels:
         namespace: "teampam"
         severity: warning
-    - alert: Høy andel HTTP serverfeil (5xx responser)
+    - alert: [pam-stillingsok] Høy andel HTTP serverfeil (5xx responser)
       expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"5.*", status!~"503", namespace="teampam", service="pam-stillingsok"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="teampam", service="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
@@ -34,7 +34,7 @@ spec:
       labels:
         namespace: "teampam"
         severity: critical
-    - alert: Høy andel HTTP serverfeil (503 responser), er stillingsok nede eller er det bare scraping?
+    - alert: [pam-stillingsok] Høy andel HTTP serverfeil (503 responser), er søket nede eller er det bare scraping?
       expr: sum(rate(nginx_ingress_controller_requests{host="arbeidsplassen.nav.no", path="/stillinger(/.*)?", status=~"503"}[5m])) > 12
       for: 10m
       annotations:
@@ -43,7 +43,7 @@ spec:
         namespace: "teampam"
         severity: critical
 
-    - alert: Elastic search virker treg (over 500 ms gjennomsnittlig responstid)
+    - alert: [pam-stillingsok] Elastic search virker treg (over 500 ms gjennomsnittlig responstid)
       expr: sum(rate(elastic_search_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.5
       for: 3m
       annotations:
@@ -52,7 +52,7 @@ spec:
         namespace: "teampam"
         severity: critical
 
-    - alert: Elastic search suggestions virker treg (over 200 ms gjennomsnittlig responstid)
+    - alert: [pam-stillingsok] Elastic search suggestions virker treg (over 200 ms gjennomsnittlig responstid)
       expr: sum(rate(suggestion_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.2
       for: 3m
       annotations:
@@ -61,7 +61,7 @@ spec:
         namespace: "teampam"
         severity: critical
 
-    - alert: Kall fra pam-stillingsok til pam-aduser feiler
+    - alert: [pam-stillingsok] Kall til pam-aduser feiler
       expr: (100 * (sum(rate(aduser_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(aduser_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
@@ -70,7 +70,7 @@ spec:
         namespace: "teampam"
         severity: critical
 
-    - alert: Kall fra pam-stillingsok til elastic search feiler
+    - alert: [pam-stillingsok] Kall til elastic search feiler
       expr: (100 * (sum(rate(elastic_search_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(elastic_search_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:
@@ -79,7 +79,7 @@ spec:
         namespace: "teampam"
         severity: critical
 
-    - alert: Kall fra pam-stillingsok til elastic search suggestions feiler
+    - alert: [pam-stillingsok] Kall til elastic search suggestions feiler
       expr: (100 * (sum(rate(suggestion_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(suggestion_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m
       annotations:

--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -42,11 +42,3 @@ spec:
       labels:
         namespace: "teampam"
         severity: critical
-    - alert: Høy andel HTTP klientfeil (4xx responser)
-      expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"4.*", status!~"404", namespace="teampam", service="pam-stillingsok"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="teampam", service="pam-stillingsok"}[3m])))) > 25
-      for: 3m
-      annotations:
-        action: "Sjekk loggene for å se hvorfor {{ $labels.service }} returnerer HTTP feilresponser"
-      labels:
-        namespace: "teampam"
-        severity: warning

--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -34,9 +34,9 @@ spec:
       labels:
         namespace: "teampam"
         severity: critical
-    - alert: Høy andel HTTP serverfeil (503 responser), er stillingsok nede?
+    - alert: Høy andel HTTP serverfeil (503 responser), er stillingsok nede eller er det bare scraping?
       expr: sum(rate(nginx_ingress_controller_requests{host="arbeidsplassen.nav.no", path="/stillinger(/.*)?", status=~"503"}[5m])) > 12
-      for: 3m
+      for: 10m
       annotations:
         action: "Sjekk loggene for å se hvorfor {{ $labels.service }} returnerer HTTP feilresponser"
       labels:

--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -9,15 +9,6 @@ spec:
   groups:
   - name: "teampam stillingsok alerts"
     rules:
-    - alert: "[pam-stillingsok] er nede"
-      expr: kube_deployment_status_replicas_available{deployment="pam-stillingsok"} == 0
-      for: 2m
-      annotations:
-        consequence: "App {{ $labels.deployment }} er nede i namespace {{ $labels.namespace }}"
-        action: "kubectl describe pod {{ $labels.deployment }} -n {{ $labels.namespace }}` for events, og `kubectl logs {{ $labels.deployment }} -n {{ $labels.namespace }}` for logger"
-      labels:
-        namespace: "teampam"
-        severity: critical
     - alert: "[pam-stillingsok] Mye feil i loggene"
       expr: (100 * sum(rate(log_messages_errors{app="pam-stillingsok"}[3m])) / sum(rate(log_messages_total{app="pam-stillingsok"}[3m]))) > 1
       for: 3m

--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -61,6 +61,15 @@ spec:
         namespace: "teampam"
         severity: critical
 
+    - alert: [pam-stillingsok] Ingen kall til elastic search på lang tid, er søket nede?
+      expr: sum(rate(elastic_search_requests{app="pam-stillingsok"}[3m])) == 0
+      for: 10m
+      annotations:
+        action: "Sjekk loggene for å se om det er noe feil"
+      labels:
+        namespace: "teampam"
+        severity: critical
+
     - alert: [pam-stillingsok] Kall til pam-aduser feiler
       expr: (100 * (sum(rate(aduser_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(aduser_requests{app="pam-stillingsok"}[3m])))) > 1
       for: 3m


### PR DESCRIPTION
* Remove old 4xx alert warning - most of them are false positives coming from 401 responses when checking if a user is logged in
* Add new alerts
  * No search for 10 minutes
  * Failing requests to elastic search for search and suggestions
  * Slow responses from elastic search for search and suggestions
  * Failing requests to pam-aduser
* Prefix alerts to easier identify application in alerts channel