### PR TITLE
Rollback history push since it throws an error

### DIFF
--- a/src/app/(sok)/_components/searchResult/SearchResultItem.jsx
+++ b/src/app/(sok)/_components/searchResult/SearchResultItem.jsx
@@ -122,21 +122,7 @@ SearchResultItem.propTypes = {
 
 function LinkToAd({ children, stilling }) {
     return (
-        <AkselLink
-            onClick={() => {
-                if (typeof window !== "undefined") {
-                    window.history.push("/stillinger", {
-                        state: {
-                            history: [window.location.href],
-                        },
-                    });
-                }
-            }}
-            className="purple-when-visited"
-            as={Link}
-            href={`/stilling/${stilling.uuid}`}
-            prefetch={false}
-        >
+        <AkselLink className="purple-when-visited" as={Link} href={`/stilling/${stilling.uuid}`} prefetch={false}>
             {children}
         </AkselLink>
     );


### PR DESCRIPTION
Ønsker å rulle tilbake denne commiten, fordi det den gir feil.

`onClick` ble lagt til her for å fikse issuet på iphone der man gikk inn på en stillingsannonse, og deretter trykket tilbakeknapp i nettleser, så hoppet man over stillingsøk-siden og kom helt tilbake til forsiden på arbeidsplassen (eller den siden du var inne på før du gikk til stillingsøket).

Men denne koden gir en feil: 
`TypeError: window.history.push is not a function`

Jeg forsøkte å endre til window.history.pushState, men da får jeg en annen feil:
`TypeError: Cannot create property '__NA' on string '/stillinger'`

Kanskje denne bare ble prodsatt slik av vi kunne teste i prod på en iphone og se om issuet ble fikset?

Jeg har en hypotse om at det ikke er lenken eller history som er feil, men at det skjer en eller annen feil på stillingsøket.
- Jeg ble vist en gang før sommeren at dette issuet ikke oppsto hver gang, da kom an på hva man valgte i stillingsøket først.
- Hva skjer med andre lenker på iphone, f.eks om man går inn på superrask søknad fra en annonse og trykker tilbake, hopper den til feil side da?


