### PR TITLE
Create common parseSearchParams function

### DIFF
--- a/src/app/(sok)/_components/SearchQueryProvider.tsx
+++ b/src/app/(sok)/_components/SearchQueryProvider.tsx
@@ -18,8 +18,6 @@ export type SearchQueryActions = {
     reset: () => void;
     setPaginate: (paginate: boolean) => void;
     paginate: boolean;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    asJavaScriptObject: () => any;
 };
 
 interface SearchQueryProviderProps {
@@ -126,23 +124,6 @@ export function SearchQueryProvider({ children }: SearchQueryProviderProps): Rea
         return newUrlSearchParams;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function asJavaScriptObject(): any {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const params: any = {};
-
-        Array.from(urlSearchParams.keys()).forEach((key) => {
-            const values = urlSearchParams.getAll(key);
-            if (values.length > 1) {
-                params[key] = values;
-            } else {
-                [params[key]] = values;
-            }
-        });
-
-        return params;
-    }
-
     return (
         <SearchQueryContext.Provider
             // eslint-disable-next-line
@@ -158,7 +139,6 @@ export function SearchQueryProvider({ children }: SearchQueryProviderProps): Rea
                 reset,
                 setPaginate,
                 paginate,
-                asJavaScriptObject,
             }}
         >
             {children}

--- a/src/app/(sok)/_components/feedback/Feedback.tsx
+++ b/src/app/(sok)/_components/feedback/Feedback.tsx
@@ -6,6 +6,7 @@ import logAmplitudeEvent from "@/app/_common/monitoring/amplitude";
 import useSearchQuery from "@/app/(sok)/_components/SearchQueryProvider";
 import { SEARCH_STRING } from "@/app/(sok)/_components/searchParamNames";
 import { logSearch } from "@/app/_common/monitoring/search-logging";
+import { parseSearchParams } from "@/app/(sok)/_utils/parseSearchParams";
 
 export default function Feedback(): ReactElement {
     const [hasGivenRating, setHasGiverRating] = useState<boolean>(false);
@@ -17,7 +18,7 @@ export default function Feedback(): ReactElement {
                 rating: text,
                 hasSearchString: searchQuery.has(SEARCH_STRING),
             });
-            logSearch(text, searchQuery.asJavaScriptObject());
+            logSearch(text, parseSearchParams(searchQuery.urlSearchParams));
         } catch (err) {
             // ignore
         }

--- a/src/app/(sok)/_utils/parseSearchParams.js
+++ b/src/app/(sok)/_utils/parseSearchParams.js
@@ -1,0 +1,16 @@
+export function parseSearchParams(urlSearchParams) {
+    const searchParamsObject = {};
+
+    urlSearchParams.forEach((value, key) => {
+        if (searchParamsObject[key]) {
+            if (Array.isArray(searchParamsObject[key])) {
+                searchParamsObject[key] = [...searchParamsObject[key], value];
+            } else {
+                searchParamsObject[key] = [searchParamsObject[key], value];
+            }
+        } else {
+            searchParamsObject[key] = value;
+        }
+    });
+    return searchParamsObject;
+}

--- a/src/app/(sok)/_utils/parseSearchParams.test.js
+++ b/src/app/(sok)/_utils/parseSearchParams.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { parseSearchParams } from "@/app/(sok)/_utils/parseSearchParams";
+
+describe("parseSearchParams", () => {
+    test("Should parse url param to object member", () => {
+        const urlSearchParams = new URLSearchParams([["q", "Utvikler"]]);
+        const expectedResult = {
+            q: "Utvikler",
+        };
+        const searchParamsObject = parseSearchParams(urlSearchParams);
+        expect(searchParamsObject).toEqual(expectedResult);
+    });
+
+    test("Should parse multiple params with same name into array", () => {
+        const urlSearchParams = new URLSearchParams([
+            ["extent", "Deltid"],
+            ["extent", "Heltid"],
+        ]);
+        const expectedResult = {
+            extent: ["Deltid", "Heltid"],
+        };
+        const searchParamsObject = parseSearchParams(urlSearchParams);
+        expect(searchParamsObject).toEqual(expectedResult);
+    });
+});

--- a/src/app/api/search/route.js
+++ b/src/app/api/search/route.js
@@ -3,25 +3,9 @@ import { migrateSearchParams } from "@/app/(sok)/_utils/searchParamsVersioning";
 import { NextResponse } from "next/server";
 import logger from "@/app/_common/utils/logger";
 import { fetchElasticSearch } from "@/app/(sok)/_utils/fetchElasticSearch";
+import { parseSearchParams } from "@/app/(sok)/_utils/parseSearchParams";
 
 export const dynamic = "force-dynamic";
-
-function parseSearchParams(entries) {
-    const searchParams = {};
-
-    entries.forEach((value, key) => {
-        if (searchParams[key]) {
-            if (Array.isArray(searchParams[key])) {
-                searchParams[key] = [...searchParams[key], value];
-            } else {
-                searchParams[key] = [searchParams[key], value];
-            }
-        } else {
-            searchParams[key] = value;
-        }
-    });
-    return searchParams;
-}
 
 /**
  * Note: This endpoint is used by pam-aduser


### PR DESCRIPTION
- Flere steder i koden hvor vi trenger å parse fra `URLSearchParams` til nextjs sin `searchParams` objekt
- Trekker ut til felles funksjon og legger til test