### PR TITLE
sjekk isValidUUID før fetch

### DIFF
--- a/src/app/stillinger/_common/actions/savedSearchActions.ts
+++ b/src/app/stillinger/_common/actions/savedSearchActions.ts
@@ -63,6 +63,10 @@ export async function getAllSavedSearchesAction(): Promise<SavedSearch[]> {
 export async function getSavedSearchAction(uuid: string): Promise<GetSavedSearchResponse> {
     appLogger.info("GET saved search");
 
+    if (!isValidUUID(uuid)) {
+        return { success: false };
+    }
+
     const baseHeaders = await getDefaultHeaders();
     const auth = await getAduserRequestHeaders({ csrf: "none", baseHeaders });
 
@@ -137,7 +141,7 @@ export async function updateSavedSearchAction(savedSearch: SavedSearch): Promise
     }
 
     const uuid = savedSearch.uuid ?? "";
-    if (!uuid) {
+    if (!isValidUUID(uuid)) {
         return { success: false };
     }
 
@@ -165,6 +169,10 @@ export async function updateSavedSearchAction(savedSearch: SavedSearch): Promise
 
 export async function deleteSavedSearchAction(uuid: string): Promise<ActionResponse<SavedSearch>> {
     appLogger.info(`DELETE saved search: ${uuid}`);
+
+    if (!isValidUUID(uuid)) {
+        return { success: false };
+    }
 
     const baseHeaders = await getDefaultHeaders();
     const auth = await getAduserRequestHeaders({ csrf: "required", baseHeaders });

--- a/src/app/stillinger/_common/actions/savedSearchActions.ts
+++ b/src/app/stillinger/_common/actions/savedSearchActions.ts
@@ -133,15 +133,15 @@ export async function saveSavedSearchAction(savedSearch: SavedSearch): Promise<A
 export async function updateSavedSearchAction(savedSearch: SavedSearch): Promise<ActionResponse<SavedSearch>> {
     appLogger.info(`PUT SavedSearchAction uuid:${savedSearch.uuid ?? "unknown"}`);
 
+    const uuid = savedSearch.uuid ?? "";
+    if (!isValidUUID(uuid)) {
+        return { success: false };
+    }
+
     const baseHeaders = await getDefaultHeaders();
     const auth = await getAduserRequestHeaders({ csrf: "required", baseHeaders });
 
     if (!auth.ok) {
-        return { success: false };
-    }
-
-    const uuid = savedSearch.uuid ?? "";
-    if (!isValidUUID(uuid)) {
         return { success: false };
     }
 

--- a/src/app/stillinger/trekk-soknad/[uuid]/[adUuid]/actions/withdrawActions.ts
+++ b/src/app/stillinger/trekk-soknad/[uuid]/[adUuid]/actions/withdrawActions.ts
@@ -1,9 +1,14 @@
 "use server";
 
+import { validate as isValidUUID } from "uuid";
 import { WithdrawResponse } from "@/app/stillinger/trekk-soknad/[uuid]/[adUuid]/_types/Responses";
 import { getDefaultHeaders } from "@/app/stillinger/_common/utils/fetch";
 
 export async function withdrawApplication(adUuid: string, uuid: string): Promise<WithdrawResponse> {
+    if (!isValidUUID(adUuid) || !isValidUUID(uuid)) {
+        return { success: false, error: "unknown" };
+    }
+
     try {
         const headers = await getDefaultHeaders();
         const res = await fetch(`${process.env.INTEREST_API_URL}/application-form/${adUuid}/application/${uuid}`, {

--- a/src/app/stillinger/trekk-soknad/[uuid]/[adUuid]/page.tsx
+++ b/src/app/stillinger/trekk-soknad/[uuid]/[adUuid]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { validate as isValidUUID } from "uuid";
 import { getDefaultHeaders } from "@/app/stillinger/_common/utils/fetch";
 import * as actions from "@/app/stillinger/trekk-soknad/[uuid]/[adUuid]/actions";
 import { WithdrawResponse } from "@/app/stillinger/trekk-soknad/[uuid]/[adUuid]/_types/Responses";
@@ -19,6 +20,10 @@ type PageProps = {
 };
 
 async function fetchApplicationExists(adUuid: string, uuid: string): Promise<string> {
+    if (!isValidUUID(adUuid) || !isValidUUID(uuid)) {
+        notFound();
+    }
+
     const headers = await getDefaultHeaders();
     const res = await fetch(`${process.env.INTEREST_API_URL}/application-form/${adUuid}/application/${uuid}`, {
         method: "HEAD",


### PR DESCRIPTION
Bruker isValidUUID() fra uuid-pakken, som tidligere er brukt. UUID-format garanterer at verdien kun inneholder hex-tegn og bindestreker for å hindre Server-Side Request Forgery (SSRF).


- getSavedSearchAction: validerer uuid før fetch → fikser alert (https://github.com/navikt/pam-stillingsok/security/code-scanning/53)
- deleteSavedSearchAction: validerer uuid før fetch → fikser alert (https://github.com/navikt/pam-stillingsok/security/code-scanning/55)
- updateSavedSearchAction: oppgraderer tom-streng-sjekk til isValidUUID(), flyttet før auth-oppslag
- withdrawApplication: validerer adUuid og uuid før fetch → fikser alert (https://github.com/navikt/pam-stillingsok/security/code-scanning/41)
- fetchApplicationExists (page.tsx): validerer adUuid og uuid før HEAD-kall (samme sårbarhet, ikke fanget av scanner)

Har ikke endret denne, skal være ok

- restartSavedSearchAction (alert (https://github.com/navikt/pam-stillingsok/security/code-scanning/56)), hadde allerede isValidUUID-sjekk