### PR TITLE
Sort by _id if everything else is equal, to have determinstic order int the results

### DIFF
--- a/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
@@ -32,7 +32,8 @@ type Sort =
               [key: string]: string | number | boolean;
           } & Record<string, unknown>;
       }
-    | "_score";
+    | "_score"
+    | "_id";
 
 interface TermQuery {
     term?: {
@@ -1383,6 +1384,7 @@ const elasticSearchRequestBody = (query: ExtendedQuery) => {
                     },
                 },
                 "_score",
+                "_id",
             ],
         };
     }


### PR DESCRIPTION
Add _id as last param when sorting the OpenSearch result, to make sure the order is deterministic. This is needed comparing old and new search instances.