### PR TITLE
Cookiebanner A/B test

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,234 @@
+# GitHub Copilot Instructions
+
+Disse instruksjonene gjelder for alle forslag Copilot gir i dette prosjektet.  
+Målet er konsekvent, typesikker og idiomatisk kode for **Next.js 14**, **TypeScript** og **Vitest** – uten bruk av `any`.
+
+---
+
+## Generelle retningslinjer
+
+- All kode skal være skrevet i **TypeScript** (ikke JavaScript).
+- Bruk **`type`** fremfor `interface` når du definerer typer.
+- **Aldri bruk `any`**. Dersom typer er usikre, bruk `unknown` og snevre inn via type guards eller validering (f.eks. Zod).
+- Følg **strict typing** i hele koden (ingen implicit `any`, unngå løse typer).
+- Bruk **beskrivende navn** for variabler og funksjoner.
+    - Unngå 1–2 bokstaver eller kryptiske forkortelser (`a`, `b`, `x`, `obj`, `acc`).
+    - Velg navn som gjør koden selvforklarende, også når man ser den utenfor kontekst.
+    - Bruk `totalCount` fremfor `cnt`, `userPreferences` fremfor `prefs`, osv.
+- Kommenter kode kun når det forklarer kompleks logikk eller begrunnelser/avvik.
+- Skriv små, gjenbrukbare komponenter. Trekk ut logikk i hooks/utils når hensiktsmessig.
+- Tilgjengelighet (WCAG): når du skriver UI, sørg for semantikk, labels, fokusrekkefølge og tastaturnavigasjon.
+
+---
+
+## Prosjektspesifikke rammer
+
+- **Next.js 14** med **App Router**.
+- **Functional components** med sterkt typede props.
+- Bruk `"use client"` **kun** når nødvendig (interaksjon, state, effects, nettleser-API).
+- Følg ESLint- og Prettier-regler (idiomatisk Next.js/React).
+- Datahenting følger Next.js-praksis: **React Server Components** og caching der egnet.
+- API-kall skal være **typeriktige** og valideres (f.eks. **Zod**). Behandle ukjente inputs som `unknown` → valider → transformer til sikre typer.
+
+---
+
+## Component style (React + TypeScript)
+
+**Hovedregel**
+- Bruk **funksjonsdeklarasjon** som standard for React-komponenter.
+- Bruk **`const` pilfunksjon** kun når du (1) bruker `React.memo`, (2) bruker `forwardRef`, (3) skriver **generiske** komponenter, eller (4) må sette `displayName` manuelt.
+
+**Krav**
+- Bruk `type` fremfor `interface` for props og hjelpe-typer.
+- **Aldri `any`**. Ved usikker type, bruk `unknown` og snevre inn via type guards/validering.
+- Oppgi eksplisitt returtype: `JSX.Element` (evt. `Promise<JSX.Element>` for async server-komponenter).
+- Bevar Next.js-konvensjoner for `page.tsx`, `layout.tsx` m.m. (default export).
+
+### Standard: Funksjonsdeklarasjon
+```tsx
+type SectionProps = {
+  title: string;
+  children?: React.ReactNode;
+};
+
+export default function Section({ title, children }: SectionProps): JSX.Element {
+  return <section aria-label={title}>{children}</section>;
+}
+```
+
+### Unntak 1: `forwardRef` → `const` + pilfunksjon
+```tsx
+import { forwardRef } from "react";
+
+type ButtonProps = {
+  onClick?: () => void;
+  children?: React.ReactNode;
+};
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { onClick, children }: ButtonProps,
+  ref,
+): JSX.Element {
+  return (
+    <button ref={ref} type="button" onClick={onClick}>
+      {children}
+    </button>
+  );
+});
+
+Button.displayName = "Button";
+export default Button;
+```
+
+### Unntak 2: `memo` (+ valgfritt `forwardRef`) → `const` + pilfunksjon
+```tsx
+import { memo } from "react";
+
+type TagProps = {
+  label: string;
+};
+
+const Tag = memo(function Tag({ label }: TagProps): JSX.Element {
+  return <span>{label}</span>;
+});
+
+Tag.displayName = "Tag";
+export default Tag;
+```
+
+### Unntak 3: **Generisk** komponent → `const` + pilfunksjon
+```tsx
+type ListProps<T> = {
+  items: readonly T[];
+  renderItem: (item: T, index: number) => JSX.Element;
+  ariaLabel?: string;
+};
+
+const List = <T,>({ items, renderItem, ariaLabel }: ListProps<T>): JSX.Element => {
+  return (
+    <ul aria-label={ariaLabel}>
+      {items.map((item, index) => (
+        <li key={index}>{renderItem(item, index)}</li>
+      ))}
+    </ul>
+  );
+};
+
+export default List;
+```
+
+### Next.js Server Components: tillat `async` + funksjonsdeklarasjon
+```tsx
+// app/example/page.tsx
+export default async function Page(): Promise<JSX.Element> {
+  const data = await getData();
+  return <main>{data.title}</main>;
+}
+```
+
+### Client Components: bruk `use client` kun når nødvendig
+```tsx
+"use client";
+
+import { useState } from "react";
+
+type CounterProps = {
+  initial?: number;
+};
+
+export default function Counter({ initial = 0 }: CounterProps): JSX.Element {
+  const [value, setValue] = useState<number>(initial);
+  return (
+    <div>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue((v) => v + 1)}>
+        +
+      </button>
+    </div>
+  );
+}
+```
+
+### Returtyper og typing
+- **Returtype:** `JSX.Element` (ikke `ReactNode` som return-type); for async: `Promise<JSX.Element>`.
+- **Props:** bruk `type` (ikke `interface`).
+- **Null/undefined:** modeller eksplisitt i typer (f.eks. `children?: React.ReactNode`).
+- **Unngå `any`:** bruk `unknown` + innsnevring eller generiske typer.
+
+### Eksport
+- **Default export** i Next.js rutefiler (`page.tsx`, `layout.tsx`, osv.).
+- Ellers kan named exports brukes fritt i delte komponenter/utilities; unngå å blande stiler vilkårlig i samme mappe.
+
+---
+
+## Navigasjon og ruting (Next.js)
+
+- Bruk `next/link` for lenker og `next/navigation` for programmatisk navigasjon i App Router.
+- Unngå manuelle `window.location`-endringer i klientkomponenter uten god grunn.
+- Følg konvensjoner for filstruktur i `app/` (ruter, layouts, loading, error, route handlers).
+
+---
+
+## Datahåndtering, validering og feil
+
+- Alle eksterne data behandles som **ukjent input** (`unknown`), valideres (f.eks. Zod), og transformeres til trygge domene-typer.
+- Lag egne util-funksjoner/hooks for validering og mapping (unngå validering spredt i UI).
+- Feilhåndtering:
+    - Bruk Next.js `error.tsx`/`not-found.tsx` der relevant.
+    - Logg tekniske detaljer, vis brukervennlige feilmeldinger.
+    - Returnér tidlig ved valideringsfeil; ikke la usikre data sive videre.
+
+---
+
+## Testing (Vitest)
+
+- Bruk **Vitest** med Jest-lignende API (`describe`, `it`, `expect`).
+- Testfiler ligger ved siden av filen de tester:
+    - `Component.test.tsx` for komponenter
+    - `utils.test.ts` for hjelpefunksjoner
+- Test **typer, edge cases og realistiske scenarier** (unngå over-mocking).
+- For React-test: bruk `@testing-library/react` ved behov; test observerbar atferd fremfor implementasjon.
+- Legg til `typecheck`-skript (`tsc --noEmit`) i CI.
+
+---
+
+## Tilgjengelighet (WCAG)
+
+- Bruk semantiske elementer (`<button>`, `<nav>`, `<main>`, `<header>`, `<section>` med `aria-label` der nødvendig).
+- Sørg for fokusrekkefølge, fokusindikatorer og tastaturnavigasjon.
+- Tekstalternativer for ikoner/bilder (`alt`, `aria-hidden`, `aria-label`).
+- Skjemaer: riktig kobling mellom label og input, feilmeldinger knyttet til felt.
+
+---
+
+## Mappestruktur (anbefalt)
+
+```
+src/
+  app/                # Next.js App Router
+  components/         # Delte UI-komponenter
+  lib/                # Domene/forretningslogikk, API-klienter, validering (Zod)
+  hooks/              # Delte React-hooks
+  utils/              # Små hjelpefunksjoner uten React
+  test/               # Evt. felles testverktøy/mocks
+```
+
+---
+
+## Pull Requests
+
+- Følg sjekklisten i PR-malen.
+- Bruk gjerne **Copilot Actions** → *"Generate summary of the changes in this pull request"* for en detaljert AI-oppsummering som supplement til din egen beskrivelse.
+- Hold PR-er små og målrettede; beskriv breaking changes tydelig.
+
+---
+
+## Copilot—spesifikke føringer
+
+- Generer kun **TypeScript**.
+- Ikke foreslå `any`. Bruk `unknown` + innsnevring eller generics.
+- Foreslå **funksjonsdeklarasjon** for komponenter som standard; bruk `const`-pilfunksjon kun i unntakene angitt over (`memo`, `forwardRef`, generics, `displayName`).
+- Når inputtype er ukjent, foreslå Zod-skjema + parsing før bruk.
+- Foreslå tester (Vitest) sammen med nye utils/komponenter når det er naturlig.
+
+---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Hva endres?
+<!-- Kort beskrivelse  -->
+
+
+## Sjekkliste
+- [ ] Ingen bruk av `any` (bruk `unknown` + innsnevring der nødvendig)
+- [ ] `type` brukt fremfor `interface`
+- [ ] Streng typing (ingen implicit any / løse typer)
+- [ ] **Leselige variabelnavn brukt** (unngå 1–2 bokstaver og kryptiske navn som `a`, `b`, `x`, `obj`, `acc`)
+- [ ] **Komponentstil fulgt:** funksjonsdeklarasjon som standard; `const`-pilfunksjon kun ved `memo`, `forwardRef`, generiske komponenter eller behov for `displayName`
+- [ ] Next.js-konvensjoner fulgt (App Router, `next/link`, `next/navigation`, server actions der naturlig)
+- [ ] Tester (Vitest) lagt til/oppdatert (`*.test.ts(x)` ved siden av kildekoden)
+- [ ] Tilgjengelighet (WCAG) vurdert der det er UI-endringer
+- [ ] Jeg har lest/fulgt retningslinjene i [.github/copilot-instructions.md](./copilot-instructions.md)
+
+## Notater for reviewer
+<!-- Eventuelle avklaringer, oppfølging, TODO -->
+
+---
+
+💡 **Tips:**  
+Bruk gjerne **Copilot Actions** → *"Generate a summary of the changes in this pull request"* for å få en detaljert, AI-generert oppsummering som supplement til din egen beskrivelse.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ Applikasjonen henter stillinger fra en dokumentdatabase (OpenSearch) gjennom
 e-poster skjer gjennom applikasjonen [pam-aduser](https://github.com/navikt/pam-aduser).
 Navnet til innlogget bruker hentes fra [pam-aduser](https://github.com/navikt/pam-aduser).
 
+## Copilot Cheatsheet 🚀
+
+**Prosjektregler (Next.js 14 + TypeScript + Vitest)**
+
+- ✅ Bruk **TypeScript** (ikke JS)
+- ✅ Bruk **`type`** fremfor `interface`
+- ✅ **Aldri `any`** → bruk `unknown` + innsnevring/validering
+- ✅ **Komponentstil:**
+    - Funksjonsdeklarasjon som standard
+    - `const` pilfunksjon kun ved `memo`, `forwardRef`, generiske komponenter eller `displayName`
+- ✅ Next.js App Router-konvensjoner (`next/link`, `next/navigation`, `server actions`)
+- ✅ Test med **Vitest**, filer skal hete `*.test.ts(x)` og ligge ved siden av koden
+- ✅ Små, gjenbrukbare komponenter → del logikk i hooks/utils
+- ✅ **Leselige variabelnavn** (unngå korte navn som `a`, `b`, `x`, `obj`, `acc`)
+- ✅ Tilgjengelighet (WCAG) ivaretatt i UI
+
+📌 For detaljer, se [`copilot-instructions.md`](./.github/copilot-instructions.md).
+
 ## Før kjøring av applikasjonen lokalt
 
 ### Hvordan få tilgang til @navikt/arbeidsplassen-react og @navikt/arbeidsplassen-css

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,0 @@
-declare module "@navikt/arbeidsplassen-react";

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@azure/identity": "^4.10.1",
                 "@navikt/aksel-icons": "^7.30.1",
                 "@navikt/arbeidsplassen-css": "^8.5.0",
-                "@navikt/arbeidsplassen-react": "^8.6.5",
+                "@navikt/arbeidsplassen-react": "8.7.7",
                 "@navikt/arbeidsplassen-theme": "^6.1.0",
                 "@navikt/ds-css": "^7.30.1",
                 "@navikt/ds-react": "^7.30.1",
@@ -2011,9 +2011,9 @@
             "license": "ISC"
         },
         "node_modules/@navikt/arbeidsplassen-react": {
-            "version": "8.6.5",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidsplassen-react/8.6.5/ab1620029556c56313603e265d4ec4546834c970",
-            "integrity": "sha512-cGacn7zcgj6BoM7pC6I4M3R36MmpuTlv64xik9kI6AKSDo/N8hEJLV7Y8klePAxnJdmkStL5wuc9lY2tNEhO7g==",
+            "version": "8.7.7",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidsplassen-react/8.7.7/15f0db13237e0428adeb00ac03e23899aedbfa1c",
+            "integrity": "sha512-Uj252/J5PJ3jwzLkPFN4Y1MaLe5eVwmwm8qIigRhSzUoczpatza9m52LJ1/kKYWMFbSw6SVka9gElM54UJVzog==",
             "license": "ISC",
             "dependencies": {
                 "@babel/polyfill": "^7.12.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@azure/identity": "^4.10.1",
         "@navikt/aksel-icons": "^7.30.1",
         "@navikt/arbeidsplassen-css": "^8.5.0",
-        "@navikt/arbeidsplassen-react": "^8.6.5",
+        "@navikt/arbeidsplassen-react": "^8.7.7",
         "@navikt/arbeidsplassen-theme": "^6.1.0",
         "@navikt/ds-css": "^7.30.1",
         "@navikt/ds-react": "^7.30.1",

--- a/src/app/(artikler)/informasjonskapsler/Informasjonskapsler.tsx
+++ b/src/app/(artikler)/informasjonskapsler/Informasjonskapsler.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useRef, useState } from "react";
 import { Box, BodyLong, Heading, Link as AkselLink, List, Button, HGrid } from "@navikt/ds-react";
 import NextLink from "next/link";
 import CookieBannerContext, { CookieBannerContextType } from "@/app/_common/cookie-banner/CookieBannerContext";
-import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
+import { getConsentValues, getUserActionTakenValue } from "@navikt/arbeidsplassen-react";
 
 interface ConsentValues {
     consent?: {
@@ -42,8 +42,8 @@ function Informasjonskapsler({ consentValues, userActionTaken }: Informasjonskap
 
     useEffect(() => {
         if (!showCookieBanner) {
-            setLocalConsentValues(CookieBannerUtils.getConsentValues());
-            setLocalUserActionTaken(CookieBannerUtils.getUserActionTakenValue());
+            setLocalConsentValues(getConsentValues());
+            setLocalUserActionTaken(getUserActionTakenValue());
         }
     }, [showCookieBanner]);
 

--- a/src/app/(artikler)/informasjonskapsler/page.tsx
+++ b/src/app/(artikler)/informasjonskapsler/page.tsx
@@ -1,19 +1,19 @@
 import Informasjonskapsler from "@/app/(artikler)/informasjonskapsler/Informasjonskapsler";
 import { cookies } from "next/headers";
-import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
+import { ConsentValues, getConsentValues, getUserActionTakenValue } from "@navikt/arbeidsplassen-react";
 
 export const metadata = {
     title: "Informasjonskapsler på arbeidsplassen.no",
 };
 
 interface ConsentData {
-    consentValues: Record<string, string>;
+    consentValues: ConsentValues;
     userActionTaken: boolean | null;
 }
 
 export async function getConsentData(cookies: string): Promise<ConsentData> {
-    const consentValues = CookieBannerUtils.getConsentValues(cookies);
-    const userActionTaken = CookieBannerUtils.getUserActionTakenValue(cookies);
+    const consentValues = getConsentValues(cookies);
+    const userActionTaken = getUserActionTakenValue(cookies);
 
     return {
         consentValues,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,8 +14,9 @@ import { configureAnalytics } from "@/app/_common/umami";
 type AppProps = {
     userActionTaken: boolean;
     children: ReactNode;
+    cookieBannerVariant?: "A" | "B";
 };
-function App({ userActionTaken, children }: AppProps) {
+function App({ userActionTaken, children, cookieBannerVariant }: AppProps) {
     configureAnalytics();
     useEffect(() => {
         googleTranslateWorkaround();
@@ -29,7 +30,7 @@ function App({ userActionTaken, children }: AppProps) {
 
     return (
         <div id="app">
-            <CookieBanner />
+            <CookieBanner cookieBannerVariant={cookieBannerVariant} />
             <SkipLink href="#main-content" />
             <div className="arb-push-footer-down">
                 <Axe />

--- a/src/app/_common/cookie-banner/CookieBanner.tsx
+++ b/src/app/_common/cookie-banner/CookieBanner.tsx
@@ -1,9 +1,10 @@
 import React, { useRef } from "react";
-import { CookieBanner as ArbeidsplassenCookieBanner } from "@navikt/arbeidsplassen-react";
 import { useCookieBanner } from "@/app/_common/cookie-banner/CookieBannerContext";
-import { onConsentChanged } from "@/app/_common/umami";
+import { onConsentChanged, track } from "@/app/_common/umami";
+import { CookieBannerA } from "@navikt/arbeidsplassen-react";
+import { CookieBannerB } from "@navikt/arbeidsplassen-react";
 
-export default function CookieBanner() {
+export default function CookieBanner({ cookieBannerVariant = "A" }: { cookieBannerVariant?: "A" | "B" }) {
     const { closeCookieBanner, showCookieBanner, setShowCookieBanner } = useCookieBanner();
     const bannerRef = useRef<HTMLDivElement>(null);
 
@@ -11,15 +12,37 @@ export default function CookieBanner() {
 
     return (
         <div ref={bannerRef}>
-            <ArbeidsplassenCookieBanner
-                headingLevel="2"
-                bannerRef={bannerRef}
-                onClose={() => {
-                    closeCookieBanner();
-                    setShowCookieBanner(false);
-                    onConsentChanged();
-                }}
-            />
+            {cookieBannerVariant === "A" && (
+                <CookieBannerA
+                    headingLevel="2"
+                    getUrl={() => window.location.pathname}
+                    variant="A"
+                    onAcceptedAllTrack={(payload) => {
+                        track("Cookiebanner – Godta alle", payload);
+                    }}
+                    onClose={() => {
+                        closeCookieBanner();
+                        setShowCookieBanner(false);
+                        onConsentChanged();
+                    }}
+                />
+            )}
+
+            {cookieBannerVariant === "B" && (
+                <CookieBannerB
+                    headingLevel="2"
+                    getUrl={() => window.location.pathname}
+                    variant="B"
+                    onAcceptedAllTrack={(payload) => {
+                        track("Cookiebanner – Godta alle", payload);
+                    }}
+                    onClose={() => {
+                        closeCookieBanner();
+                        setShowCookieBanner(false);
+                        onConsentChanged();
+                    }}
+                />
+            )}
         </div>
     );
 }

--- a/src/app/_common/cookie-banner/CookieBannerContext.tsx
+++ b/src/app/_common/cookie-banner/CookieBannerContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useState, useEffect, useContext, ReactNode, useRef, useMemo } from "react";
-import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
+import { getUserActionTakenValue } from "@navikt/arbeidsplassen-react";
 
 export interface CookieBannerContextType {
     showCookieBanner: boolean;
@@ -21,7 +21,7 @@ export function CookieBannerProvider({ children, initialState = false }: CookieB
 
     useEffect(() => {
         // Check if user has already made a choice about cookies
-        const hasMadeChoice = CookieBannerUtils.getUserActionTakenValue();
+        const hasMadeChoice = getUserActionTakenValue();
         setShowCookieBanner(!hasMadeChoice);
     }, []);
 

--- a/src/app/_common/header/Header.test.ts
+++ b/src/app/_common/header/Header.test.ts
@@ -8,7 +8,7 @@ describe("getActiveMenuItem", () => {
     });
 
     it("should return no active menu item", () => {
-        expect(getActiveMenuItem("/sommerjobb/something")).toBe("");
+        expect(getActiveMenuItem("/sommerjobb/something")).toBe(undefined);
     });
 
     it("should return 'ledige-stillinger' as active menu item", () => {
@@ -20,7 +20,7 @@ describe("getActiveMenuItem", () => {
     });
 
     it("should return no active menu item", () => {
-        expect(getActiveMenuItem("/bedrift")).toBe("");
+        expect(getActiveMenuItem("/bedrift")).toBe(undefined);
     });
 });
 

--- a/src/app/_common/header/Header.tsx
+++ b/src/app/_common/header/Header.tsx
@@ -1,5 +1,9 @@
 import React, { useContext } from "react";
-import { Header as ArbeidsplassenHeader } from "@navikt/arbeidsplassen-react";
+import {
+    Active,
+    AuthenticationStatus as ArbeidsplassenAuthenticationStatus,
+    Header as ArbeidsplassenHeader,
+} from "@navikt/arbeidsplassen-react";
 import COMPANY_PATHS from "@/app/_common/header/companyPaths";
 import { usePathname } from "next/navigation";
 import {
@@ -7,16 +11,18 @@ import {
     AuthenticationStatus,
 } from "@/app/stillinger/_common/auth/contexts/AuthenticationProvider";
 
-export function getActiveMenuItem(pathname: string): string {
+export function getActiveMenuItem(pathname: string): Active | undefined {
     if (pathname === "/sommerjobb") {
         return "sommerjobb";
     } else if (pathname.startsWith("/stillinger")) {
         return "ledige-stillinger";
     }
-    return "";
+    return undefined;
 }
 
-export function getHeaderAuthenticationStatus(authenticationStatus: string | undefined): string {
+export function getHeaderAuthenticationStatus(
+    authenticationStatus: string | undefined,
+): ArbeidsplassenAuthenticationStatus {
     if (authenticationStatus === AuthenticationStatus.IS_AUTHENTICATED) {
         return "is-authenticated";
     } else if (authenticationStatus === AuthenticationStatus.NOT_AUTHENTICATED) {

--- a/src/app/_common/umami/events.ts
+++ b/src/app/_common/umami/events.ts
@@ -1,3 +1,4 @@
+export type CookieBannerVariant = "A" | "B";
 export type Events = {
     /** Klikk på lenke til karriereveiledning fra forsiden */
     "Forside klikk karriereveiledning": undefined;
@@ -18,6 +19,11 @@ export type Events = {
         to: number;
         pageBefore: number;
         pageAfter: number;
+    };
+
+    "Cookiebanner – Godta alle": {
+        variant: CookieBannerVariant;
+        url: string;
     };
 
     // TODO: flere eventtyper her

--- a/src/app/_common/umami/index.ts
+++ b/src/app/_common/umami/index.ts
@@ -1,7 +1,7 @@
 import { bindGlobals, startTracking, track, trackPageview, trackerStateChanged } from "./track";
 import type { EventName, EventPayload } from "./events";
 import { getWebsiteId } from "@/app/_common/umami/getWebsiteId";
-import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
+import { getConsentValues } from "@navikt/arbeidsplassen-react";
 
 /**
  * Konfigurerer Umami analytics med nødvendige globale funksjoner og starter sporing.
@@ -9,7 +9,7 @@ import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
  */
 export const configureAnalytics = (): void => {
     bindGlobals(
-        () => CookieBannerUtils.getConsentValues(),
+        () => getConsentValues(),
         () => getWebsiteId(),
     );
 

--- a/src/app/_common/umami/umamiTracking.ts
+++ b/src/app/_common/umami/umamiTracking.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { getWebsiteId } from "./getWebsiteId";
-import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
+import { getConsentValues } from "@navikt/arbeidsplassen-react";
 
 export interface UmamiTrackingData {
     [key: string]: string | number;
@@ -9,7 +9,7 @@ export interface UmamiTrackingData {
 
 export function umamiTracking(name?: string, data?: UmamiTrackingData) {
     // Dont track if not agreed
-    const consentValues = CookieBannerUtils.getConsentValues();
+    const consentValues = getConsentValues();
     if (!consentValues.analyticsConsent) {
         return;
     }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { BodyLong, Heading, VStack } from "@navikt/ds-react";
-import { WorriedFigure } from "@navikt/arbeidsplassen-react";
+import { getUserActionTakenValue, WorriedFigure } from "@navikt/arbeidsplassen-react";
 import React, { ReactElement, useEffect, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
 import App from "@/app/App";
 import { localFont } from "@/app/_common/utils/loadFont";
-import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }): ReactElement {
     const [userActionTaken, setUserActionTaken] = useState<boolean>(false);
@@ -15,7 +14,7 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
     }, [error]);
 
     useEffect(() => {
-        setUserActionTaken(CookieBannerUtils.getUserActionTakenValue() ?? false);
+        setUserActionTaken(getUserActionTakenValue() ?? false);
     }, []);
 
     return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import "@navikt/ds-css/dist/global/tokens.css";
 import "@navikt/ds-css/dist/global/reset.css";
 import "@navikt/ds-css/dist/global/baseline.css";
@@ -15,9 +15,9 @@ import { Metadata } from "@/app/stillinger/stilling/_data/types";
 import { ReactElement } from "react";
 import App from "./App";
 import Providers from "./Providers";
-import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
 import ScrollTracker from "@/app/_common/umami/ScrollTracker";
 import { UtmParamsHandler } from "@/app/_common/trackers/UtmParamsHandler";
+import { getUserActionTakenValue } from "@navikt/arbeidsplassen-react";
 
 export const metadata: Metadata = {
     title: {
@@ -53,13 +53,17 @@ export default async function RootLayout({ children }: RootLayoutProps): Promise
         .getAll()
         .map((c) => `${c.name}=${c.value}`)
         .join("; ");
-    const userActionTaken = CookieBannerUtils.getUserActionTakenValue(cookiesValue) ?? false;
+    const userActionTaken = getUserActionTakenValue(cookiesValue) ?? false;
+    const variantHeader = headers().get("x-cookie-banner-variant");
+    const cookieBannerVariant = variantHeader === "B" ? "B" : "A";
 
     return (
         <html lang="no">
             <body data-theme="arbeidsplassen" className={localFont.className}>
                 <Providers userActionTaken={userActionTaken}>
-                    <App userActionTaken={userActionTaken}>{children}</App>
+                    <App userActionTaken={userActionTaken} cookieBannerVariant={cookieBannerVariant}>
+                        {children}
+                    </App>
                     {/* FastApi tracking paused until it #researchops fixes it */}
                     <ScrollTracker />
                     <UtmParamsHandler />

--- a/src/app/stillinger/(sok)/_components/searchBox/SearchCombobox.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/SearchCombobox.tsx
@@ -9,7 +9,7 @@ import {
     findLabelForFilter,
     getSearchBoxOptions,
 } from "@/app/stillinger/(sok)/_components/searchBox/buildSearchBoxOptions";
-import { ComboboxExternalItems } from "@navikt/arbeidsplassen-react";
+import { ComboboxExternalItems, ComboboxItem } from "@navikt/arbeidsplassen-react";
 import FilterAggregations from "@/app/stillinger/_common/types/FilterAggregations";
 import { SearchLocation } from "@/app/stillinger/(sok)/page";
 import ScreenReaderText from "./ScreenReaderText";
@@ -221,8 +221,12 @@ function SearchCombobox({ aggregations, locations }: SearchComboboxProps) {
                     fontWeight="semibold"
                     itemsLeadingText="Søket ditt"
                     items={selectedOptions}
-                    removeComboboxItem={(val: { label: string; value: string }) => {
-                        handleFilterOption(val.value, false);
+                    removeComboboxItem={(val: ComboboxItem) => {
+                        if (typeof val === "string") {
+                            handleFilterOption(val, false);
+                        } else {
+                            handleFilterOption(val.value, false);
+                        }
                     }}
                 />
             </Show>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,7 @@ import { CURRENT_VERSION, migrateSearchParams } from "@/app/stillinger/(sok)/_ut
 import { QueryNames } from "@/app/stillinger/(sok)/_utils/QueryNames";
 import { verifyIdPortenJwtWithClaims } from "@/app/min-side/_common/auth/idportenVerifier";
 import { extractBearer } from "@/app/min-side/_common/auth/extractBearer";
-import { CookieBannerUtils } from "@navikt/arbeidsplassen-react";
+import { getConsentValues, getUserActionTakenValue } from "@navikt/arbeidsplassen-react";
 
 /*
  * Match all request paths except for the ones starting with:
@@ -27,6 +27,16 @@ const makeNonce = (): string => {
     for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
     return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 };
+const VARIANT_HEADER = "x-cookie-banner-variant";
+type Variant = "A" | "B";
+
+// 50/50 – ingen cookie, ingen persist
+function pickVariant(): Variant {
+    // Edge-safe random
+    const buf = new Uint8Array(1);
+    crypto.getRandomValues(buf);
+    return (buf[0] & 1) === 0 ? "A" : "B";
+}
 
 function addCspHeaders(requestHeaders: Headers, responseHeaders: Headers) {
     const nonce = makeNonce();
@@ -104,9 +114,9 @@ function trackIfUserAcceptedAnalyticsCookies(request: NextRequest, requestHeader
     const cookieString = requestHeaders.get("cookie") || "";
     let actionValue = "no-action";
 
-    const userActionTaken = CookieBannerUtils.getUserActionTakenValue(cookieString);
+    const userActionTaken = getUserActionTakenValue(cookieString);
 
-    const hasCookieConsent: { analyticsConsent: boolean } = CookieBannerUtils.getConsentValues(cookieString);
+    const hasCookieConsent: { analyticsConsent: boolean } = getConsentValues(cookieString);
 
     if (hasCookieConsent.analyticsConsent) {
         actionValue = "accepted-analytics";
@@ -140,6 +150,13 @@ const applyResponseHeaders = (res: NextResponse, headers: Headers) => {
 export async function middleware(request: NextRequest) {
     const requestHeaders = new Headers(request.headers);
     const responseHeaders = new Headers();
+
+    // --- A/B: bestem variant hvis ikke allerede satt ---
+    const incomingVariant = request.headers.get(VARIANT_HEADER);
+    const abVariant: Variant = incomingVariant === "A" || incomingVariant === "B" ? incomingVariant : pickVariant();
+
+    // Legg på header på REQUESTEN som sendes videre til appen
+    requestHeaders.set(VARIANT_HEADER, abVariant);
 
     // ⬇️  AUTH FØRST: kun for /min-side/*
     if (request.nextUrl.pathname.startsWith("/min-side") && !request.nextUrl.pathname.startsWith("/oauth2")) {
@@ -202,6 +219,7 @@ export async function middleware(request: NextRequest) {
         },
     });
 
+    responseHeaders.set(VARIANT_HEADER, abVariant);
     applyResponseHeaders(response, responseHeaders);
 
     return response;


### PR DESCRIPTION
- Oppdatert arbeidsplassen-react til ny versjon med CookieBanner varianter
- Legg til random variant av CookieBanner i middleware
- Legg til logikk for å vise variant basert på valg i middleware i visning
- fiks type issues etter oppdatering av arbeidsplassen-react
- Legg til tracking event av godta alle infokapsler

This pull request introduces updated project conventions and refactors the cookie banner implementation to support A/B testing, while also improving type safety and code clarity across the codebase. The most important changes are grouped below:

**Project conventions and documentation**

* Added `.github/copilot-instructions.md` with comprehensive guidelines for TypeScript, Next.js 14, and Vitest, including strict typing, naming conventions, component styles, accessibility, and Copilot-specific instructions.
* Updated `.github/pull_request_template.md` to include a checklist enforcing new coding standards and a Copilot summary tip.
* Added a "Copilot Cheatsheet" to `README.md` summarizing key project rules for contributors.

**Cookie banner A/B testing and API changes**

* Refactored cookie banner to support A/B testing: replaced the generic `CookieBanner` with `CookieBannerA` and `CookieBannerB` components, controlled by a new `cookieBannerVariant` prop. Updated related context and usage throughout the app. [[1]](diffhunk://#diff-1fbb42de2066b6bc2002f139addb1b15957af85d415c5fcf381bf859d9ebb6b3L2-R45) [[2]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07R17-R19) [[3]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L32-R33)
* Updated imports and usage of cookie consent utilities to use new named exports (`getConsentValues`, `getUserActionTakenValue`) instead of `CookieBannerUtils`, reflecting changes in `@navikt/arbeidsplassen-react`. [[1]](diffhunk://#diff-0b98cd0efcf9134c03193139c1cdfc0bd6043106c008bc5113d108b6573586a9L6-R6) [[2]](diffhunk://#diff-0b98cd0efcf9134c03193139c1cdfc0bd6043106c008bc5113d108b6573586a9L45-R46) [[3]](diffhunk://#diff-d151bbb53f5cc45845d2d013b2fec902993678581c70e4adbea2950627f15b99L3-R16) [[4]](diffhunk://#diff-ff0d163a97f36c27c2233729f0ccb7851c11cf36abbb685d17cf618649c9189dL2-R2) [[5]](diffhunk://#diff-ff0d163a97f36c27c2233729f0ccb7851c11cf36abbb685d17cf618649c9189dL24-R24) [[6]](diffhunk://#diff-9bbb3fccb49cd60662e5c59e8e0b132c7e43cecdecdf30836e686c44e82a2746L4-R12) [[7]](diffhunk://#diff-de9efd02a551831b29acc250a8952016bf28a6758f05c32574e4c7e70db71c11L4-R12)

**Type safety and code clarity**

* Improved type safety in header logic: `getActiveMenuItem` now returns `Active | undefined` instead of a string, and `getHeaderAuthenticationStatus` uses the correct enum type. Updated corresponding tests. [[1]](diffhunk://#diff-3b8d512e951b8c89e1095696257f4bac49552f97e18f67c2fc6e8a3cc0da8dfbL2-R25) [[2]](diffhunk://#diff-9b869011d46362a44aa91f4a88ac24cc177466ca73f36eeb734bc77e6f0e6f4eL11-R11) [[3]](diffhunk://#diff-9b869011d46362a44aa91f4a88ac24cc177466ca73f36eeb734bc77e6f0e6f4eL23-R23)
* Updated the `ConsentValues` type and its usage for stronger typing in cookie consent data.

**Analytics and event tracking**

* Added new event types for cookie banner A/B testing in Umami analytics, including payload structure for tracking which variant was accepted. [[1]](diffhunk://#diff-1e9b59cbc01849d3fd00c4d26baf81bbc3c3f2de47e0e8e8e35521c2852b8536R1) [[2]](diffhunk://#diff-1e9b59cbc01849d3fd00c4d26baf81bbc3c3f2de47e0e8e8e35521c2852b8536R24-R28)

**Dependency updates**

* Upgraded `@navikt/arbeidsplassen-react` to version `8.7.7` in `package.json` to support new cookie banner components and API.