### PR TITLE
Reduce JS bundle size

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@navikt/arbeidsplassen-react';

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-declare module '@navikt/arbeidsplassen-react';
+declare module "@navikt/arbeidsplassen-react";

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-    enabled: process.env.ANALYZE === 'true',
-})
+const withBundleAnalyzer = require("@next/bundle-analyzer")({
+    enabled: process.env.ANALYZE === "true",
+});
 
 const nextConfig = withBundleAnalyzer({
     basePath: "/stillinger",

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 const nextConfig = withBundleAnalyzer({
     basePath: "/stillinger",
     cacheHandler: process.env.NODE_ENV === "production" ? require.resolve("./cache-handler.mjs") : undefined,
+    transpilePackages: ["@navikt/arbeidsplassen-react"],
     experimental: {
         optimizePackageImports: ["@navikt/ds-react", "@navikt/aksel-icons"],
         instrumentationHook: true,

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+    enabled: process.env.ANALYZE === 'true',
+})
+
+const nextConfig = withBundleAnalyzer({
     basePath: "/stillinger",
     cacheHandler: process.env.NODE_ENV === "production" ? require.resolve("./cache-handler.mjs") : undefined,
     experimental: {
@@ -14,7 +18,7 @@ const nextConfig = {
     env: {
         STILLINGSREGISTRERING_PATH: "/stillingsregistrering",
     },
-};
+});
 
 const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 const { withSentryConfig } = require("@sentry/nextjs");

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@axe-core/react": "^4.9.1",
                 "@navikt/aksel-icons": "^6.16.3",
                 "@navikt/arbeidsplassen-css": "^8.2.17",
-                "@navikt/arbeidsplassen-react": "^8.2.17",
+                "@navikt/arbeidsplassen-react": "^8.3.0",
                 "@navikt/arbeidsplassen-theme": "^6.0.7",
                 "@navikt/ds-css": "^6.16.3",
                 "@navikt/ds-react": "^6.16.3",
@@ -1304,9 +1304,10 @@
             "integrity": "sha512-tPpR7SrHgbfjnDz2R64oMxN6ujggzfuucTMsTDPuuCE+VaOELH6kPXFJCSJ87BVhDJnDk3Rs/3PyI700F0J2Ew=="
         },
         "node_modules/@navikt/arbeidsplassen-react": {
-            "version": "8.2.17",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidsplassen-react/8.2.17/a9d0464a7584e523b5215f62c75c33c53fb70a51",
-            "integrity": "sha512-6TVAQQX9Yom8BcMLGUnGG/SDLQrftJ7bz6ol3evxxjh7SiAWYCtiDEAKb5JMnaY+HW0flCmO5JEQpFi48uzNaQ==",
+            "version": "8.3.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidsplassen-react/8.3.0/0318d6476799d05703fbf877f502e407f8641420",
+            "integrity": "sha512-MZ9Nn45MYq+QLfB3B1x7L5iK59wd/zIOG9jlMyObY69BewuqkUqZDR1V8zKqZjJV63T5CmbvFlgx70X0EGMcDw==",
+            "license": "ISC",
             "dependencies": {
                 "@babel/polyfill": "^7.12.1"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@axe-core/react": "^4.9.1",
                 "@navikt/aksel-icons": "^6.16.3",
                 "@navikt/arbeidsplassen-css": "^8.2.17",
-                "@navikt/arbeidsplassen-react": "^8.3.0",
+                "@navikt/arbeidsplassen-react": "^8.3.1",
                 "@navikt/arbeidsplassen-theme": "^6.0.7",
                 "@navikt/ds-css": "^6.16.3",
                 "@navikt/ds-react": "^6.16.3",
@@ -41,6 +41,8 @@
                 "@testing-library/jest-dom": "^6.4.2",
                 "@testing-library/react": "^14.2.2",
                 "@types/node": "20.12.12",
+                "@types/react": "^18.2.0",
+                "@types/react-dom": "^18.2.0",
                 "@types/testing-library__jest-dom": "^6.0.0",
                 "@types/testing-library__react": "^10.2.0",
                 "@typescript-eslint/eslint-plugin": "^7.14.1",
@@ -65,6 +67,7 @@
                 "prettier": "^3.2.5",
                 "stylelint": "^16.5.0",
                 "stylelint-config-recommended": "^14.0.0",
+                "typescript": "^4.9.5",
                 "vitest": "^1.6.0"
             }
         },
@@ -1314,9 +1317,9 @@
             "integrity": "sha512-tPpR7SrHgbfjnDz2R64oMxN6ujggzfuucTMsTDPuuCE+VaOELH6kPXFJCSJ87BVhDJnDk3Rs/3PyI700F0J2Ew=="
         },
         "node_modules/@navikt/arbeidsplassen-react": {
-            "version": "8.3.0",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidsplassen-react/8.3.0/0318d6476799d05703fbf877f502e407f8641420",
-            "integrity": "sha512-MZ9Nn45MYq+QLfB3B1x7L5iK59wd/zIOG9jlMyObY69BewuqkUqZDR1V8zKqZjJV63T5CmbvFlgx70X0EGMcDw==",
+            "version": "8.3.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidsplassen-react/8.3.1/043bb6451aeff52903d1cd1cbf967b74a70edd01",
+            "integrity": "sha512-95T5hFa2q6xbnHC9fKuAsKFH6Cu09j8LwMf6j64RVFl973cveeYyAJvrwzVW+W1HJKH+Wp34S9Dk2f2z3dCdPw==",
             "license": "ISC",
             "dependencies": {
                 "@babel/polyfill": "^7.12.1"
@@ -9947,17 +9950,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-            "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=14.17"
+                "node": ">=4.2.0"
             }
         },
         "node_modules/ufo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "winston": "^3.13.0"
             },
             "devDependencies": {
+                "@next/bundle-analyzer": "^14.2.13",
                 "@next/eslint-plugin-next": "^14.2.1",
                 "@testing-library/jest-dom": "^6.4.2",
                 "@testing-library/react": "^14.2.2",
@@ -657,6 +658,15 @@
                 "colorspace": "1.1.x",
                 "enabled": "2.0.x",
                 "kuler": "^2.0.0"
+            }
+        },
+        "node_modules/@discoveryjs/json-ext": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+            "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@dual-bundle/import-meta-resolve": {
@@ -1379,6 +1389,15 @@
                 "redis": ">=4.6"
             }
         },
