### PR TITLE
query with sizes larger than 10000 will not be sent to pam-search-api

### DIFF
--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -77,10 +77,7 @@ export default async function Page({ searchParams }) {
         if (Number(searchParams.from) + Number(size) > MAX_QUERY_SIZE) {
             return (
                 <VStack align="center">
-                    <MaxQuerySizeExceeded
-                        title="Du har nådd maks antall annonser for ditt søk"
-                        text="Utvid søket ditt ved å prøve andre filtre eller søkeord for å oppdage flere annonser."
-                    />
+                    <MaxQuerySizeExceeded />
                     <Button variant="primary" as={Link} role="link" href="/">
                         Gå til søket
                     </Button>

--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -12,7 +12,10 @@ import { fetchCachedElasticSearch } from "@/app/(sok)/_utils/fetchCachedElasticS
 import * as actions from "@/app/_common/actions";
 import { redirect } from "next/navigation";
 import { migrateSearchParams } from "@/app/(sok)/_utils/searchParamsVersioning";
-import NotFoundPage from "@/app/_common/components/NotFoundPage";
+import { Button, VStack } from "@navikt/ds-react";
+import Link from "next/link";
+import React from "react";
+import MaxQuerySizeExceeded from "@/app/_common/components/MaxQuerySizeExceeded";
 
 const MAX_QUERY_SIZE = 10000;
 
@@ -73,10 +76,15 @@ export default async function Page({ searchParams }) {
         const size = searchParams.size ? searchParams.size : 25;
         if (Number(searchParams.from) + Number(size) > MAX_QUERY_SIZE) {
             return (
-                <NotFoundPage
-                    title="Du har nådd maks antall annonser for ditt søk"
-                    text="Utvid søket ditt ved å prøve andre filtre eller søkeord for å oppdage flere annonser."
-                />
+                <VStack align="center">
+                    <MaxQuerySizeExceeded
+                        title="Du har nådd maks antall annonser for ditt søk"
+                        text="Utvid søket ditt ved å prøve andre filtre eller søkeord for å oppdage flere annonser."
+                    />
+                    <Button variant="primary" as={Link} role="link" href="/">
+                        Gå til søket
+                    </Button>
+                </VStack>
             );
         }
     }

--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -12,6 +12,9 @@ import { fetchCachedElasticSearch } from "@/app/(sok)/_utils/fetchCachedElasticS
 import * as actions from "@/app/_common/actions";
 import { redirect } from "next/navigation";
 import { migrateSearchParams } from "@/app/(sok)/_utils/searchParamsVersioning";
+import NotFoundPage from "@/app/_common/components/NotFoundPage";
+
+const MAX_QUERY_SIZE = 10000;
 
 export async function generateMetadata({ searchParams }) {
     const query = createQuery(searchParams);
@@ -66,6 +69,17 @@ async function fetchLocations() {
 }
 
 export default async function Page({ searchParams }) {
+    if (searchParams.from) {
+        const size = searchParams.size ? searchParams.size : 25;
+        if (Number(searchParams.from) + Number(size) > MAX_QUERY_SIZE) {
+            return (
+                <NotFoundPage
+                    title="Du har nådd maks antall annonser for ditt søk"
+                    text="Utvid søket ditt ved å prøve andre filtre eller søkeord for å oppdage flere annonser."
+                />
+            );
+        }
+    }
     const newSearchParams = migrateSearchParams(searchParams);
 
     if (newSearchParams !== undefined) {

--- a/src/app/_common/components/MaxQuerySizeExceeded.jsx
+++ b/src/app/_common/components/MaxQuerySizeExceeded.jsx
@@ -1,18 +1,15 @@
 "use client";
 
 import React from "react";
-import PropTypes from "prop-types";
 import { NotFound } from "@navikt/arbeidsplassen-react";
 
-export default function MaxQuerySizeExceeded({ title, text }) {
+export default function MaxQuerySizeExceeded() {
     return (
         <div className="container-large mt-12 mb-12">
-            <NotFound title={title} text={text} />
+            <NotFound
+                title="Du har nådd maks antall annonser for ditt søk"
+                text="Utvid søket ditt ved å prøve andre filtre eller søkeord for å oppdage flere annonser."
+            />
         </div>
     );
 }
-
-MaxQuerySizeExceeded.propTypes = {
-    title: PropTypes.string,
-    text: PropTypes.string,
-};

--- a/src/app/_common/components/MaxQuerySizeExceeded.jsx
+++ b/src/app/_common/components/MaxQuerySizeExceeded.jsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+import PropTypes from "prop-types";
+import { NotFound } from "@navikt/arbeidsplassen-react";
+
+export default function MaxQuerySizeExceeded({ title, text }) {
+    return (
+        <div className="container-large mt-12 mb-12">
+            <NotFound title={title} text={text} />
+        </div>
+    );
+}
+
+MaxQuerySizeExceeded.propTypes = {
+    title: PropTypes.string,
+    text: PropTypes.string,
+};


### PR DESCRIPTION
query with sizes larger than 10000 will not be sent to pam-search-api as elastic search can't handle it