### PR TITLE
Unngår bruk av default description

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,6 @@ import { localFont } from "@/app/_common/utils/loadFont";
 import * as actions from "@/app/stillinger/_common/actions";
 import { Metadata } from "@/app/stillinger/stilling/_data/types";
 import { ReactElement } from "react";
-import { defaultMetadataDescription } from "@/app/metadata";
 import App from "./App";
 import Providers from "./Providers";
 import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
@@ -28,9 +27,7 @@ export async function generateMetadata(): Promise<Metadata> {
             template: "%s - arbeidsplassen.no",
             default: "Arbeidsplassen.no",
         },
-        description: defaultMetadataDescription,
         openGraph: {
-            description: defaultMetadataDescription,
             images: [
                 {
                     url: "https://arbeidsplassen.nav.no/images/arbeidsplassen-open-graph.png",

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -1,2 +1,0 @@
-export const defaultMetadataDescription: string =
-    "Finn din neste jobb i en av Norges største samlinger av stillinger. Her finner du jobber fra alle bransjer i markedet";

--- a/src/app/sommerjobb/page.tsx
+++ b/src/app/sommerjobb/page.tsx
@@ -46,8 +46,6 @@ export async function generateMetadata() {
         title: pageTitle,
         description: description,
         openGraph: {
-            title: pageTitle,
-            description: description,
             images: [
                 {
                     url: "https://arbeidsplassen.nav.no/images/sommerjobb-open-graph.png",

--- a/src/app/stillinger/(sok)/page.tsx
+++ b/src/app/stillinger/(sok)/page.tsx
@@ -23,15 +23,9 @@ import { SearchResult } from "@/app/stillinger/_common/types/SearchResult";
 const MAX_QUERY_SIZE = 10000;
 
 export async function generateMetadata() {
-    const pageTitle = "Ledige stillinger";
-    const metaDesc = "Søk etter ledige jobber. Her har vi samlet ledige stillinger fra hele Norge.";
     return {
-        title: pageTitle,
-        description: metaDesc,
-        openGraph: {
-            title: pageTitle,
-            description: metaDesc,
-        },
+        title: "Ledige stillinger",
+        description: "Søk etter ledige jobber. Her har vi samlet ledige stillinger fra hele Norge.",
     };
 }
 

--- a/src/app/stillinger/stilling/[id]/page.tsx
+++ b/src/app/stillinger/stilling/[id]/page.tsx
@@ -28,10 +28,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {
         title: getStillingTitle(title),
         description: getStillingDescription(data),
-        openGraph: {
-            title: getStillingTitle(title),
-            description: getStillingDescription(data),
-        },
         robots: response && data?.status !== "ACTIVE" ? "noindex" : "",
         alternates: {
             canonical: isFinn && data?.sourceUrl ? data?.sourceUrl : "",

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/page.tsx
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/page.tsx
@@ -30,10 +30,6 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
     return {
         title: getSuperraskTitle(stilling),
         description: getStillingDescription(stilling),
-        openGraph: {
-            title: getSuperraskTitle(stilling),
-            description: getStillingDescription(stilling),
-        },
         robots: stilling && stilling.status !== "ACTIVE" ? "noindex" : "",
     };
 }


### PR DESCRIPTION
- Fjerner default description, fordi denne ga nesten alle artikler samme meta description. Det er neppe bra for SEO, og gir heller ingen mening med en generisk description på alle sider
- Fjerner også oppsett for openGraph.description siden nextjs fikser det for oss