+        "node_modules/@next/bundle-analyzer": {
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-14.2.13.tgz",
+            "integrity": "sha512-CQOVKmfenD9HsG4AmyXG2ElMvtGKAT9TlS2JLgpL/EORi4WX+QMiQ8Ri6b+A7HRT+AiUGjsYnocIOET59i6Jfw==",
+            "dev": true,
+            "dependencies": {
+                "webpack-bundle-analyzer": "4.10.1"
+            }
+        },
         "node_modules/@next/env": {
             "version": "14.1.3",
             "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.3.tgz",
@@ -1800,6 +1819,12 @@
             "funding": {
                 "url": "https://opencollective.com/unts"
             }
+        },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.28",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
+            "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
+            "dev": true
         },
         "node_modules/@redis/bloom": {
             "version": "1.2.0",
@@ -4113,6 +4138,12 @@
                 "url": "https://github.com/sponsors/kossnocorp"
             }
         },
+        "node_modules/debounce": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+            "dev": true
+        },
         "node_modules/debug": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -4331,6 +4362,12 @@
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
+        },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "dev": true
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
@@ -5989,6 +6026,21 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
+        "node_modules/gzip-size": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+            "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+            "dev": true,
+            "dependencies": {
+                "duplexer": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -6096,6 +6148,12 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true
         },
         "node_modules/html-react-parser": {
             "version": "5.1.10",
@@ -7496,6 +7554,15 @@
             "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
             "peer": true
         },
