### PR TITLE
Log driving distance to Amplitude

### DIFF
--- a/src/app/(sok)/_components/filters/DrivingDistance.tsx
+++ b/src/app/(sok)/_components/filters/DrivingDistance.tsx
@@ -5,6 +5,7 @@ import { TrashIcon } from "@navikt/aksel-icons";
 import { Postcode } from "@/app/(sok)/_utils/fetchPostcodes";
 import { ComboboxOption } from "@navikt/ds-react/esm/form/combobox/types";
 import "./DrivingDistance.css";
+import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 
 // TODO: Replace when TS query interface has been merged
 interface DrivingDistanceQueryProps {
@@ -90,14 +91,27 @@ function DrivingDistance({ query, dispatch, postcodes }: DrivingDistanceProps): 
         } else {
             dispatch({ type: REMOVE_POSTCODE });
         }
+        logFilterChanged({
+            name: "reisevei",
+            value: option || (selectedPostcode[0] as ComboboxOption).value,
+            level: "postkod",
+            checked: isSelected && !!query.distance,
+        });
     }
 
-    function handleDistanceChange(value: string | null) {
-        if (value === null || value === undefined || value === "") {
+    function handleDistanceChange(value: string | undefined) {
+        const hasNoValue = value === undefined || value === "";
+        if (hasNoValue) {
             dispatch({ type: REMOVE_DISTANCE });
         } else {
             dispatch({ type: ADD_DISTANCE, value });
         }
+        logFilterChanged({
+            name: "reisevei",
+            value: value || query.distance,
+            level: "avstand",
+            checked: !hasNoValue && selectedPostcode.length > 0,
+        });
     }
 
     function resetDistanceFilters() {

--- a/src/app/(sok)/_components/filters/DrivingDistance.tsx
+++ b/src/app/(sok)/_components/filters/DrivingDistance.tsx
@@ -94,7 +94,7 @@ function DrivingDistance({ query, dispatch, postcodes }: DrivingDistanceProps): 
         logFilterChanged({
             name: "reisevei",
             value: option || (selectedPostcode[0] as ComboboxOption).value,
-            level: "postkod",
+            level: "postnummer",
             checked: isSelected && !!query.distance,
         });
     }


### PR DESCRIPTION
Checked is only set if both postcode _and_ distance are set, since they're both needed for the filter to be active.