### PR TITLE
Legg til tittel til definisjonslister

### DIFF
--- a/src/app/stillinger/stilling/[id]/_components/AdDetails.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/AdDetails.tsx
@@ -17,7 +17,7 @@ export default function AdDetails({ adData }: AdDetailsProps) {
                 align={{ xs: "start", sm: "center" }}
                 justify="space-between"
             >
-                <Heading level="2" size="medium">
+                <Heading id="ad-details-heading" level="2" size="medium">
                     Annonsedata
                 </Heading>
                 <Button
@@ -30,7 +30,7 @@ export default function AdDetails({ adData }: AdDetailsProps) {
                 >
                     Rapporter annonse
                 </Button>
-                <dl className="ad-description-list">
+                <dl className="ad-description-list" aria-labelledby="ad-details-heading">
                     {adData.id && (
                         <div>
                             <dt>

--- a/src/app/stillinger/stilling/[id]/_components/EmployerDetails.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/EmployerDetails.tsx
@@ -10,13 +10,13 @@ type EmployerDetailsProps = {
 export default function EmployerDetails({ employer }: EmployerDetailsProps) {
     return (
         <section className="mt-8 mb-8 about-company">
-            <Heading level="2" size="large" spacing>
+            <Heading id="employer-details-heading" level="2" size="large" spacing>
                 Om bedriften
             </Heading>
             {employer.descriptionHtml && (
                 <RichText className="job-posting-text mt-4">{parse(employer.descriptionHtml)}</RichText>
             )}
-            <dl className="ad-description-list">
+            <dl className="ad-description-list" aria-labelledby="employer-details-heading">
                 {employer.sector && (
                     <div>
                         <dt>

--- a/src/app/stillinger/stilling/[id]/_components/EmploymentDetails.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/EmploymentDetails.tsx
@@ -49,7 +49,7 @@ export default function EmploymentDetails({ adData }: EmploymentDetailsProps) {
     return (
         <section className="full-width mt-8 mb-8">
             <HStack gap="space-16" justify="space-between" align="center" className="mb-4">
-                <Heading level="2" size="large">
+                <Heading id="employment-details-heading" level="2" size="large">
                     Om jobben
                 </Heading>
                 {adData.id != null && (

--- a/src/app/stillinger/stilling/[id]/_components/EmploymentDetailsPanel.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/EmploymentDetailsPanel.tsx
@@ -157,7 +157,11 @@ export default function EmploymentDetailsPanel({ adData }: EmploymentDetailsProp
 
     return (
         <div>
-            <dl id="employment-details-dl-list" className="ad-description-list mb-4">
+            <dl
+                id="employment-details-dl-list"
+                className="ad-description-list mb-4"
+                aria-labelledby="employment-details-heading"
+            >
                 {detailsList.items.map((detail) => (
                     <div key={detail.id}>
                         <HStack align="center" gap="space-6" as="dt">


### PR DESCRIPTION
Lenke til [oppgave-beskrivelse](https://trello.com/c/5FiCWauO) på Trello.

Oppgaven går ut på å koble en beskrivende tittel med tihørende definisjonsliste for skjermleser.

Jeg har valgt å ta i bruk `aria-labelledby` prop i `<dl>`-elementene for å kunne hente heading-tekst fra nærmeste `Heading`-komponent. `aria-labelledby` peker mot `id`-propen i `Heading`. På denne måten unngår vi å duplisere tekst; vi har _én kilde; én sannhet_.



**Hva VoiceOver Rotor viser nå:**

<img width="690" height="710" alt="image" src="https://github.com/user-attachments/assets/9536faea-1fc2-4872-aaa3-09d40b481cc8" />
