### PR TITLE
Fix boime lint errors etter migrering

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,6 +38,9 @@
                 "useBlockStatements": "error",
                 "noDefaultExport": "off"
             },
+            "complexity": {
+                "noImportantStyles": "warn"
+            },
             "suspicious": {
                 "noConsole": "warn",
                 "noExplicitAny": "error",

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,2 @@
 declare module "@navikt/arbeidsplassen-css";
 declare module "@navikt/arbeidsplassen-theme";
-

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "lint": "biome check .",
         "lint:fix": "biome check --write .",
         "format": "biome format --write .",
+        "prettier": "echo 'Formatting handled by biome – see lint script'",
         "prepare": "husky",
         "pre-commit": "lint-staged",
         "compileTS": "tsc --noEmit",

--- a/src/app/(artikler)/personvern/Personvern.tsx
+++ b/src/app/(artikler)/personvern/Personvern.tsx
@@ -11,7 +11,7 @@ type Props = {
     readonly meta: PageInfo;
 };
 export default function Personvern({ meta }: Props) {
-    let updatedAt;
+    let updatedAt: string | undefined;
 
     if (meta.updatedAt) {
         const [year, month] = meta.updatedAt.split("-");

--- a/src/app/_common/IllustratedCallout/IllustratedCallout.tsx
+++ b/src/app/_common/IllustratedCallout/IllustratedCallout.tsx
@@ -50,6 +50,7 @@ function IllustratedCallout({
             </div>
 
             {illustration ? (
+                // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-label rendres kun når role="img" også er satt
                 <div
                     className={cn(styles.illustration, illustrationClassName)}
                     aria-hidden={illustrationAriaLabel ? undefined : true}

--- a/src/app/_common/css/artikler-og-forside.css
+++ b/src/app/_common/css/artikler-og-forside.css
@@ -40,7 +40,6 @@
 }
 
 /**** ARTICLE ****/
-
 .article-image {
     border-radius: 96px 0 0 0;
     position: relative !important;

--- a/src/app/_experiments/evaluateRandom.test.ts
+++ b/src/app/_experiments/evaluateRandom.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { evaluateExperimentRandom, type Rng } from "./evaluateRandom";
 import type { ExperimentDefinition } from "./types";
 
-export function createSeededRng(seedStart: number): Rng {
+function createSeededRng(seedStart: number): Rng {
     let seed = seedStart;
 
     return () => {

--- a/src/app/api/muligheter/checkAccess/route.ts
+++ b/src/app/api/muligheter/checkAccess/route.ts
@@ -13,7 +13,7 @@ export async function GET(): Promise<NextResponse<HasMuligheterAccess>> {
     }
 
     try {
-        let oboToken;
+        let oboToken: string;
         try {
             oboToken = await getDirApiOboToken();
         } catch (err) {

--- a/src/app/min-side/_common/components/tilgang/SkjulInnholdHvisIkkeTilgang.jsx
+++ b/src/app/min-side/_common/components/tilgang/SkjulInnholdHvisIkkeTilgang.jsx
@@ -14,8 +14,8 @@ export default function SkulInnholdHvisIkkeTilgang({ children }) {
     }
 
     if (personalia.data && personalia.data.kanLoggePaa === false) {
-        return <></>;
+        return null;
     }
 
-    return <>{children}</>;
+    return children;
 }

--- a/src/app/muligheter/_common/auth/checkAccess.server.ts
+++ b/src/app/muligheter/_common/auth/checkAccess.server.ts
@@ -13,7 +13,7 @@ import { getDirApiOboToken } from "@/app/muligheter/_common/auth/auth";
  * calls when used in both generateMetadata and Page.
  */
 export const checkMuligheterAccess = cache(async (): Promise<boolean> => {
-    let oboToken;
+    let oboToken: string;
     try {
         oboToken = await getDirApiOboToken();
     } catch (err) {
@@ -21,7 +21,7 @@ export const checkMuligheterAccess = cache(async (): Promise<boolean> => {
         return false;
     }
 
-    let res;
+    let res: Response;
     try {
         res = await fetch(`${process.env.PAM_DIR_API_URL}/rest/dir/tilgang`, {
             method: "GET",

--- a/src/app/muligheter/mulighet/[id]/_components/EmploymentDetailsMuligheter.tsx
+++ b/src/app/muligheter/mulighet/[id]/_components/EmploymentDetailsMuligheter.tsx
@@ -22,7 +22,7 @@ const options: HTMLReactParserOptions = {
                 attribs &&
                 (attribs.id === "arb-serEtter" || attribs.id === "arb-arbeidsoppgaver" || attribs.id === "arb-tilbyr")
             ) {
-                return <></>;
+                return null;
             }
             return domToReact(children as DOMNode[]);
         }

--- a/src/app/muligheter/mulighet/[id]/_utils/mulighetAdDataActions.tsx
+++ b/src/app/muligheter/mulighet/[id]/_utils/mulighetAdDataActions.tsx
@@ -63,7 +63,7 @@ export async function getInternalAdData(id: string): Promise<AdDTO> {
         notFound();
     }
 
-    let headers;
+    let headers: Headers;
 
     try {
         headers = await getDirApiOboHeaders();

--- a/src/app/muligheter/mulighet/[id]/meld-interesse/_components/SkyraSurveyMuligheter.tsx
+++ b/src/app/muligheter/mulighet/[id]/meld-interesse/_components/SkyraSurveyMuligheter.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/app/_common/utils/cn";
 import styles from "./skyraSurveyMuligheter.module.css";
 
 export default function SkyraSurveyMuligheter() {
-    const buttonRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
     const skyraSurveyRef = useRef<HTMLElement>(null);
     const [openState, setOpenState] = useState<boolean>(false);
 
@@ -21,14 +21,15 @@ export default function SkyraSurveyMuligheter() {
     const isError = status === "error";
     return (
         <>
-            <div
+            <button
+                type="button"
                 ref={buttonRef}
                 className={cn(styles["muligheter-inline-button"], "mb-4")}
                 aria-expanded={openState}
                 onClick={() => setOpenState((prev) => !prev)}
             >
                 Skriv en kort tilbakemelding
-            </div>
+            </button>
 
             {openState &&
                 createPortal(

--- a/src/app/muligheter/mulighet/[id]/meld-interesse/actions.ts
+++ b/src/app/muligheter/mulighet/[id]/meld-interesse/actions.ts
@@ -11,7 +11,7 @@ export async function meldInteresseAction(id: string): Promise<ActionStatusRespo
         return { success: false };
     }
 
-    let headers;
+    let headers: Headers;
     try {
         headers = await getDirApiOboHeaders();
     } catch {
@@ -19,7 +19,7 @@ export async function meldInteresseAction(id: string): Promise<ActionStatusRespo
         return { success: false };
     }
 
-    let res;
+    let res: Response;
     try {
         res = await fetch(`${process.env.PAM_DIR_API_URL}/rest/dir/${encodeURIComponent(id)}/interesse`, {
             headers,

--- a/src/app/sommerjobb/_components/DebugItem.tsx
+++ b/src/app/sommerjobb/_components/DebugItem.tsx
@@ -46,7 +46,7 @@ function DebugItem({ sommerjobbAd }: SommerjobbItemProps) {
                                 <Box background={allCategories.includes(it) ? "warning-soft" : "default"}>
                                     <BodyShort size="small">{it}</BodyShort>
                                 </Box>
-                                {index + 1 < sommerjobbAd.searchtagsai!.length ? ", " : "."}
+                                {index + 1 < (sommerjobbAd.searchtagsai?.length ?? 0) ? ", " : "."}
                             </HStack>
                         ))}
                     </HStack>

--- a/src/app/sommerjobb/_components/SommerjobbResults.tsx
+++ b/src/app/sommerjobb/_components/SommerjobbResults.tsx
@@ -40,13 +40,7 @@ function SommerjobbResults({ ads, totalAds, totalStillinger }: SommerjobbResults
                             {ads.map((item, index) => (
                                 <React.Fragment key={item.uuid}>
                                     {index === 6 && page === "2" && (
-                                        <Box
-                                            key={`karriereveiledning-${index}`}
-                                            as="article"
-                                            background="default"
-                                            borderRadius="2"
-                                            data-nosnippet="true"
-                                        >
+                                        <Box as="article" background="default" borderRadius="2" data-nosnippet="true">
                                             <HStack
                                                 justify="space-between"
                                                 wrap={false}

--- a/src/app/stillinger/(sok)/_components/searchResult/SearchResultItem.test.tsx
+++ b/src/app/stillinger/(sok)/_components/searchResult/SearchResultItem.test.tsx
@@ -119,7 +119,7 @@ describe("SearchResultItem", () => {
         render(
             <SearchResultItem
                 ad={{}}
-                favouriteButton={<button>Favoritt</button>}
+                favouriteButton={<button type="button">Favoritt</button>}
                 isDebug={false}
                 isFavourites={false}
             />,

--- a/src/app/stillinger/(sok)/_components/skeletons/SearchContentSkeleton.tsx
+++ b/src/app/stillinger/(sok)/_components/skeletons/SearchContentSkeleton.tsx
@@ -32,6 +32,7 @@ function ExpandedFilterSectionSkeleton(): React.JSX.Element {
 
             <div className={styles["filter-options"]}>
                 {Array.from({ length: FILTER_OPTION_COUNT }).map((_, index) => {
+                    // biome-ignore lint/suspicious/noArrayIndexKey: statisk skeleton-liste med fast rekkefølge
                     return <FilterOptionSkeleton key={`filter-option-${index}`} />;
                 })}
             </div>
@@ -58,6 +59,7 @@ function FiltersSkeleton(): React.JSX.Element {
             <ExpandedFilterSectionSkeleton />
 
             {Array.from({ length: COLLAPSED_FILTER_COUNT }).map((_, index) => {
+                // biome-ignore lint/suspicious/noArrayIndexKey: statisk skeleton-liste med fast rekkefølge
                 return <CollapsedFilterSectionSkeleton key={`collapsed-filter-${index}`} />;
             })}
         </section>
@@ -87,6 +89,7 @@ function SearchResultsSkeleton({ resultCardCount }: Readonly<{ readonly resultCa
     return (
         <section aria-label="Laster treffliste" className={styles["result-column"]}>
             {Array.from({ length: resultCardCount }).map((_, index) => {
+                // biome-ignore lint/suspicious/noArrayIndexKey: statisk skeleton-liste med fast rekkefølge
                 return <ResultCardSkeleton key={`result-card-${index}`} />;
             })}
         </section>

--- a/src/app/stillinger/(sok)/_utils/query.ts
+++ b/src/app/stillinger/(sok)/_utils/query.ts
@@ -18,7 +18,7 @@ function asArray(value: unknown) {
 }
 
 function asInteger(value: string | string[] | undefined) {
-    let result;
+    let result: number;
 
     if (!value) {
         return undefined;

--- a/src/app/stillinger/lagrede-sok/_components/SavedSearchListItem.tsx
+++ b/src/app/stillinger/lagrede-sok/_components/SavedSearchListItem.tsx
@@ -38,9 +38,9 @@ function SavedSearchListItem({
 
     function deleteSavedSearch(): void {
         startTransition(async () => {
-            let isSuccess;
+            let isSuccess: boolean | undefined;
             try {
-                const { success } = await actions.deleteSavedSearchAction(savedSearch!.uuid!);
+                const { success } = await actions.deleteSavedSearchAction(savedSearch.uuid!);
                 isSuccess = success;
             } catch {
                 isSuccess = false;
@@ -57,22 +57,22 @@ function SavedSearchListItem({
     async function reactivateEmailNotification(): Promise<void> {
         setRestartEmailNotificationStatus(FetchStatus.IS_FETCHING);
 
-        let isSuccess: boolean;
-        let result: ActionResponse<SavedSearch>;
+        let isSuccess: boolean | undefined;
+        let result: ActionResponse<SavedSearch> | undefined;
         try {
             const updatedSavedSearch = {
                 ...savedSearch,
                 status: "ACTIVE",
             };
-            result = await actions.restartSavedSearchAction(savedSearch!.uuid!, updatedSavedSearch);
+            result = await actions.restartSavedSearchAction(savedSearch.uuid!, updatedSavedSearch);
             isSuccess = result.success;
         } catch {
             isSuccess = false;
         }
 
-        if (isSuccess) {
+        if (isSuccess && result?.data) {
             setRestartEmailNotificationStatus(FetchStatus.SUCCESS);
-            replaceSavedSearchInList(result!.data!);
+            replaceSavedSearchInList(result.data);
         } else {
             setRestartEmailNotificationStatus(FetchStatus.FAILURE);
         }

--- a/src/app/stillinger/lagrede-sok/_components/modal/RegisterEmailForm.tsx
+++ b/src/app/stillinger/lagrede-sok/_components/modal/RegisterEmailForm.tsx
@@ -1,5 +1,6 @@
 import { BodyLong, Button, LocalAlert, Modal, TextField } from "@navikt/ds-react";
 import { type ChangeEvent, type FormEvent, type RefObject, useContext, useEffect, useRef, useState } from "react";
+import type { AdUser } from "@/app/_common/auth/aduserClient";
 import * as actions from "@/app/stillinger/_common/actions";
 import { FetchStatus } from "@/app/stillinger/_common/hooks/useFetchReducer";
 import { UserContext } from "@/app/stillinger/_common/user/UserProvider";
@@ -48,9 +49,9 @@ function RegisterEmailForm({ onClose, onSuccess }: RegisterEmailFormProps) {
 
         if (validateForm()) {
             setSaveStatus(FetchStatus.IS_FETCHING);
-            let isSuccess;
+            let isSuccess: boolean | undefined;
 
-            let result: { success: boolean; statusCode?: number; data?: any };
+            let result: { success: boolean; statusCode?: number; data?: AdUser } | undefined;
 
             const brukerMedEpost = user ? { ...user, email } : undefined;
             try {
@@ -60,9 +61,9 @@ function RegisterEmailForm({ onClose, onSuccess }: RegisterEmailFormProps) {
                 isSuccess = false;
             }
 
-            if (isSuccess) {
+            if (isSuccess && result?.data) {
                 setSaveStatus(FetchStatus.SUCCESS);
-                updateUser(result!.data);
+                updateUser(result.data);
                 onSuccess();
             } else {
                 setSaveStatus(FetchStatus.FAILURE);

--- a/src/app/stillinger/lagrede-sok/_components/modal/SaveSearchForm.tsx
+++ b/src/app/stillinger/lagrede-sok/_components/modal/SaveSearchForm.tsx
@@ -89,16 +89,16 @@ function SaveSearchForm({ existingSavedSearch, onClose, onSuccess, formData, def
             if (formMode === FormModes.ADD) {
                 startTransition(async () => {
                     setShowError(false);
-                    let isSuccess;
-                    let result: ActionResponse<SavedSearch>;
+                    let isSuccess: boolean | undefined;
+                    let result: ActionResponse<SavedSearch> | undefined;
                     try {
                         result = await actions.saveSavedSearchAction(dataToBeSaved);
                         isSuccess = result.success;
                     } catch {
                         isSuccess = false;
                     }
-                    if (isSuccess) {
-                        onSuccess(result!.data!);
+                    if (isSuccess && result?.data) {
+                        onSuccess(result.data);
                     } else {
                         setShowError(true);
                     }
@@ -117,16 +117,16 @@ function SaveSearchForm({ existingSavedSearch, onClose, onSuccess, formData, def
                 }
                 startTransition(async () => {
                     setShowError(false);
-                    let isSuccess;
-                    let result: ActionResponse<SavedSearch>;
+                    let isSuccess: boolean | undefined;
+                    let result: ActionResponse<SavedSearch> | undefined;
                     try {
                         result = await actions.updateSavedSearchAction(dataToBeSaved);
                         isSuccess = result.success;
                     } catch {
                         isSuccess = false;
                     }
-                    if (isSuccess) {
-                        onSuccess(result!.data!);
+                    if (isSuccess && result?.data) {
+                        onSuccess(result.data);
                     } else {
                         setShowError(true);
                     }

--- a/src/app/stillinger/rapporter-annonse/[id]/_components/ReportAd.tsx
+++ b/src/app/stillinger/rapporter-annonse/[id]/_components/ReportAd.tsx
@@ -87,7 +87,7 @@ export default function ReportAd({ ad, submitForm }: ReportAdProps) {
             success: false,
             error: "",
         };
-        let fetchSuccess;
+        let fetchSuccess: boolean | undefined;
 
         try {
             result = await submitForm(formData);

--- a/src/app/stillinger/stilling/[id]/_components/AdText.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/AdText.tsx
@@ -27,6 +27,7 @@ const options: HTMLReactParserOptions = {
                 // Dokumentasjonen sier at dette er måten å gjøre det på
                 // Skulle helst ha returnert null her men har ingen
                 // effekt, da teksten rendres uansett av en eller annen grunn
+                // biome-ignore lint/complexity/noUselessFragments: html-react-parser krever JSX-element for å skjule noder
                 return <></>;
             }
             return domToReact(children as DOMNode[]);

--- a/src/app/stillinger/stilling/[id]/_components/EmploymentDetails.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/EmploymentDetails.tsx
@@ -18,6 +18,7 @@ const options: HTMLReactParserOptions = {
                 attribs &&
                 (attribs.id === "arb-serEtter" || attribs.id === "arb-arbeidsoppgaver" || attribs.id === "arb-tilbyr")
             ) {
+                // biome-ignore lint/complexity/noUselessFragments: html-react-parser krever JSX-element for å skjule noder
                 return <></>;
             }
             return domToReact(children as DOMNode[]);

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -15,6 +15,7 @@ body {
     background: var(--ax-bg-default);
     color: var(--ax-text-neutral);
 }
+
 body,
 input,
 select,


### PR DESCRIPTION
 - Legg til eksplisitte typer på alle uinitialiserte let-deklarasjoner (noImplicitAnyLet)
 - Bytt div → button i SkyraSurveyMuligheter for korrekt a11y
 - Fjern export fra testhelper (noExportsInTest)
 - Erstatt tomme fragmenter med null der mulig, biome-ignore der html-react-parser krever det
 - Legg til type="button" i test-fixture
 - biome-ignore på skeleton array-index-keys og IllustratedCallout aria-label
 - Sett noImportantStyles til warn i biome.json (midlertidig)
 - Fiks TS-feil: null-safe result-sjekker i lagrede søk og RegisterEmailForm
 - Fjern any → unknown + AdUser-typing i RegisterEmailForm