### PR TITLE
bruk valkey istedenfor redis

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -73,6 +73,6 @@ spec:
         - host: {{ arbeidsplassen_domain }}
         - host: umami.nav.no
         - host: sentry.gc.nav.no
-  redis:
+  valkey:
     - instance: {{ redis.instance }}
       access: readwrite


### PR DESCRIPTION
Dette er vel alt som trengs for å bruke valkey, men det er mer vi kan gjøre her virker det som (trenger vi deploy-redis i deploy-dev.yml osv?)

Med dette har jeg hvertfall bekreftet at vi bruker valkey i dev og at redis ikke blir brukt lenger. Dette gjorde jeg via nais console hvor jeg ser valkey blir brukt av stillingsok og redis blir ikke brukt.

Valkey
https://console.nav.cloud.nais.io/team/teampam/dev-gcp/valkey/valkey-teampam-stillingsok

Redis
https://console.nav.cloud.nais.io/team/teampam/dev-gcp/redis/redis-teampam-stillingsok