+        "node_modules/mrmime": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
+            "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7870,6 +7937,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/opener": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+            "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+            "dev": true,
+            "bin": {
+                "opener": "bin/opener-bin.js"
             }
         },
         "node_modules/openid-client": {
@@ -8814,6 +8890,20 @@
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
             "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         },
+        "node_modules/sirv": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+            "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+            "dev": true,
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.24",
+                "mrmime": "^2.0.0",
+                "totalist": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -9689,6 +9779,15 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/totalist": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+            "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/tough-cookie": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
@@ -10164,6 +10263,75 @@
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+            "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+            "dev": true,
+            "dependencies": {
+                "@discoveryjs/json-ext": "0.5.7",
+                "acorn": "^8.0.4",
+                "acorn-walk": "^8.0.0",
+                "commander": "^7.2.0",
+                "debounce": "^1.2.1",
+                "escape-string-regexp": "^4.0.0",
+                "gzip-size": "^6.0.0",
+                "html-escaper": "^2.0.2",
+                "is-plain-object": "^5.0.0",
+                "opener": "^1.5.2",
+                "picocolors": "^1.0.0",
+                "sirv": "^2.0.3",
+                "ws": "^7.3.1"
+            },
+            "bin": {
+                "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "name": "pam-stillingsok-frontend",
     "version": "0.211.0",
     "description": "",
-    "main": "index.js",
     "scripts": {
         "next": "npm run dev",
         "build": "next build",
@@ -24,7 +23,7 @@
         "@axe-core/react": "^4.9.1",
         "@navikt/aksel-icons": "^6.16.3",
         "@navikt/arbeidsplassen-css": "^8.2.17",
-        "@navikt/arbeidsplassen-react": "^8.2.17",
+        "@navikt/arbeidsplassen-react": "^8.3.0",
         "@navikt/arbeidsplassen-theme": "^6.0.7",
         "@navikt/ds-css": "^6.16.3",
         "@navikt/ds-react": "^6.16.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@axe-core/react": "^4.9.1",
         "@navikt/aksel-icons": "^6.16.3",
         "@navikt/arbeidsplassen-css": "^8.2.17",
-        "@navikt/arbeidsplassen-react": "^8.3.0",
+        "@navikt/arbeidsplassen-react": "^8.3.1",
         "@navikt/arbeidsplassen-theme": "^6.0.7",
         "@navikt/ds-css": "^6.16.3",
         "@navikt/ds-react": "^6.16.3",
@@ -51,6 +51,8 @@
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.2",
         "@types/node": "20.12.12",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
         "@types/testing-library__jest-dom": "^6.0.0",
         "@types/testing-library__react": "^10.2.0",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
@@ -75,6 +77,7 @@
         "prettier": "^3.2.5",
         "stylelint": "^16.5.0",
         "stylelint-config-recommended": "^14.0.0",
+        "typescript": "^4.9.5",
         "vitest": "^1.6.0"
     },
     "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "winston": "^3.13.0"
     },
     "devDependencies": {
+        "@next/bundle-analyzer": "^14.2.13",
         "@next/eslint-plugin-next": "^14.2.1",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.2",

--- a/src/app/(sok)/_components/SearchQueryProvider.tsx
+++ b/src/app/(sok)/_components/SearchQueryProvider.tsx
@@ -62,7 +62,7 @@ export function SearchQueryProvider({ children }: SearchQueryProviderProps): Rea
     }
 
     function has(key: string, value?: string): boolean {
-        // @ts-expect-error https://github.com/microsoft/TypeScript/issues/55569
+        // @ts-expect-error https://github.com/microsoft/TypeScript/issues/55569 /
         return urlSearchParams.has(key, value);
     }
 

--- a/src/app/(sok)/_components/SearchQueryProvider.tsx
+++ b/src/app/(sok)/_components/SearchQueryProvider.tsx
@@ -62,6 +62,7 @@ export function SearchQueryProvider({ children }: SearchQueryProviderProps): Rea
     }
 
     function has(key: string, value?: string): boolean {
+        // @ts-expect-error https://github.com/microsoft/TypeScript/issues/55569
         return urlSearchParams.has(key, value);
     }
 
@@ -90,6 +91,7 @@ export function SearchQueryProvider({ children }: SearchQueryProviderProps): Rea
     function remove(key: string, value?: string): void {
         setUrlSearchParams((previous) => {
             const newUrlSearchParams = new URLSearchParams(previous);
+            // @ts-expect-error https://github.com/microsoft/TypeScript/issues/55569
             newUrlSearchParams.delete(key, value);
             return setDefaultValues(newUrlSearchParams, key);
         });

--- a/src/app/(sok)/_components/feedback/Feedback.tsx
+++ b/src/app/(sok)/_components/feedback/Feedback.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState } from "react";
 import { BodyLong, Heading, HStack, Link as AkselLink, Panel, VStack } from "@navikt/ds-react";
 import { FaceFrownIcon, FaceSmileIcon } from "@navikt/aksel-icons";
-// @ts-expect-error Denne er instalert, men oppdages ikke, noe feil med pakken
 import { FeedbackButton } from "@navikt/arbeidsplassen-react";
 import logAmplitudeEvent from "@/app/_common/monitoring/amplitude";
 import useSearchQuery from "@/app/(sok)/_components/SearchQueryProvider";

