### PR TITLE
Skrur på muligheter-mvp i prod

### DIFF
--- a/.nais/prod.yml
+++ b/.nais/prod.yml
@@ -5,7 +5,7 @@ arbeidsplassen_domain:
 env:
   ADUSER_AUDIENCE: "prod-gcp:teampam:pam-aduser"
   INTEREST_API_URL: "https://arbeidsplassen.nav.no/interesse-api"
-  MULIGHETER_ENABLED: "false"
+  MULIGHETER_ENABLED: "true"
   PAM_DIR_API_AUDIENCE: "prod-gcp:teampam:pam-dir-api"
   LOG_LEVEL: "info"
 valkey:


### PR DESCRIPTION
Toggler på muligheter-mvpen i prod. 

Denne er fremdeles feature-togglet av for brukere i backend. Toggler på i frontenden slik at vi kan teste med prod-stillinger og se hvordan det spinner for et knippe whitelistede brukere (teammedlemmer) før vi feature toggler på i backend for de ekte brukerne.