### PR TITLE
Legg til workaround for søk på "english"

### DIFF
--- a/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
@@ -729,7 +729,7 @@ function mainQueryTemplateFunc(qAsArray: string[]): BoolFilter {
                         ...baseFreeTextSearchMatch(qAsArray, matchFields),
                         ...businessNameFreeTextSearchMatch(qAsArray),
                         ...geographyAllTextSearchMatch(qAsArray),
-                        englishWorkLanguageTextSearchMatch(qAsArray),
+                        englishFreeTextSearchMatch(qAsArray),
                         {
                             match: {
                                 id: {
@@ -800,13 +800,12 @@ function titleFreeTextSearchMatch(queries: string[]) {
     }));
 }
 
-function englishWorkLanguageTextSearchMatch(queries: string[]) {
-    let freeTextIsOnlyEnglish = "";
-    if (queries.length === 1 && queries[0].toLowerCase() === "english") freeTextIsOnlyEnglish = "Engelsk";
+function englishFreeTextSearchMatch(queries: string[]) {
+    const freeTextOnlyContainsEnglish = queries.length === 1 && queries[0].toLowerCase() === "english";
     return {
         match_phrase: {
             worklanguage_facet: {
-                query: freeTextIsOnlyEnglish,
+                query: freeTextOnlyContainsEnglish ? "Engelsk" : "",
                 boost: 2,
             },
         },


### PR DESCRIPTION
## Hva endres?
- Ved kun søk på fritekst "english" **matcher** den i tekstsøk på `worklanguage`-feltet
- Ved søk på fritekst med flere kombinasjoner f.eks "english" + "engineer" så **filtreres** det på `worklanguage`-feltet

Dette er for å kunne forholde seg til at "english" blir både et fritekst søk og et filter. Ved kun søk på fritekst eller filtrering får man respektivt for stort resultat eller for lite resultat.

## Sjekkliste
- [ ] Ingen bruk av `any` (bruk `unknown` + innsnevring der nødvendig)
- [ ] `type` brukt fremfor `interface`
- [ ] Streng typing (ingen implicit any / løse typer)
- [ ] **Leselige variabelnavn brukt** (unngå 1–2 bokstaver og kryptiske navn som `a`, `b`, `x`, `obj`, `acc`)
- [ ] **Komponentstil fulgt:** funksjonsdeklarasjon som standard; `const`-pilfunksjon kun ved `memo`, `forwardRef`, generiske komponenter eller behov for `displayName`
- [ ] Next.js-konvensjoner fulgt (App Router, `next/link`, `next/navigation`, server actions der naturlig)
- [ ] Tester (Vitest) lagt til/oppdatert (`*.test.ts(x)` ved siden av kildekoden)
- [ ] Tilgjengelighet (WCAG) vurdert der det er UI-endringer
- [ ] Jeg har lest/fulgt retningslinjene i [.github/copilot-instructions.md](./copilot-instructions.md)

## Notater for reviewer
<!-- Eventuelle avklaringer, oppfølging, TODO -->

Må se om det bør legges til en brukerundersøkelse eller lignende for å samle inn data på **hva** brukere ønsker å få når de søker "english" 

---

💡 **Tips:**  
Bruk gjerne **Copilot Actions** → *"Generate a summary of the changes in this pull request"* for å få en detaljert, AI-generert oppsummering som supplement til din egen beskrivelse.