### PR TITLE
Sommer jobb search query

### DIFF
--- a/src/app/sommerjobb/_components/SommerjobbItem.tsx
+++ b/src/app/sommerjobb/_components/SommerjobbItem.tsx
@@ -16,7 +16,7 @@ interface SommerjobbItemProps {
 const SommerjobbItem = forwardRef(function Component({ sommerjobbAd }: SommerjobbItemProps, ref): ReactElement {
     const deadline = sommerjobbAd.applicationDue ? formatDate(sommerjobbAd.applicationDue) : undefined;
     let location = sommerjobbAd.location;
-    const employerName = sommerjobbAd.employerName;
+    const employerName = sommerjobbAd.employer.name;
     const ariaLabel = [sommerjobbAd.title, employerName, location].join(", ");
     let description = sommerjobbAd.description;
 

--- a/src/app/sommerjobb/_components/SommerjobbResults.tsx
+++ b/src/app/sommerjobb/_components/SommerjobbResults.tsx
@@ -11,7 +11,9 @@ export interface SommerjobbAd {
     uuid: string;
     title: string;
     description: string;
-    employerName: string;
+    employer: {
+        name: string;
+    };
     location: string;
     applicationDue: string;
 }

--- a/src/app/sommerjobb/page.tsx
+++ b/src/app/sommerjobb/page.tsx
@@ -2,6 +2,24 @@ import { ReactElement } from "react";
 import Sommerjobb from "@/app/sommerjobb/_components/Sommerjobb";
 import { fetchCachedPostcodes } from "@/app/stillinger/(sok)/_utils/fetchPostcodes";
 import { getMetadataTitle } from "@/constants/layout";
+import { createQuery, toApiQuery } from "@/app/stillinger/(sok)/_utils/query";
+import { fetchCachedSimplifiedElasticSearch } from "@/app/stillinger/(sok)/_utils/fetchElasticSearch";
+import { SommerjobbAd } from "@/app/sommerjobb/_components/SommerjobbResults";
+
+const SummerJobKeywords = {
+    SOMMERJOBB: ["Sommerjobb", "Sommervikar", "Sesongarbeid"],
+    BUTIKK: ["Butikk", "Salg", "Detaljhandel"],
+    HELSE: ["Helse", "Sykepleier", "Lege"],
+    KONTOR: ["Kontor", "Administrasjon", "Sekretær"],
+    KULTUR: ["Kultur", "Kunst", "Musikk"],
+    KUNDESERVICE: ["Kundeservice", "Support", "Kundebehandling"],
+    LAGER_OG_INDUSTRI: ["Lager", "Industri", "Produksjon"],
+    RENHOLD: ["Renhold", "Vask", "Rengjøring"],
+    RESTAURANT_OG_KAFE: ["Restaurant", "Kafé", "Servering"],
+    TRANSPORT: ["Transport", "Sjåfør", "Logistikk"],
+    TURISME: ["Turisme", "Reise", "Guide"],
+    UTENDØRS: ["Utendørs", "Friluft"],
+};
 
 export async function generateMetadata() {
     const pageTitle = getMetadataTitle("Sommerjobben 2025");
@@ -31,14 +49,33 @@ export default async function Page({
     const postcodesResult = await fetchCachedPostcodes();
     const postcodes = postcodesResult.data || [];
     console.log(searchParams);
+    const searchKeywords: string[] = SummerJobKeywords.SOMMERJOBB;
 
-    const ads = [
+    const searchResult = await fetchCachedSimplifiedElasticSearch(
+        toApiQuery(createQuery({ q: searchKeywords, v: "5" })),
+    );
+    /**
+     * For testing, men merk at alle søkeord bruker OR operator akkurat nå.
+     * searchKeywords = Array.from(new Set([...searchKeywords, ...SummerJobKeywords.UTENDØRS])) // Legger til utendørs
+     * searchKeywords = searchKeywords.filter(word => !SummerJobKeywords.TURISME.includes(word)); // Fjerner turisme søkeord
+     */
+
+    const ads: SommerjobbAd[] = searchResult?.data?.ads.map((ad) => ({
+        uuid: ad.uuid,
+        title: ad.title,
+        description: ad.description || "",
+        employer: {
+            name: ad.employer.name || "",
+        },
+        location: ad.locationList?.[0]?.city || "",
+        applicationDue: ad.applicationDue || "",
+    })) || [
         {
             uuid: "475ac49a-8d46-46bb-a6c7-fa7b9845580a",
             title: "Turisthyttemedarbeider sommer 2025",
             description:
                 "Medarbeider og sommerhjelp søkes til sesongen 2025. Det største behovet for ansatte er fra 8. Juli og så langt utover august som mulig. (Vi stenger 9. Oktober) Tidligere erfaring fra servicejobb ell...",
-            employerName: "Spiterstulen Turisthytte",
+            employer: { name: "Spiterstulen Turisthytte" },
             location: "Lom",
             applicationDue: "03.04.2025",
         },
@@ -47,7 +84,7 @@ export default async function Page({
             title: "Meningsfull og spennende sommerjobb",
             description:
                 "Vil du ha sommerjobb på et verdens beste bosenter? Vi søker engasjerte ferievikarer som ønsker å jobbe i tidsrommet uke 25 -33. Er du student under helsefaglig utdanning, sykepleiere og hel...",
-            employerName: "Bosenter AS",
+            employer: { name: "Bosenter AS" },
             location: "Oslo, Bergen, Stavanger, m.fl.",
             applicationDue: "2025-05-06T00:00:00",
         },
@@ -56,7 +93,7 @@ export default async function Page({
             title: "Hunderfossen Hotel & Resort",
             description:
                 "Hunderfossen Hotell & Resort ligger midt i hjertet av alle eventyrlige opplevelser på Hunderfossen og har overnatting som passer for alle reisende. 40 komfortable hotellrom, 30 helårs bekve...",
-            employerName: "Hunderfossen Hotel & Resort",
+            employer: { name: "Hunderfossen Hotel & Resort" },
             location: "Fåberg",
             applicationDue: "Snarest",
         },
@@ -65,7 +102,7 @@ export default async function Page({
             title: "Din beste sommerjobb",
             description:
                 "Er du mellom 13 – 19 år, bosatt i bydel Nordre Aker og ønsker en meningsfull sommer? Kanskje dette er sommerjobben for deg. Det er viktig at du er tilgjengelig for å jobbe hele uker av gangen. Arbei...",
-            employerName: "HIMALAYA TANDORI AS",
+            employer: { name: "HIMALAYA TANDORI AS" },
             location: "Horten",
             applicationDue: "2025-05-10",
         },
@@ -74,7 +111,7 @@ export default async function Page({
             title: "UngJobb sommerjobb 2025",
             description:
                 "Stilling: Servitør / Kjøkkenhjelp / Bartender Oppvask Tid: Sommeren 2025 Sted: Horten.Vestfold. Travel og Trivelig Restaurant. Alderskrav: Minimum 20 år (unntak for elever som går salg og ser...",
-            employerName: "Forebyggende enhet, Oslo kommune, Bydel Nordre Aker",
+            employer: { name: "Forebyggende enhet, Oslo kommune, Bydel Nordre Aker" },
             location: "Oslo",
             applicationDue: "2025-05-09T00:00:00",
         },
@@ -83,7 +120,7 @@ export default async function Page({
             title: "Vil du ha en sommerjobb med mening?",
             description:
                 "Er du sykepleier, vernepleier, helsefagarbeider, assistent, student eller bare har lyst til å jobbe med mennesker som trenger omsorg, er du velkommen til å søke jobb hos oss. Vi søker engasjerte og m...",
-            employerName: "Spiterstulen Turisthytte",
+            employer: { name: "Spiterstulen Turisthytte" },
             location: "Lom",
             applicationDue: "Søk Asap",
         },
@@ -92,7 +129,7 @@ export default async function Page({
             title: "Turisthyttemedarbeider sommer 2025",
             description:
                 "Bo- og miljøtjenesten har behov for flinke sommervikarer til alle våre enheter i ukene 25-33. Stillingsprosent og arbeidstid vil variere ved de ulike enhetene. Vi har arbeid både på dag, kveld o...",
-            employerName: "Spiterstulen Turisthytte",
+            employer: { name: "Spiterstulen Turisthytte" },
             location: "Lom",
             applicationDue: "2025-05-19T00:00:00",
         },
@@ -101,7 +138,7 @@ export default async function Page({
             title: "Meningsfull og spennende sommerjobb",
             description:
                 "Vi søker medisinstudenter til sommerjobb i BUP Grenland Sør, BUP Vestmar og BUP Notodden. Vil du være med på laget vårt for å bedre psykisk helse for barn og unge? Liker du variasjon i arbeide...",
-            employerName: "Odinsvei bosenter",
+            employer: { name: "Odinsvei bosenter" },
             location: "Nesttun",
             applicationDue: "2025-04-30T00:00:00",
         },
@@ -109,7 +146,7 @@ export default async function Page({
 
     let data = {
         ads: ads,
-        totalAds: 32,
+        totalAds: searchResult?.data?.totalAds || 0,
     };
 
     if (searchParams.jobb === "Utendørs") {

--- a/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
@@ -917,6 +917,7 @@ const elasticSearchRequestBody = (query: ExtendedQuery) => {
                 "categoryList.name",
                 "categoryList.categoryType",
                 "properties.keywords",
+                "properties.adtext",
                 "properties.searchtagsai",
                 "properties.searchtags.label",
                 "properties.searchtags.score",

--- a/src/server/schemas/stillingSearchSchema.ts
+++ b/src/server/schemas/stillingSearchSchema.ts
@@ -35,6 +35,7 @@ const PropertySchema = z.object({
     searchtags: z.array(SearchTagSchema).optional(),
     searchtagsai: z.array(z.string()).optional(),
     keywords: z.string().optional(),
+    adtext: z.string(),
     adtextFormat: z.string().optional(),
     employer: z.string().optional(),
     remote: z.string().optional(),
@@ -275,6 +276,7 @@ export function mapHits(data: HitRaw) {
         published: data._source.published,
         jobTitle: data._source.properties?.jobtitle,
         title: data._source.title,
+        description: data._source.properties?.adtext, // brukt for sommerjobb, kan fjernes hvis sommerjobb er fjernet
         searchtags: data._source.properties?.searchtags,
         searchtagsai: data._source.properties?.searchtagsai,
         applicationDue: data._source.properties?.applicationdue,


### PR DESCRIPTION
Jah, kan vel si dette er første versjon av søket. Elastic search er ganske tungvint slik vi har satt det opp (vi har "simplifiedElasticSearch" og "simplifiedResponse"  eller noe lignende som betyr også at ting ikke er så fleksibelt da.

Uansett tenker at dette er greit første steg for å få data inn på sommerjobb siden ihvertfall. Dere kan også bruke det ved å legge til de nye kategoriene. Har laget SummerJobKeywords som første utkast av søkeord for de forskjellige kategoriene (mesteparten er generert av AI)

const SummerJobKeywords = {
    SOMMERJOBB: ["Sommerjobb", "Sommervikar", "Sesongarbeid"],
    BUTIKK: ["Butikk", "Salg", "Detaljhandel"],
    HELSE: ["Helse", "Sykepleier", "Lege"],
    KONTOR: ["Kontor", "Administrasjon", "Sekretær"],
    KULTUR: ["Kultur", "Kunst", "Musikk"],
    KUNDESERVICE: ["Kundeservice", "Support", "Kundebehandling"],
    LAGER_OG_INDUSTRI: ["Lager", "Industri", "Produksjon"],
    RENHOLD: ["Renhold", "Vask", "Rengjøring"],
    RESTAURANT_OG_KAFE: ["Restaurant", "Kafé", "Servering"],
    TRANSPORT: ["Transport", "Sjåfør", "Logistikk"],
    TURISME: ["Turisme", "Reise", "Guide"],
    UTENDØRS: ["Utendørs", "Friluft"],
};

Du kan da leke med "searchKeywords" (`src/app/sommerjobb/page.tsx`) og legge til eller trekke fra disse som dere vil for testing. Akkurat nå bruker vi OR for alle søkeordene. Jeg må grave dypere ned ElasticSearch for å finne ut mer eller eventuelt skippe og gå direkte til AI. Uansett, forslag på hvordan dere kan legge til og fjerne søkeord

```searchKeywords = Array.from(new Set([...searchKeywords, ...SummerJobKeywords.UTENDØRS])) // Legger til utendørs søkeord```
```searchKeywords = searchKeywords.filter(word => !SummerJobKeywords.TURISME.includes(word)); // Fjerner turisme søkeord```