### PR TITLE
Add prefix length to fuzzy match to reduce matches

### DIFF
--- a/src/app/stillinger-3/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger-3/(sok)/_utils/elasticSearchRequestBody.ts
@@ -773,7 +773,7 @@ function businessNameFreeTextSearchMatch(queries: string[]) {
                 query: q,
                 fuzziness: "AUTO",
                 max_expansions: 2,
-                prefix_length: 2,
+                prefix_length: 1,
                 operator: "and",
                 boost: 2,
             },

--- a/src/app/stillinger-3/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger-3/(sok)/_utils/elasticSearchRequestBody.ts
@@ -773,6 +773,7 @@ function businessNameFreeTextSearchMatch(queries: string[]) {
                 query: q,
                 fuzziness: "AUTO",
                 max_expansions: 2,
+                prefix_length: 2,
                 operator: "and",
                 boost: 2,
             },

--- a/src/app/stillinger-4/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger-4/(sok)/_utils/elasticSearchRequestBody.ts
@@ -772,6 +772,7 @@ function businessNameFreeTextSearchMatch(queries: string[]) {
                 query: q,
                 fuzziness: "AUTO",
                 max_expansions: 2,
+                prefix_length: 2,
                 operator: "and",
                 boost: 2,
             },

--- a/src/app/stillinger-4/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger-4/(sok)/_utils/elasticSearchRequestBody.ts
@@ -772,7 +772,7 @@ function businessNameFreeTextSearchMatch(queries: string[]) {
                 query: q,
                 fuzziness: "AUTO",
                 max_expansions: 2,
-                prefix_length: 2,
+                prefix_length: 1,
                 operator: "and",
                 boost: 2,
             },

--- a/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
@@ -772,6 +772,7 @@ function businessNameFreeTextSearchMatch(queries: string[]) {
                 query: q,
                 fuzziness: "AUTO",
                 max_expansions: 2,
+                prefix_length: 2,
                 operator: "and",
                 boost: 2,
             },

--- a/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
@@ -772,7 +772,7 @@ function businessNameFreeTextSearchMatch(queries: string[]) {
                 query: q,
                 fuzziness: "AUTO",
                 max_expansions: 2,
-                prefix_length: 2,
+                prefix_length: 1,
                 operator: "and",
                 boost: 2,
             },


### PR DESCRIPTION
Set prefix_length to 1 so that the first character in the input must match, reducing irrelevant matches, for example "python" -> "thon".
`prefix_length`
> The number of leading characters that are not considered in fuzziness. Default is 0.