### PR TITLE
[amplitude] disable page viewed events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.211.0",
             "license": "ISC",
             "dependencies": {
-                "@amplitude/analytics-browser": "^2.7.2",
+                "@amplitude/analytics-browser": "^2.11.9",
                 "@axe-core/react": "^4.9.1",
                 "@navikt/aksel-icons": "^6.16.3",
                 "@navikt/arbeidsplassen-css": "^8.2.17",
@@ -83,29 +83,29 @@
             "license": "MIT"
         },
         "node_modules/@amplitude/analytics-browser": {
-            "version": "2.11.8",
-            "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.11.8.tgz",
-            "integrity": "sha512-lFv8deROLwBfSlg92+r1NitWJ6BN45IKwpPLoixA0fZytScXEJqc0Gl5O+BY4qScbFECYt9PFKblhB+jC+IvPg==",
+            "version": "2.11.9",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.11.9.tgz",
+            "integrity": "sha512-FHejpsW3OypNKaIBvMwLm74UUSBcR+VwrBsj7V2VlPDNRdeaFi21kJgVYUW5AcjxTsadMzBQGBb4BarZ4k2+9Q==",
             "license": "MIT",
             "dependencies": {
-                "@amplitude/analytics-client-common": "^2.3.4",
-                "@amplitude/analytics-core": "^2.5.3",
+                "@amplitude/analytics-client-common": "^2.3.5",
+                "@amplitude/analytics-core": "^2.5.4",
                 "@amplitude/analytics-remote-config": "^0.4.0",
-                "@amplitude/analytics-types": "^2.8.3",
+                "@amplitude/analytics-types": "^2.8.4",
                 "@amplitude/plugin-autocapture-browser": "^1.0.2",
-                "@amplitude/plugin-page-view-tracking-browser": "^2.3.4",
+                "@amplitude/plugin-page-view-tracking-browser": "^2.3.5",
                 "tslib": "^2.4.1"
             }
         },
         "node_modules/@amplitude/analytics-client-common": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.3.4.tgz",
-            "integrity": "sha512-3oqdvca5W4BPblTaxf60YRtlh2uC+N3rA99wowDAhTBJoMJJaauOBoXu5BbiQO1u8Zw/c8ymyr8E20+glyptUg==",
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.3.5.tgz",
+            "integrity": "sha512-BCP+jorfLMAKK/g87fAk4IPP/NzQLMCep+Qe23tqOCWguwTEINYnyzD/GmhaIKXSM2o9pmMLlHbhkA1vXUtF8g==",
             "license": "MIT",
             "dependencies": {
                 "@amplitude/analytics-connector": "^1.4.8",
-                "@amplitude/analytics-core": "^2.5.3",
-                "@amplitude/analytics-types": "^2.8.3",
+                "@amplitude/analytics-core": "^2.5.4",
+                "@amplitude/analytics-types": "^2.8.4",
                 "tslib": "^2.4.1"
             }
         },
@@ -119,12 +119,12 @@
             }
         },
         "node_modules/@amplitude/analytics-core": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.5.3.tgz",
-            "integrity": "sha512-dvx3PS0adnHRS22VbuP9YtWg//bQGF2c61Pj5IYXVsemtRRHqiS7XJ860brk3WeQgOkqf3Gyc023DoYcsWGoNQ==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.5.4.tgz",
+            "integrity": "sha512-J5ZF8hQmxmxM+7bu25a2TfTnk/LQ/oH5FYdg79f1lJ85Aa6oUlCDxgvXwy1RVpwaFjWlZQgV4XVaAUrxtSPRFw==",
             "license": "MIT",
             "dependencies": {
-                "@amplitude/analytics-types": "^2.8.3",
+                "@amplitude/analytics-types": "^2.8.4",
                 "tslib": "^2.4.1"
             }
         },
@@ -141,9 +141,9 @@
             }
         },
         "node_modules/@amplitude/analytics-types": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.8.3.tgz",
