### PR TITLE
Sørger for at korrekt contenttype blir satt

### DIFF
--- a/src/app/api/search/route.js
+++ b/src/app/api/search/route.js
@@ -48,7 +48,7 @@ export async function GET(request) {
         }
 
         const data = await res.json();
-        return new NextResponse(JSON.stringify(data), { status: res.status });
+        return Response.json(data);
     } catch (error) {
         if (error.name === "TimeoutError") {
             logger.warn("Det tok for lang tid å vente på svar, avbryter:", error);


### PR DESCRIPTION
`pam-aduser` forventer at content-type-en er `application/json`, og ikke `text/plain;charset=UTF-8`. Dette blir satt korrekt av `Response.json(data)`, det er slik koden var før jeg innførte denne buggen i https://github.com/navikt/pam-stillingsok/pull/754.

Http-statuskoden er uansett OK/200 hvis koden kommer til denne linja, så derfor er det ikke behov for å spesifisere det igjen.

Har verifisert at content-type-en blir riktig ved bruk av Postman.