### PR TITLE
Disable prefetching on some links

### DIFF
--- a/src/app/(sok)/_components/searchResult/SearchResultItem.jsx
+++ b/src/app/(sok)/_components/searchResult/SearchResultItem.jsx
@@ -122,7 +122,7 @@ SearchResultItem.propTypes = {
 
 function LinkToAd({ children, stilling }) {
     return (
-        <AkselLink className="purple-when-visited" as={Link} href={`/stilling/${stilling.uuid}`}>
+        <AkselLink className="purple-when-visited" as={Link} href={`/stilling/${stilling.uuid}`} prefetch={false}>
             {children}
         </AkselLink>
     );

--- a/src/app/lagrede-sok/_components/SavedSearchListItem.jsx
+++ b/src/app/lagrede-sok/_components/SavedSearchListItem.jsx
@@ -76,7 +76,7 @@ function SavedSearchListItem({
     return (
         <article>
             <Heading level="2" size="small" spacing>
-                <AkselLink as={Link} href={`/${savedSearch.searchQuery}&saved=${savedSearch.uuid}`}>
+                <AkselLink as={Link} href={`/${savedSearch.searchQuery}&saved=${savedSearch.uuid}`} prefetch={false}>
                     {savedSearch.title}
                 </AkselLink>
             </Heading>

--- a/src/app/stilling/[id]/_components/AdDetails.jsx
+++ b/src/app/stilling/[id]/_components/AdDetails.jsx
@@ -24,6 +24,7 @@ export default function AdDetails({ adData }) {
                     href={`/rapporter-annonse/${adData.id}`}
                     variant="tertiary"
                     icon={<ExclamationmarkTriangleIcon aria-hidden />}
+                    prefetch={false}
                 >
                     Rapporter annonse
                 </Button>

--- a/src/app/stilling/[id]/_components/HowToApply.jsx
+++ b/src/app/stilling/[id]/_components/HowToApply.jsx
@@ -84,6 +84,7 @@ export default function HowToApply({ adData }) {
                                     });
                                 }}
                                 href={`/${path}/${adData.id}/superrask-soknad`}
+                                prefetch={false}
                             >
                                 Gå til superrask søknad
                             </Button>


### PR DESCRIPTION
Disable prefetch on pages that makes a lot of requests and/or links that are not heavily clicked.

* Search results (or it will load each ad just by scrolling the page, which means 25 or 100 requests per page)
* Saved searches
* Favorites
* Report ad button
* Superrask søknad button