### PR TITLE
Feature/combobox sort by relevant by default

### DIFF
--- a/src/app/(sok)/_components/searchResult/Sorting.jsx
+++ b/src/app/(sok)/_components/searchResult/Sorting.jsx
@@ -3,28 +3,34 @@ import PropTypes from "prop-types";
 import { Select } from "@navikt/ds-react";
 import { SET_SORTING } from "@/app/(sok)/_utils/queryReducer";
 
+export const SortByValues = {
+    RELEVANT: "relevant",
+    PUBLISHED: "published",
+    EXPIRES: "expires",
+};
+
+const DEFAULT_SORT = SortByValues.RELEVANT;
+
 function Sorting({ query, dispatch }) {
     function handleChange(e) {
         const { value } = e.target;
-        dispatch({ type: SET_SORTING, value });
+        if (value === DEFAULT_SORT) {
+            dispatch({ type: SET_SORTING, value: undefined });
+        } else {
+            dispatch({ type: SET_SORTING, value });
+        }
     }
 
     return (
         <Select
             onChange={handleChange}
-            value={query.sort || "relevant"}
+            value={query.sort || SortByValues.RELEVANT}
             label="Sorter etter"
             className="inline-select hide-label-sm"
         >
-            <option key="relevant" value="relevant">
-                Mest relevant
-            </option>
-            <option key="published" value="published">
-                Nyeste øverst
-            </option>
-            <option key="expires" value="expires">
-                Søknadsfrist
-            </option>
+            <option value={SortByValues.RELEVANT}>Mest relevant</option>
+            <option value={SortByValues.PUBLISHED}>Nyeste øverst</option>
+            <option value={SortByValues.EXPIRES}>Søknadsfrist</option>
         </Select>
     );
 }

--- a/src/app/(sok)/_components/searchResult/Sorting.jsx
+++ b/src/app/(sok)/_components/searchResult/Sorting.jsx
@@ -12,15 +12,15 @@ function Sorting({ query, dispatch }) {
     return (
         <Select
             onChange={handleChange}
-            value={query.sort || "published"}
+            value={query.sort || "relevant"}
             label="Sorter etter"
             className="inline-select hide-label-sm"
         >
-            <option key="published" value="published">
-                Nyeste øverst
-            </option>
             <option key="relevant" value="relevant">
                 Mest relevant
+            </option>
+            <option key="published" value="published">
+                Nyeste øverst
             </option>
             <option key="expires" value="expires">
                 Søknadsfrist

--- a/src/app/(sok)/_utils/queryReducer.js
+++ b/src/app/(sok)/_utils/queryReducer.js
@@ -41,13 +41,6 @@ export const SET_INTERNATIONAL = "SET_INTERNATIONAL";
 export const RESET = "RESET";
 export const SET_FROM_AND_SIZE = "SET_FROM_AND_SIZE";
 
-function getSort(previousSort, searchString) {
-    if (searchString) {
-        return "relevant";
-    }
-    return "";
-}
-
 export default function queryReducer(state, action) {
     // Reset pagination when user add or remove a search criteria
     const queryState = {
@@ -282,7 +275,6 @@ export default function queryReducer(state, action) {
             return {
                 ...queryState,
                 q: [...queryState.q, action.value],
-                sort: getSort(queryState.sort, action.value),
             };
         case REMOVE_SEARCH_STRING:
             return {


### PR DESCRIPTION
- Ender slik at sortering av treff by default er sortert på Mest relevant

Etter at vi gjorde om søk på occupation fra fritekst til filter, så fungerer det nå å ha mest relevant som default sortering. Om man søker med fritekst vil alle treff ha score 1, og sorteringen for mest relevant sorterer da disse etter dato dato. Legger vi inn søkeord, sorteres de etter score. Så mest relevant fungerer for de fleste som default