### PR TITLE
Only request ads with correct ID and increase alarm theresholds

### DIFF
--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -36,7 +36,7 @@ spec:
         namespace: "teampam"
         severity: critical
 
-    - alert: "[pam-stillingsok] Elastic search virker treg (over 750 ms gjennomsnittlig responstid)"
+    - alert: "[pam-stillingsok] OpenSearch virker treg (over 750 ms gjennomsnittlig responstid)"
       expr: sum(rate(elastic_search_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.75
       for: 5m
       annotations:
@@ -45,7 +45,7 @@ spec:
         namespace: "teampam"
         severity: warning
 
-    - alert: "[pam-stillingsok] Elastic search suggestions virker treg (over 300 ms gjennomsnittlig responstid)"
+    - alert: "[pam-stillingsok] OpenSearch suggestions virker treg (over 300 ms gjennomsnittlig responstid)"
       expr: sum(rate(suggestion_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.3
       for: 5m
       annotations:
@@ -54,7 +54,7 @@ spec:
         namespace: "teampam"
         severity: warning
 
-    - alert: "[pam-stillingsok] Ingen kall til elastic search på lang tid, er søket nede?"
+    - alert: "[pam-stillingsok] Ingen kall til OpenSearch på lang tid, er søket nede?"
       expr: sum(rate(elastic_search_requests{app="pam-stillingsok"}[3m])) == 0
       for: 10m
       annotations:
@@ -72,20 +72,20 @@ spec:
         namespace: "teampam"
         severity: critical
 
-    - alert: "[pam-stillingsok] Kall til elastic search feiler"
+    - alert: "[pam-stillingsok] Kall til OpenSearch feiler"
       expr: (100 * (sum(rate(elastic_search_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(elastic_search_requests{app="pam-stillingsok"}[3m])))) > 5
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor så mange kall til elastic search feiler"
+        action: "Sjekk loggene for å se hvorfor så mange kall til OpenSearch feiler"
       labels:
         namespace: "teampam"
         severity: critical
 
-    - alert: "[pam-stillingsok] Kall til elastic search suggestions feiler"
+    - alert: "[pam-stillingsok] Kall til OpenSearch suggestions feiler"
       expr: (100 * (sum(rate(suggestion_requests{app="pam-stillingsok", result="failure"}[3m]))) / (sum(rate(suggestion_requests{app="pam-stillingsok"}[3m])))) > 5
       for: 3m
       annotations:
-        action: "Sjekk loggene for å se hvorfor så mange kall til elastic search suggestions feiler"
+        action: "Sjekk loggene for å se hvorfor så mange kall til OpenSearch suggestions feiler"
       labels:
         namespace: "teampam"
         severity: critical

--- a/.nais/alerts.yml
+++ b/.nais/alerts.yml
@@ -36,18 +36,18 @@ spec:
         namespace: "teampam"
         severity: critical
 
-    - alert: "[pam-stillingsok] Elastic search virker treg (over 500 ms gjennomsnittlig responstid)"
-      expr: sum(rate(elastic_search_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.5
-      for: 3m
+    - alert: "[pam-stillingsok] Elastic search virker treg (over 750 ms gjennomsnittlig responstid)"
+      expr: sum(rate(elastic_search_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.75
+      for: 5m
       annotations:
         action: "Sjekk loggene for å se hvorfor søket er tregt"
       labels:
         namespace: "teampam"
         severity: warning
 
-    - alert: "[pam-stillingsok] Elastic search suggestions virker treg (over 200 ms gjennomsnittlig responstid)"
-      expr: sum(rate(suggestion_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.2
-      for: 3m
+    - alert: "[pam-stillingsok] Elastic search suggestions virker treg (over 300 ms gjennomsnittlig responstid)"
+      expr: sum(rate(suggestion_duration_seconds_sum{app="pam-stillingsok"}[3m])) > 0.3
+      for: 5m
       annotations:
         action: "Sjekk loggene for å se hvorfor søkforslag er tregt"
       labels:

--- a/src/app/stillinger/stilling/_data/adDataActions.tsx
+++ b/src/app/stillinger/stilling/_data/adDataActions.tsx
@@ -8,6 +8,7 @@ import {
 import { notFound } from "next/navigation";
 import { logZodError } from "@/app/stillinger/_common/actions/LogZodError";
 import { isNotFoundError } from "next/dist/client/components/not-found";
+import { validate as uuidValidate } from "uuid";
 
 // Expose only necessary data to client
 const sourceIncludes = [
@@ -75,6 +76,10 @@ const sourceIncludes = [
  * @returns Promise<Response<StillingDetaljer>>
  */
 export async function getAdData(id: string): Promise<StillingDetaljer> {
+    if (!uuidValidate(id)) {
+        notFound();
+    }
+
     try {
         const headers = await getDefaultHeaders();
         const res = await fetch(`${process.env.PAMSEARCHAPI_URL}/api/ad/${id}?_source_includes=${sourceIncludes}`, {
@@ -87,7 +92,7 @@ export async function getAdData(id: string): Promise<StillingDetaljer> {
         }
 
         if (!res.ok) {
-            const errorMessage = `Stillingssøk med id ${id} feilet, status: ${res.status}`;
+            const errorMessage = `Hent stilling med id ${id} feilet, status: ${res.status}`;
             logger.error(errorMessage);
             return Promise.reject(errorMessage);
         }


### PR DESCRIPTION
* Don't try to fetch ads if id is not valid uuid - this will also stop the fetch call from reporting errors
* Increase OpenSearch thresholds, as peaks that hit current thresholds are normal