### PR TITLE
Fikser et uu-issue med lenketekst og litt på typografi

### DIFF
--- a/src/app/ung/artikler/blitt-ghosta-av-arbeidsgiver-hva-na/data.tsx
+++ b/src/app/ung/artikler/blitt-ghosta-av-arbeidsgiver-hva-na/data.tsx
@@ -55,7 +55,7 @@ export const tipsList: { title: string; description: ReactNode; id: string }[] =
                 </BodyLong>
                 <BodyLong>
                     For andre jobbsøkertips, se
-                    <Link href="https://www.nav.no/soker-jobb">jobbsøkertipsene på nav.no.</Link>
+                    <Link href="https://www.nav.no/soker-jobb">jobbsøkertips på nav.no.</Link>
                 </BodyLong>
             </>
         ),

--- a/src/app/ung/artikler/blitt-ghosta-av-arbeidsgiver-hva-na/data.tsx
+++ b/src/app/ung/artikler/blitt-ghosta-av-arbeidsgiver-hva-na/data.tsx
@@ -54,7 +54,7 @@ export const tipsList: { title: string; description: ReactNode; id: string }[] =
                     frivillig arbeid eller ta kurs. Sjekk ut frivillige jobber på frivillig.no.
                 </BodyLong>
                 <BodyLong>
-                    <Link href="https://www.nav.no/soker-jobb">For andre jobbsøkertips se her.</Link>
+                    <Link href="https://www.nav.no/soker-jobb">For andre jobbsøkertips se nav.no.</Link>
                 </BodyLong>
             </>
         ),

--- a/src/app/ung/artikler/blitt-ghosta-av-arbeidsgiver-hva-na/data.tsx
+++ b/src/app/ung/artikler/blitt-ghosta-av-arbeidsgiver-hva-na/data.tsx
@@ -1,24 +1,24 @@
 import { ReactNode } from "react";
-import { BodyShort, Link } from "@navikt/ds-react";
+import { BodyLong, Link } from "@navikt/ds-react";
 import { AkselNextLink } from "@/app/_common/components/AkselNextLink";
 
 export const tipsList: { title: string; description: ReactNode; id: string }[] = [
     {
         id: "tips-ghosting-1",
-        title: "Send en hyggelig melding til arbeidsgiver og spør om en oppdatering.",
+        title: "Send en hyggelig melding til arbeidsgiver og spør om en oppdatering",
         description: (
             <>
-                <BodyShort spacing>Et eksempel kan være:</BodyShort>
-                <BodyShort spacing>
+                <BodyLong className="mb-2">Et eksempel kan være:</BodyLong>
+                <BodyLong className="mb-2">
                     “Hei! Jeg søkte nylig på stillingen som [stillingstittel] hos dere, og ville bare høre om det er
                     noen oppdatering. Jeg er fortsatt veldig interessert i jobben.{" "}
-                </BodyShort>
-                <BodyShort spacing>Jeg ser frem til å høre fra dere!</BodyShort>
-                <BodyShort>
+                </BodyLong>
+                <BodyLong className="mb-2">Jeg ser frem til å høre fra dere!</BodyLong>
+                <BodyLong>
                     Vennlig hilsen
                     <br />
                     [Navnet ditt]”
-                </BodyShort>
+                </BodyLong>
             </>
         ),
     },
@@ -27,16 +27,20 @@ export const tipsList: { title: string; description: ReactNode; id: string }[] =
         title: "Søk andre stillinger mens du venter på svar",
         description: (
             <>
-                <BodyShort spacing>
-                    Sjekk ut flere stillinger{" "}
-                    <AkselNextLink href="/stillinger?experience=Ingen&v=5">her.</AkselNextLink>
-                </BodyShort>
-                <BodyShort>
-                    Det finnes også flere andre steder du kan se etter jobb. Sjekk tips for alternative steder du kan
-                    <Link href="https://karriereveiledning.no/karrierevalg/6-steder-du-kan-lete-etter-jobb?tema=1289">
+                <BodyLong className="mb-2">
+                    <AkselNextLink href="/stillinger?experience=Ingen&v=5">
+                        Sjekk ut flere stillinger her.
+                    </AkselNextLink>
+                </BodyLong>
+                <BodyLong>
+                    Det finnes også flere andre steder du kan se etter jobb. Sjekk tips for alternative steder du kan{" "}
+                    <Link
+                        inlineText
+                        href="https://karriereveiledning.no/karrierevalg/6-steder-du-kan-lete-etter-jobb?tema=1289"
+                    >
                         lete etter jobb på karriereveiledning.no
                     </Link>
-                </BodyShort>
+                </BodyLong>
             </>
         ),
     },
@@ -45,13 +49,13 @@ export const tipsList: { title: string; description: ReactNode; id: string }[] =
         title: "Bruk ventetiden smart",
         description: (
             <>
-                <BodyShort spacing>
+                <BodyLong className="mb-2">
                     Google deg selv og sjekk profiler du har i sosiale medier og jobbportaler, oppdater CV og vurder
                     frivillig arbeid eller ta kurs. Sjekk ut frivillige jobber på frivillig.no.
-                </BodyShort>
-                <BodyShort>
-                    For andre jobbsøkertips se <Link href="https://www.nav.no/soker-jobb">her.</Link>
-                </BodyShort>
+                </BodyLong>
+                <BodyLong>
+                    <Link href="https://www.nav.no/soker-jobb">For andre jobbsøkertips se her.</Link>
+                </BodyLong>
             </>
         ),
     },
@@ -59,12 +63,12 @@ export const tipsList: { title: string; description: ReactNode; id: string }[] =
         id: "tips-ghosting-4",
         title: "Forbered deg til intervju",
         description: (
-            <>
+            <BodyLong>
                 Øv deg på intervjuspørsmål på{" "}
                 <Link href="https://karriereveiledning.no/karrierevalg/ov-deg-pa-intervjusporsmal?tema=1289">
                     karriereveiledning.no
                 </Link>
-            </>
+            </BodyLong>
         ),
     },
 ];

--- a/src/app/ung/artikler/blitt-ghosta-av-arbeidsgiver-hva-na/data.tsx
+++ b/src/app/ung/artikler/blitt-ghosta-av-arbeidsgiver-hva-na/data.tsx
@@ -54,7 +54,8 @@ export const tipsList: { title: string; description: ReactNode; id: string }[] =
                     frivillig arbeid eller ta kurs. Sjekk ut frivillige jobber på frivillig.no.
                 </BodyLong>
                 <BodyLong>
-                    <Link href="https://www.nav.no/soker-jobb">For andre jobbsøkertips se nav.no.</Link>
+                    For andre jobbsøkertips, se
+                    <Link href="https://www.nav.no/soker-jobb">jobbsøkertipsene på nav.no.</Link>
                 </BodyLong>
             </>
         ),


### PR DESCRIPTION
- Bruker `BodyLong` i stedet for `BodyShort`. BodyLong har litt større linjeavstand og passer bedre når teksten går over flere linjer. Når jeg byttet til BodyLong, så droppet jeg standard spacing mellom tekstblokkene, og bruker en litt mindre avstand `mb-2`.
- Det var et par lenker som bare hatt lenketekst `her`. Inkluderte mer i lenketeksten slik at den blir mer beskrivende for de som bruker skjermleser.
- La til `inlineText` på lenker, slik at de bryter sammen med resten av teksten de står i.