### PR TITLE
Fiks: erstatt lenke med knapp som ser ut som lenke i SkyraSurvey

### DIFF
--- a/src/app/_common/skyra/SkyraSurvey.tsx
+++ b/src/app/_common/skyra/SkyraSurvey.tsx
@@ -1,23 +1,9 @@
 "use client";
 
-import { Button, Loader, Popover, Link, type LinkProps } from "@navikt/ds-react";
-import { useRef, useState, forwardRef } from "react";
+import { Button, Loader, Popover } from "@navikt/ds-react";
+import { useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSkyra } from "@/app/_common/hooks/useSkyra";
-import NextLink from "next/link";
-
-// ForwardRef-versjon av AkselNextLink
-export const AkselNextLink = forwardRef<HTMLAnchorElement, LinkProps & { href: string }>(
-    ({ children, href, ...rest }, ref) => {
-        return (
-            <Link as={NextLink} href={href} ref={ref} {...rest} prefetch={false}>
-                {children}
-            </Link>
-        );
-    },
-);
-
-AkselNextLink.displayName = "AkselNextLink";
 
 type SkyraSurveyProps = {
     buttonText: string;
@@ -35,7 +21,6 @@ export default function SkyraSurvey({
     asLink = false,
 }: SkyraSurveyProps) {
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const linkRef = useRef<HTMLAnchorElement>(null);
     const skyraSurveyRef = useRef<HTMLElement>(null);
     const [openState, setOpenState] = useState<boolean>(false);
 
@@ -48,35 +33,20 @@ export default function SkyraSurvey({
 
     const isLoading = status === "loading";
 
-    const anchorEl = asLink ? linkRef.current : buttonRef.current;
+    const anchorEl = buttonRef.current ?? undefined;
 
     return (
         <>
-            {asLink ? (
-                <AkselNextLink
-                    ref={linkRef}
-                    href="#"
-                    onClick={(e) => {
-                        e.preventDefault();
-                        setOpenState((prev) => !prev);
-                    }}
-                    aria-expanded={openState}
-                >
-                    {buttonText}
-                </AkselNextLink>
-            ) : (
-                <Button
-                    ref={buttonRef}
-                    onClick={() => setOpenState((prev) => !prev)}
-                    aria-expanded={openState}
-                    variant={buttonVariant}
-                    size={buttonSize}
-                    className="skyra-link-button"
-                >
-                    {buttonText}
-                </Button>
-            )}
-
+            <Button
+                ref={buttonRef}
+                onClick={() => setOpenState((prev) => !prev)}
+                aria-expanded={openState}
+                variant={buttonVariant}
+                size={buttonSize}
+                className={asLink ? "skyra-link-button" : undefined}
+            >
+                {asLink ? <span className="skyra-link-text">{buttonText}</span> : buttonText}
+            </Button>
             {openState &&
                 anchorEl &&
                 createPortal(

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -404,3 +404,22 @@ skyra-survey {
 .linkcard-hover-underline:hover a {
     text-decoration: underline;
 }
+
+.skyra-link-button {
+    background: none;
+}
+
+.skyra-link-text {
+    font-weight: 400;
+    text-decoration: underline;
+    text-decoration-thickness: 0.05em;
+    text-underline-offset: 0.1em;
+}
+
+.skyra-link-button:hover .skyra-link-text {
+    text-decoration-thickness: 2px;
+}
+
+.skyra-link-button:focus-visible {
+    border-radius: 2px !important;
+}


### PR DESCRIPTION
Denne endringen erstatter lenke med knapp som ser ut som en lenke i SkyraSurvey.

Formålet er å sikre riktig semantikk og interaksjonsmønster, siden elementet ikke navigerer til en ny side, men åpner en Popover med et skjema.