### PR TITLE
Fix redirect loop when query url is empty

### DIFF
--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -91,6 +91,7 @@ export default async function Page({ searchParams }) {
         }
     }
     const newSearchParams = migrateSearchParams(searchParams);
+
     if (newSearchParams !== undefined) {
         const newQuery = {
             ...createQuery(newSearchParams),

--- a/src/app/(sok)/page.jsx
+++ b/src/app/(sok)/page.jsx
@@ -91,13 +91,12 @@ export default async function Page({ searchParams }) {
         }
     }
     const newSearchParams = migrateSearchParams(searchParams);
-
     if (newSearchParams !== undefined) {
         const newQuery = {
             ...createQuery(newSearchParams),
             saved: newSearchParams.saved,
         };
-        redirect(stringifyQuery(toBrowserQuery(newQuery)));
+        redirect(stringifyQuery(toBrowserQuery(newQuery)) || "/");
     }
 
     const userPreferences = await actions.getUserPreferences();


### PR DESCRIPTION
- Fikser slik at en tom url query etter migrering redirectes til `/`.
- Ellers vil den redirecte til samme side igjen med gamle parameternavn og ende opp i en redirect loop