--- a/src/app/_common/components/NotFoundPage.tsx
+++ b/src/app/_common/components/NotFoundPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { ReactElement } from "react";
-// @ts-expect-error TODO: Add typeinfo for arbeidsplassen-react
 import { NotFound } from "@navikt/arbeidsplassen-react";
 
 interface NotFoundPageProps {

--- a/src/app/_common/user/UserProvider.tsx
+++ b/src/app/_common/user/UserProvider.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useContext, useEffect, useState } from "react";
 import { BodyLong, Button, HStack, Modal } from "@navikt/ds-react";
-// @ts-expect-error TODO: Add typeinfo for arbeidsplassen-react
 import { WorriedFigure } from "@navikt/arbeidsplassen-react";
 import { AuthenticationContext, AuthenticationStatus } from "@/app/_common/auth/contexts/AuthenticationProvider";
 import useToggle from "@/app/_common/hooks/useToggle";

--- a/src/app/lagrede-sok/_components/NoSavedSearches.tsx
+++ b/src/app/lagrede-sok/_components/NoSavedSearches.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from "react";
 import { BodyLong, Button, Heading, VStack } from "@navikt/ds-react";
-// @ts-expect-error TODO: Add typeinfo for arbeidsplassen-react
 import { FigureWithMagnifier } from "@navikt/arbeidsplassen-react";
 import Link from "next/link";
 

--- a/src/app/lagrede-sok/_components/SavedSearchListItem.tsx
+++ b/src/app/lagrede-sok/_components/SavedSearchListItem.tsx
@@ -10,6 +10,7 @@ import useToggle from "@/app/_common/hooks/useToggle";
 import { FetchStatus } from "@/app/_common/hooks/useFetchReducer";
 import * as actions from "@/app/_common/actions";
 import { SavedSearch } from "@/app/_common/actions/savedSearchActions";
+import { ActionResponse } from "@/app/_common/actions/types";
 import { FormModes, SaveSearchFormData } from "./modal/SaveSearchForm";
 import SaveSearchModal from "./modal/SaveSearchModal";
 