-            "integrity": "sha512-HNmKVd0ACoi3xTi86xi+is7WgqKT78JA4fYLcM25/ckFkZ1zVCqD1AubaADEh26m34nJ3qDLK5Pob4QptQNPAg==",
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.8.4.tgz",
+            "integrity": "sha512-jQ8WY1aPbpBshl0L/0YEeQn/wZlBr8Jlqc20qf8nbuDuimFy8RqAkE+BVaMI86FCkr3AJ7PjMXkGwCSbUx88CA==",
             "license": "MIT"
         },
         "node_modules/@amplitude/experiment-core": {
@@ -168,13 +168,13 @@
             }
         },
         "node_modules/@amplitude/plugin-page-view-tracking-browser": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.4.tgz",
-            "integrity": "sha512-l7RS5gssG0BPYlgirV0NQ94EPzTOdDkp0z2jqU45D3DQAJXkoloUyw5lw/cbUXYwNulHZTG/BExcERfdvVWkLA==",
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.5.tgz",
+            "integrity": "sha512-qcV4DLxRAZRriYBNvjc2PGW1EDad6PSsIXmxVs6j8i9fxY2SfdvsFd/Qd23CHj1e6Dt5QpAVJZpUMCEdqqDZbA==",
             "license": "MIT",
             "dependencies": {
-                "@amplitude/analytics-client-common": "^2.3.4",
-                "@amplitude/analytics-types": "^2.8.3",
+                "@amplitude/analytics-client-common": "^2.3.5",
+                "@amplitude/analytics-types": "^2.8.4",
                 "tslib": "^2.4.1"
             }
         },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@amplitude/analytics-browser": "^2.7.2",
+        "@amplitude/analytics-browser": "^2.11.9",
         "@axe-core/react": "^4.9.1",
         "@navikt/aksel-icons": "^6.16.3",
         "@navikt/arbeidsplassen-css": "^8.2.17",

--- a/src/app/_common/monitoring/amplitude.ts
+++ b/src/app/_common/monitoring/amplitude.ts
@@ -13,10 +13,13 @@ export function initAmplitude(amplitudeToken: string | undefined) {
 
         amplitude.init(amplitudeKey, undefined, {
             serverUrl: `https://amplitude.nav.no/collect`,
-            defaultTracking: {
-                pageViews: true,
+            autocapture: {
+                attribution: true,
+                pageViews: false,
                 sessions: true,
-                formInteractions: true,
+                formInteractions: false,
+                fileDownloads: false,
+                elementInteractions: false,
             },
             /** Need this for /collect-auto according to https://nav-it.slack.com/archives/CMK1SCBP1/p1669722646425599
              * but seems to work fine with /collect? Keeping it here just in case.


### PR DESCRIPTION
Hovedmålet er å ta vekk `Page Viewed` events.

Oppgraderer til analytics-browser-2.11.9, dette er fordi dokumentasjon sier man trenger høyere enn 2.10.0 av en eller annen grunn for å bruke nye `autocapture` options (litt usikker rundt hva 2.10.0 gjør annerledes), bruker man `defaultTracking` så får man beskjed om "deprecated value". Uansett det er bakgrunnen for oppgradering og har ikke sett noe feil hittil så beholder

Disabler alt av autocapture utenom to ting.
- [attribution](https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2#track-marketing-attribution): Dette innholder ting som referrer informasjon (hvor bruker kommer fra) som er ganske nyttig for oss. Gjerne si ifra hvis dere ser noen røde flagg her.
- [sessions](https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2#track-sessions): Denne tracker sessions, og fra det jeg leser så ser det ut som den mest bare gir deg en `Start Session` event og en `End Session` event. Jeg har alltid følt session tracking er viktig men vi har egentlig ikke brukt dette noe særlig, så det er greit om vi vil ta det vekk. 

