### PR TITLE
Show alerts when geography service is down

### DIFF
--- a/src/app/(sok)/_components/Search.jsx
+++ b/src/app/(sok)/_components/Search.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import { HGrid, Hide, Show, VStack } from "@navikt/ds-react";
+import { Alert, HGrid, Hide, Show, VStack } from "@navikt/ds-react";
+import { FETCH_SEARCH_WITHIN_DISTANCE_ERROR } from "@/app/(sok)/_utils/fetchTypes";
 import SearchResult from "./searchResult/SearchResult";
 import DoYouWantToSaveSearch from "./howToPanels/DoYouWantToSaveSearch";
 import Feedback from "./feedback/Feedback";
@@ -12,8 +13,10 @@ import SearchBox from "./searchBox/SearchBox";
 import SearchPagination from "./searchResult/SearchPagination";
 import MaxResultsBox from "./searchResult/MaxResultsBox";
 
-export default function Search({ searchResult, aggregations, locations, postcodes, resultsPerPage }) {
+export default function Search({ searchResult, aggregations, locations, postcodes, resultsPerPage, errors }) {
     const [isFiltersVisible, setIsFiltersVisible] = useState(false);
+    const failedToSearchForPostcodes =
+        errors.length > 0 && errors.find((error) => error.type === FETCH_SEARCH_WITHIN_DISTANCE_ERROR);
 
     useEffect(() => {
         logAmplitudeEvent("Stillinger - Utførte søk");
@@ -22,7 +25,6 @@ export default function Search({ searchResult, aggregations, locations, postcode
     return (
         <div className="mb-24">
             <SearchBox aggregations={aggregations} locations={locations} postcodes={postcodes} />
-
             <SearchResultHeader
                 setIsFiltersVisible={setIsFiltersVisible}
                 isFiltersVisible={isFiltersVisible}
@@ -40,6 +42,7 @@ export default function Search({ searchResult, aggregations, locations, postcode
                         locations={locations}
                         postcodes={postcodes}
                         searchResult={searchResult}
+                        errors={errors}
                     />
                 </Hide>
 
@@ -51,11 +54,19 @@ export default function Search({ searchResult, aggregations, locations, postcode
                             postcodes={postcodes}
                             onCloseClick={() => setIsFiltersVisible(false)}
                             searchResult={searchResult}
+                            errors={errors}
                         />
                     )}
                 </Show>
 
                 <VStack gap="10">
+                    {failedToSearchForPostcodes && (
+                        <Alert variant="warning">
+                            Reisevei-filteret er midlertidig utilgjengelig og påvirker ikke søkeresultatene. For å
+                            avgrense søket, bruk kommune- eller fylkesfilteret.
+                        </Alert>
+                    )}
+
                     <SearchResult searchResult={searchResult} />
                     <MaxResultsBox resultsPerPage={resultsPerPage} />
                     <SearchPagination searchResult={searchResult} resultsPerPage={resultsPerPage} />

--- a/src/app/(sok)/_components/SearchWrapper.jsx
+++ b/src/app/(sok)/_components/SearchWrapper.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import Search from "@/app/(sok)/_components/Search";
 import { SearchQueryProvider } from "@/app/(sok)/_components/SearchQueryProvider";
 
-export default function SearchWrapper({ searchResult, aggregations, locations, postcodes, resultsPerPage }) {
+export default function SearchWrapper({ searchResult, aggregations, locations, postcodes, resultsPerPage, errors }) {
     return (
         <SearchQueryProvider>
             <Search
@@ -14,6 +14,7 @@ export default function SearchWrapper({ searchResult, aggregations, locations, p
                 aggregations={aggregations}
                 postcodes={postcodes}
                 resultsPerPage={resultsPerPage}
+                errors={errors}
             />
         </SearchQueryProvider>
     );

--- a/src/app/(sok)/_components/filters/DistanceOrLocation.tsx
+++ b/src/app/(sok)/_components/filters/DistanceOrLocation.tsx
@@ -6,6 +6,7 @@ import { CarIcon, LocationPinIcon } from "@navikt/aksel-icons";
 import { Postcode } from "@/app/(sok)/_utils/fetchPostcodes";
 import { UserPreferencesContext } from "@/app/_common/user/UserPreferenceProvider";
 import SearchResult from "@/app/(sok)/_types/SearchResult";
+import { FetchError } from "@/app/(sok)/_utils/fetchTypes";
 import Counties from "./Locations";
 
 // TODO: Fix disable no-explicit-any when new search field branch is merged
@@ -14,9 +15,10 @@ interface DistanceOrLocationProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     locations: any;
     searchResult: SearchResult;
+    errors: FetchError[];
 }
 
-function DistanceOrLocation({ postcodes, locations, searchResult }: DistanceOrLocationProps): ReactElement {
+function DistanceOrLocation({ postcodes, locations, searchResult, errors }: DistanceOrLocationProps): ReactElement {
     const { locationOrDistance } = useContext(UserPreferencesContext);
     const [selectedOption, setSelectedOption] = useState(locationOrDistance || "distance");
 
@@ -41,7 +43,7 @@ function DistanceOrLocation({ postcodes, locations, searchResult }: DistanceOrLo
                     label="Sted"
                 />
             </ToggleGroup>
-            {selectedOption === "distance" && <DrivingDistance postcodes={postcodes} />}
+            {selectedOption === "distance" && <DrivingDistance postcodes={postcodes} errors={errors} />}
             {selectedOption === "location" && (
                 <Counties locations={locations} updatedValues={searchResult.aggregations} />
             )}

--- a/src/app/(sok)/_components/filters/DrivingDistance.tsx
+++ b/src/app/(sok)/_components/filters/DrivingDistance.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from "react";
-import { BodyShort, Button, Fieldset, Select, UNSAFE_Combobox } from "@navikt/ds-react";
+import { Alert, BodyShort, Button, Fieldset, Select, UNSAFE_Combobox } from "@navikt/ds-react";
 import { TrashIcon } from "@navikt/aksel-icons";
 import { Postcode } from "@/app/(sok)/_utils/fetchPostcodes";
 import { ComboboxOption } from "@navikt/ds-react/esm/form/combobox/types";
@@ -7,12 +7,14 @@ import "./DrivingDistance.css";
 import { logFilterChanged } from "@/app/_common/monitoring/amplitude";
 import useSearchQuery from "@/app/(sok)/_components/SearchQueryProvider";
 import { DISTANCE, POSTCODE } from "@/app/(sok)/_components/searchParamNames";
+import { FETCH_POSTCODES_ERROR, FetchError } from "@/app/(sok)/_utils/fetchTypes";
 
 interface DrivingDistanceProps {
     postcodes: Postcode[];
+    errors: FetchError[];
 }
 
-function DrivingDistance({ postcodes }: DrivingDistanceProps): ReactElement {
+function DrivingDistance({ postcodes, errors }: DrivingDistanceProps): ReactElement {
     const searchQuery = useSearchQuery();
     const [selectedPostcode, setSelectedPostcode] = useState<ComboboxOption[] | string[]>(searchQuery.getAll(POSTCODE));
     const [filteredPostcodeOptions, setFilteredPostcodeOptions] = useState<ComboboxOption[]>([]);
@@ -106,6 +108,9 @@ function DrivingDistance({ postcodes }: DrivingDistanceProps): ReactElement {
         searchQuery.remove(DISTANCE);
     }
 
+    const failedToFetchPostcodes =
+        errors.length > 0 && errors.find((error) => error.type === FETCH_POSTCODES_ERROR) !== undefined;
+
     return (
         <Fieldset
             legend={
@@ -115,6 +120,12 @@ function DrivingDistance({ postcodes }: DrivingDistanceProps): ReactElement {
             }
             className="FilterModal__fieldset mt-2"
         >
+            {failedToFetchPostcodes && (
+                <Alert variant="warning" className="mb-4" inline>
+                    Reisevei-filteret er midlertidig utilgjengelig og påvirker ikke søkeresultatene. For å avgrense
+                    søket, bruk kommune- eller fylkesfilteret.
+                </Alert>
+            )}
             <UNSAFE_Combobox
                 label="Fra sted eller postnummer"
                 className="Combobox"

--- a/src/app/(sok)/_components/filters/FiltersDesktop.tsx
+++ b/src/app/(sok)/_components/filters/FiltersDesktop.tsx
@@ -9,6 +9,7 @@ import DistanceOrLocation from "@/app/(sok)/_components/filters/DistanceOrLocati
 import FilterAggregations from "@/app/(sok)/_types/FilterAggregations";
 import SearchResult from "@/app/(sok)/_types/SearchResult";
 import { Postcode } from "@/app/(sok)/_utils/fetchPostcodes";
+import { FetchError } from "@/app/(sok)/_utils/fetchTypes";
 import FilterAccordionItem from "./FilterAccordionItem";
 import Published from "./Published";
 import Occupations from "./Occupations";
@@ -22,6 +23,7 @@ interface FiltersDesktopProps {
     locations: [];
     postcodes: Postcode[];
     searchResult: SearchResult;
+    errors: FetchError[];
 }
 
 export default function FiltersDesktop({
@@ -29,6 +31,7 @@ export default function FiltersDesktop({
     locations,
     postcodes,
     searchResult,
+    errors,
 }: FiltersDesktopProps): ReactElement {
     return (
         <div>
@@ -41,7 +44,12 @@ export default function FiltersDesktop({
                     />
                 </FilterAccordionItem>
                 <FilterAccordionItem title="Sted" panelId="sted">
-                    <DistanceOrLocation postcodes={postcodes} locations={locations} searchResult={searchResult} />
+                    <DistanceOrLocation
+                        postcodes={postcodes}
+                        locations={locations}
+                        searchResult={searchResult}
+                        errors={errors}
+                    />
                 </FilterAccordionItem>
                 <FilterAccordionItem title="Yrkeskategori og sektor" panelId="yrke">
                     <Occupations

--- a/src/app/(sok)/_components/filters/FiltersMobile.jsx
+++ b/src/app/(sok)/_components/filters/FiltersMobile.jsx
@@ -16,7 +16,7 @@ import Sector from "./Sector";
 import EngagementType from "./Engagement";
 import WorkLanguage from "./WorkLanguage";
 
-function FiltersMobile({ onCloseClick, searchResult, aggregations, locations, postcodes }) {
+function FiltersMobile({ onCloseClick, searchResult, aggregations, locations, postcodes, errors }) {
     const [selectedFilter, setSelectedFilter] = useState("");
     const headingRef = useRef();
 
@@ -87,7 +87,12 @@ function FiltersMobile({ onCloseClick, searchResult, aggregations, locations, po
                     )}
 
                     {selectedFilter === "Sted" && (
-                        <DistanceOrLocation postcodes={postcodes} locations={locations} searchResult={searchResult} />
+                        <DistanceOrLocation
+                            postcodes={postcodes}
+                            locations={locations}
+                            searchResult={searchResult}
+                            errors={errors}
+                        />
                     )}
 
                     {selectedFilter === "Yrkeskategori og sektor" && (

--- a/src/app/(sok)/_components/searchBox/SearchBox.jsx
+++ b/src/app/(sok)/_components/searchBox/SearchBox.jsx
@@ -20,7 +20,9 @@ function SearchBox({ aggregations, locations, postcodes }) {
     savedSearchUrlWithoutVersion.delete(URL_VERSION);
     const showSaveAndResetButton = savedSearchUrlWithoutVersion.size > 0 && !onlyPostcodeOrDistanceFilterActive;
     const chosenPostcodeCity =
-        drivingDistanceFilterActive && postcodes.find((p) => p.postcode === searchQuery.get(POSTCODE)).city;
+        drivingDistanceFilterActive &&
+        postcodes.size > 0 &&
+        postcodes.find((p) => p.postcode === searchQuery.get(POSTCODE)).city;
 
     return (
         <Box paddingBlock={{ xs: "0 6", lg: "10 12" }}>

--- a/src/app/(sok)/_utils/fetchTypes.ts
+++ b/src/app/(sok)/_utils/fetchTypes.ts
@@ -1,0 +1,13 @@
+export interface FetchResult<T> {
+    errors?: FetchError[];
+    data?: T;
+}
+
+export interface FetchError {
+    type: string;
+}
+
+// These files must be in a separate file other than fetchPostcodes.ts and fetchLocationsWithinDrivingDistance.ts because those files are
+// supposed to run on the server, while these values will also be used in client code.
+export const FETCH_POSTCODES_ERROR = "FETCH_POSTCODES_ERROR";
+export const FETCH_SEARCH_WITHIN_DISTANCE_ERROR = "FETCH_SEARCH_WITHIN_DISTANCE_ERROR";

--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -119,15 +119,20 @@ export default async function Page({ searchParams }) {
         fetchCalls.push(fetchCachedSimplifiedElasticSearch(toApiQuery(initialQuery)));
     }
 
-    const [globalSearchResult, locations, postcodes, searchResult] = await Promise.all(fetchCalls);
-
+    const fetchResults = await Promise.all(fetchCalls);
+    const [globalSearchResult, locations, postcodes, searchResult] = fetchResults;
+    const errors = fetchResults
+        .filter((result) => result.errors)
+        .map((result) => result.errors)
+        .flat();
     return (
         <SearchWrapper
-            searchResult={shouldDoExtraCallIfUserHasSearchParams ? searchResult : globalSearchResult}
-            aggregations={globalSearchResult.aggregations}
+            searchResult={shouldDoExtraCallIfUserHasSearchParams ? searchResult.data : globalSearchResult.data}
+            aggregations={globalSearchResult.data.aggregations}
             locations={locations}
-            postcodes={postcodes}
+            postcodes={postcodes.data}
             resultsPerPage={resultsPerPage}
+            errors={errors}
         />
     );
 }


### PR DESCRIPTION
Show two different alerts if fetching postcodes or fetching locations within driving distance fails.

Implemented by returning a result-type that may contain errors, instead of throwing errors in the fetch methods.

![Screenshot from 2024-09-26 15-54-32](https://github.com/user-attachments/assets/2949daa5-71d1-46d5-9f25-7df2796d6577)