@@ -56,8 +57,8 @@ function SavedSearchListItem({
     async function reactivateEmailNotification(): Promise<void> {
         setRestartEmailNotificationStatus(FetchStatus.IS_FETCHING);
 
-        let isSuccess;
-        let result;
+        let isSuccess: boolean;
+        let result: ActionResponse<SavedSearch>;
         try {
             const updatedSavedSearch = {
                 ...savedSearch,

--- a/src/app/lagrede-sok/_components/UserConsentIsRequired.tsx
+++ b/src/app/lagrede-sok/_components/UserConsentIsRequired.tsx
@@ -2,7 +2,6 @@
 
 import React, { ReactElement, useState } from "react";
 import { BodyLong, Button, Heading, VStack } from "@navikt/ds-react";
-// @ts-expect-error TODO: Add typeinfo for arbeidsplassen-react
 import { FigureJugglingShieldWithCheckmark } from "@navikt/arbeidsplassen-react";
 import UserConsentModal from "@/app/_common/user/UserConsentModal";
 import { useRouter } from "next/navigation";

--- a/src/app/lagrede-sok/_components/modal/RegisterEmailForm.tsx
+++ b/src/app/lagrede-sok/_components/modal/RegisterEmailForm.tsx
@@ -58,7 +58,8 @@ function RegisterEmailForm({ onClose, onSuccess }: RegisterEmailFormProps): Reac
         if (validateForm()) {
             setSaveStatus(FetchStatus.IS_FETCHING);
             let isSuccess;
-            let result;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            let result: { success: boolean; statusCode?: number; data?: any };
 
             try {
                 result = await actions.updateUser({ ...user, email });

--- a/src/app/lagrede-sok/_components/modal/SaveSearchForm.tsx
+++ b/src/app/lagrede-sok/_components/modal/SaveSearchForm.tsx
@@ -17,6 +17,7 @@ import useToggle from "@/app/_common/hooks/useToggle";
 import { isStringEmpty } from "@/app/_common/utils/utils";
 import * as actions from "@/app/_common/actions";
 import { SavedSearch } from "@/app/_common/actions/savedSearchActions";
+import { ActionResponse } from "@/app/_common/actions/types";
 
 export const FormModes = {
     ADD: "ADD",
@@ -103,7 +104,7 @@ function SaveSearchForm({
                 startTransition(async () => {
                     setShowError(false);
                     let isSuccess;
-                    let result;
+                    let result: ActionResponse<SavedSearch>;
                     try {
                         result = await actions.saveSavedSearchAction(dataToBeSaved);
                         isSuccess = result.success;
@@ -131,7 +132,7 @@ function SaveSearchForm({
                 startTransition(async () => {
                     setShowError(false);
                     let isSuccess;
-                    let result;
+                    let result: ActionResponse<SavedSearch>;
                     try {
                         result = await actions.updateSavedSearchAction(dataToBeSaved);
                         isSuccess = result.success;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "target": "es5",
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,
@@ -12,6 +13,7 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "jsx": "preserve",
+        "forceConsistentCasingInFileNames": true,
         "plugins": [
             {
                 "name": "next"
@@ -22,9 +24,6 @@
         },
         "types": ["@testing-library/jest-dom", "vitest/globals"]
     },
-    "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+    "include": ["index.d.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
     "exclude": ["node_modules"]
 }
-
-
-// hej

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,6 +8,11 @@ export default defineConfig({
         globals: true, // Needed for cleanup https://github.com/testing-library/vue-testing-library/issues/296
         environment: "jsdom",
         setupFiles: "./vitest.setup.js",
+        server: {
+            deps: {
+                inline: ['@navikt/arbeidsplassen-react'],
+            },
+        },
     },
     resolve: {
         alias: {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
         setupFiles: "./vitest.setup.js",
         server: {
             deps: {
-                inline: ['@navikt/arbeidsplassen-react'],
+                inline: ["@navikt/arbeidsplassen-react"],
             },
         },
     },


### PR DESCRIPTION
Changed arbeidsplassen-react to ESM, which allows for fewer imports. This has reduced the first time load JS from 731 kB to 305 kB on `/stillinger`.

The shared first load JS is now 188 kB, compared to 643 kB earlier.




New build size:
```
Route (app)                              Size     First Load JS
┌ λ /                                    31.9 kB         305 kB
├ λ /_not-found                          0 B                0 B
├ λ /api/internal/isAlive                0 B                0 B
├ λ /api/internal/isReady                0 B                0 B
├ λ /api/internal/metrics                0 B                0 B
├ λ /api/internal/prometheus             0 B                0 B
├ λ /api/search                          0 B                0 B
├ λ /favoritter                          10.6 kB         276 kB
├ λ /lagrede-sok                         9.26 kB         270 kB
├ λ /rapporter-annonse/[id]              5.47 kB         263 kB
├ λ /sitemap.xml                         0 B                0 B
├ λ /stilling/[id]                       20.4 kB         291 kB
├ λ /stilling/[id]/superrask-soknad      4.47 kB         265 kB
└ λ /trekk-soknad/[uuid]/[adUuid]        4.66 kB         256 kB
+ First Load JS shared by all            188 kB
  ├ chunks/1[45](https://github.com/navikt/pam-stillingsok/actions/runs/11028332481/job/30628331780#step:14:46)-bf76ecac4f6412e9.js       95.1 kB
  ├ chunks/396[46](https://github.com/navikt/pam-stillingsok/actions/runs/11028332481/job/30628331780#step:14:47)4d2-9e935a322110e4d2.js  37 kB
  ├ chunks/fd9d1056-6f871c0060b1f758.js  53.4 kB
  └ other shared chunks (total)          2.6 kB

ƒ Middleware                             55 kB
```

Previous build size:
```
Route (app)                              Size     First Load JS
┌ λ /                                    27.8 kB         731 kB
├ λ /_not-found                          0 B                0 B
├ λ /api/internal/isAlive                0 B                0 B
├ λ /api/internal/isReady                0 B                0 B
├ λ /api/internal/metrics                0 B                0 B
├ λ /api/internal/prometheus             0 B                0 B
├ λ /api/search                          0 B                0 B
├ λ /favoritter                          5.99 kB         702 kB
├ λ /lagrede-sok                         4.7 kB          700 kB
├ λ /rapporter-annonse/[id]              5.5 kB          697 kB
├ λ /sitemap.xml                         0 B                0 B
├ λ /stilling/[id]                       20.3 kB         721 kB
├ λ /stilling/[id]/superrask-soknad      4.48 kB         699 kB
└ λ /trekk-soknad/[uuid]/[adUuid]        4.69 kB         691 kB
+ First Load JS shared by all            643 kB
  ├ chunks/132-82af888e78d9f87f.js       438 kB
  ├ chunks/145-a29e2f8456d05a42.js       95.1 kB
  ├ chunks/396464d2-9e935a322110e4d2.js  37 kB
  ├ chunks/538ff4e4-1bce7b196ad3ef9a.js  17.3 kB
  ├ chunks/fd9d1056-6f871c0060b1f758.js  53.4 kB
  └ other shared chunks (total)          2.6 kB
```