### PR TITLE
Har lagt til timeout ved kall mot pam-search-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,25 +32,6 @@ Mer informasjon om autentisering: https://docs.github.com/en/packages/working-wi
 
 ### Wonderwall
 
-[Wonderwall](https://github.com/nais/wonderwall) brukes for å håndtere login med ID-porten.
-Lokalt brukes også wonderwall, men her kjører vi mot en OIDC-provider i Docker.
-
-#### Go
-
-Go er nødvendig for å bygge wonderwall binaries. Wonderwall brukes for lokal OIDC-flyt.
-
-```shell
-brew install go
-```
-
-Installer Wonderwall:
-
-```shell
-make install
-```
-
-Når applikasjonen er oppe, så kan du gå inn på [http://localhost:3000/stillinger](http://localhost:3000/stillinger)
-
 > [!TIP]
 > Gå igjennom login-flyten ved å trykke login. Bruk testbruker `04010100653`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   default:
     name: pam-shared-network

--- a/src/app/api/search/route.js
+++ b/src/app/api/search/route.js
@@ -2,6 +2,8 @@ import elasticSearchRequestBody from "@/app/(sok)/_utils/elasticSearchRequestBod
 import { createQuery, toApiQuery } from "@/app/(sok)/_utils/query";
 import { getDefaultHeaders } from "@/app/_common/utils/fetch";
 import { migrateSearchParams } from "@/app/(sok)/_utils/searchParamsVersioning";
+import { NextResponse } from "next/server";
+import logger from "@/app/_common/utils/logger";
 
 export const dynamic = "force-dynamic";
 
@@ -30,16 +32,29 @@ export async function GET(request) {
     const migratedSearchParams = migrateSearchParams(searchParams);
     const query = createQuery(migratedSearchParams || searchParams);
     const body = elasticSearchRequestBody(toApiQuery(query));
-    const res = await fetch(`${process.env.PAMSEARCHAPI_URL}/stillingsok/ad/_search`, {
-        method: "POST",
-        headers: getDefaultHeaders(),
-        body: JSON.stringify(body),
-    });
 
-    if (!res.ok) {
-        Response.error();
+    try {
+        const res = await fetch(`${process.env.PAMSEARCHAPI_URL}/stillingsok/ad/_search`, {
+            method: "POST",
+            headers: getDefaultHeaders(),
+            body: JSON.stringify(body),
+            signal: AbortSignal.timeout(55 * 1000),
+        });
+
+        if (!res.ok) {
+            const msg = `Kallet returnerte en feilkode, sender tilbake den samme feilkoden: ${res.status}`;
+            logger.warn(msg);
+            return new NextResponse(null, { status: res.status });
+        }
+
+        const data = await res.json();
+        return new NextResponse(JSON.stringify(data), { status: res.status });
+    } catch (error) {
+        if (error.name === "TimeoutError") {
+            logger.warn("Det tok for lang tid å vente på svar, avbryter:", error);
+            return new NextResponse(null, { status: 408 });
+        }
+        logger.error(`Uventet feil oppstod:'`, error);
+        return new NextResponse(null, { status: 500 });
     }
-
-    const data = await res.json();
-    return Response.json(data);
 }


### PR DESCRIPTION
Tidligere ventet den evig, noe som skaper problemer for `pam-aduser`. `pam-aduser` sin timeout er kun på 60 sekunder, og dermed er det viktig at `pam-stillingsok` har en kortere timeout-verdie enn dette. Slik at vi vet at `pam-stillingsok` kan gjøre seg ferdig før `pam-aduser` må avslutte.

*PS*
På sikt hadde det kanskje vært like greit om `pam-aduser` kaller `pam-search-api` direkte? Jeg klarer ikke å se helt hvorfor det er behov for å gå via `pam-stillingsok`.