### PR TITLE
Legger til debug panel for annonse-kategorier

### DIFF
--- a/src/app/stilling/[id]/_components/Ad.jsx
+++ b/src/app/stilling/[id]/_components/Ad.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 
 import { Box, Heading, Tag } from "@navikt/ds-react";
 import { logStillingVisning } from "@/app/_common/monitoring/amplitude";
+import DebugAd from "@/app/stilling/[id]/_components/DebugAd";
 import AdDetails from "./AdDetails";
 import AdText from "./AdText";
 import ContactPerson from "./ContactPerson";
@@ -54,6 +55,8 @@ function Ad({ adData, organizationNumber }) {
                 <EmployerDetails employer={adData.employer} />
                 {annonseErAktiv && <ShareAd adData={adData} />}
                 <AdDetails adData={adData} />
+
+                <DebugAd adData={adData} />
             </Box>
         </Box>
     );

--- a/src/app/stilling/[id]/_components/DebugAd.jsx
+++ b/src/app/stilling/[id]/_components/DebugAd.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { BodyLong, Box, Heading, HStack, Tag, VStack } from "@navikt/ds-react";
+import { labelForNeedDriversLicense } from "@/app/(sok)/_components/filters/DriversLicense";
+import { labelForExperience } from "@/app/(sok)/_components/filters/Experience";
+import { labelForEducation } from "@/app/(sok)/_components/filters/Education";
+import { ThumbDownIcon, ThumbUpIcon } from "@navikt/aksel-icons";
+import logAmplitudeEvent from "@/app/_common/monitoring/amplitude";
+
+function vote(category, value, reason, adUuid) {
+    logAmplitudeEvent("Report AI category", { category, value, reason, adUuid });
+}
+
+function DebugAdItem({ category, value, adUuid }) {
+    const [hasVoted, setHasVoted] = useState(false);
+
+    return (
+        <Tag variant="neutral-moderate">
+            <HStack align="center" gap="4">
+                {value}
+                <HStack gap="2">
+                    {!hasVoted && (
+                        <>
+                            <ThumbUpIcon
+                                title="Stem opp"
+                                fontSize="1.25rem"
+                                onClick={() => {
+                                    setHasVoted(true);
+                                    vote(category, value, "Vote up", adUuid);
+                                }}
+                            />
+                            <ThumbDownIcon
+                                title="Stem ned"
+                                fontSize="1.25rem"
+                                onClick={() => {
+                                    setHasVoted(true);
+                                    vote(category, value, "Vote down", adUuid);
+                                }}
+                            />
+                        </>
+                    )}
+                </HStack>
+            </HStack>
+        </Tag>
+    );
+}
+
+function DebugAdGroup({ category, values, adUuid }) {
+    if (!values) {
+        return null;
+    }
+
+    return (
+        <div>
+            <Heading size="xsmall" level="3" spacing>
+                {category}
+            </Heading>
+            <HStack gap="4">
+                {values.map((value) => (
+                    <DebugAdItem key={value} category={category} value={value} adUuid={adUuid} />
+                ))}
+            </HStack>
+        </div>
+    );
+}
+
+export default function DebugAd({ adData }) {
+    const [showDebugPanel, setShowDebugPanel] = useState(false);
+
+    useEffect(() => {
+        try {
+            const valueFromLocalStorage = localStorage.getItem("isDebug");
+            if (valueFromLocalStorage && valueFromLocalStorage === "true") {
+                setShowDebugPanel(true);
+            }
+        } catch (err) {
+            // ignore
+        }
+    }, []);
+
+    if (!showDebugPanel) {
+        return null;
+    }
+
+    return (
+        <Box className="full-width mt-16">
+            <Heading level="2" size="large" spacing>
+                Har annonsen kommet i feil kategori?
+            </Heading>
+            <BodyLong spacing>Gi en tommel ned på de kategoriene som ikke stemmer.</BodyLong>
+            <VStack gap="6">
+                <DebugAdGroup
+                    adUuid={adData.id}
+                    category="Yrke"
+                    values={adData.categoryList?.map(
+                        (category) => `${category.name} (${category.categoryType.toLowerCase()})`,
+                    )}
+                />
+                <DebugAdGroup
+                    adUuid={adData.id}
+                    category="Lignende yrker"
+                    values={adData?.searchtags?.map((tag) => tag.label)}
+                />
+                <DebugAdGroup
+                    adUuid={adData.id}
+                    category="Erfaring"
+                    values={adData?.experience?.map((experience) => labelForExperience(experience))}
+                />
+                <DebugAdGroup
+                    adUuid={adData.id}
+                    category="Utdanning"
+                    values={adData?.education?.map((education) => labelForEducation(education))}
+                />
+                <DebugAdGroup
+                    adUuid={adData.id}
+                    category="Førerkort"
+                    values={adData?.needDriversLicense?.map((item) => labelForNeedDriversLicense(item))}
+                />
+            </VStack>
+        </Box>
+    );
+}
+
+DebugAd.propTypes = {
+    adData: PropTypes.shape({
+        id: PropTypes.string,
+        title: PropTypes.string,
+    }).isRequired,
+};

--- a/src/app/stilling/[id]/_components/DebugAd.jsx
+++ b/src/app/stilling/[id]/_components/DebugAd.jsx
@@ -87,7 +87,10 @@ export default function DebugAd({ adData }) {
             <Heading level="2" size="large" spacing>
                 Har annonsen kommet i feil kategori?
             </Heading>
-            <BodyLong spacing>Gi en tommel ned på de kategoriene som ikke stemmer.</BodyLong>
+            <BodyLong spacing>
+                Gi en tommel opp eller ned så får vi oversikt over hvor stor andel som stemmer, og så kan vi se detaljer
+                om de som har kommet i feil kategori.
+            </BodyLong>
             <VStack gap="6">
                 <DebugAdGroup
                     adUuid={adData.id}

--- a/src/app/stilling/_data/adData.js
+++ b/src/app/stilling/_data/adData.js
@@ -279,5 +279,12 @@ export default function mapAdData(rawElasticSearchAdResult) {
         // Employer
         employer: getEmployerData(data),
         contactList: getContactList(data.contactList),
+
+        // For debugging
+        categoryList: getArray(data.categoryList),
+        searchtags: getArray(properties.searchtags),
+        education: getArray(properties.education),
+        experience: getArray(properties.experience),
+        needDriversLicense: getArray(properties.needDriversLicense),
     });
 }

--- a/src/app/stilling/_data/adDataActions.jsx
+++ b/src/app/stilling/_data/adDataActions.jsx
@@ -63,6 +63,11 @@ const sourceIncludes = [
     "status",
     "title",
     "updated",
+    "categoryList", // For debugging
+    "properties.searchtags", // For debugging
+    "properties.needDriversLicense", // For debugging
+    "properties.education", // For debugging
+    "properties.experience", // For debugging
 ].join(",");
 
 /**


### PR DESCRIPTION
- Et panel som vises på bunn av alle annonser
- Det er bare ment for internt bruk. Må aktiveres med en `isDebug=true` value satt i localStorage
- Kategorier som ikke stemmer gir vi tommel ned
- Kategorier som stemmer gir vi tommel opp - da får se hvor stor andel av kategoriseringen som stemmer
- Måling kommer i amplitude. Sender også med ad id slik at man kan gå inn på hver enkelt om det er behov


![Skjermbilde 2024-09-03 kl  12 13 09](https://github.com/user-attachments/assets/baa23481-7f15-4778-a22e-e8ec856c5895)
