### PR TITLE
Lägg till min_score/cut-offs för sök

### DIFF
--- a/src/app/stillinger-3/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger-3/(sok)/_utils/elasticSearchRequestBody.ts
@@ -959,6 +959,7 @@ const elasticSearchRequestBody = async (query: ExtendedQuery) => {
         from: from || 0,
         size: size && ALLOWED_NUMBER_OF_RESULTS_PER_PAGE.includes(size) ? size : SEARCH_CHUNK_SIZE,
         track_total_hits: true,
+        min_score: 0.7,
         // query: mainQueryTemplateFunc(q),
         query: hybridQuery,
 

--- a/src/app/stillinger-3/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger-3/(sok)/_utils/elasticSearchRequestBody.ts
@@ -908,7 +908,6 @@ const elasticSearchRequestBody = async (query: ExtendedQuery) => {
         international,
         withinDrivingDistance,
         // explain,
-        k = 10,
     } = query;
     let { sort, q } = query;
 
@@ -933,7 +932,7 @@ const elasticSearchRequestBody = async (query: ExtendedQuery) => {
             return {
                 knn: {
                     compositeAdVector: {
-                        k: k,
+                        min_score: 1.64,
                         vector: val.embedding,
                         filter: {
                             term: {

--- a/src/app/stillinger-4/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger-4/(sok)/_utils/elasticSearchRequestBody.ts
@@ -838,6 +838,7 @@ const elasticSearchRequestBody = (query: ExtendedQuery) => {
         from: from || 0,
         size: size && ALLOWED_NUMBER_OF_RESULTS_PER_PAGE.includes(size) ? size : SEARCH_CHUNK_SIZE,
         track_total_hits: true,
+        min_score: 0.7,
         query: mainQueryTemplateFunc(q),
         post_filter: {
             bool: {

--- a/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
@@ -838,6 +838,7 @@ const elasticSearchRequestBody = (query: ExtendedQuery) => {
         from: from || 0,
         size: size && ALLOWED_NUMBER_OF_RESULTS_PER_PAGE.includes(size) ? size : SEARCH_CHUNK_SIZE,
         track_total_hits: true,
+        min_score: 0.7,
         query: mainQueryTemplateFunc(q),
         post_filter: {
             bool: {


### PR DESCRIPTION
Lägger en cut-off på

*  0.7 för det gamla söket - det är i princip aldrig några relevanta resultat på score lägre än det
* 1.64 för vektorsöket - över det så är det nästan bara relevanta träff