### PR TITLE
Implementer AI-generert hjemmekontor filter og bruk av ny felt for aggregering

### DIFF
--- a/src/app/stillinger/(sok)/_components/filters/Remote.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/Remote.tsx
@@ -1,7 +1,6 @@
 import { BodyShort, Checkbox, CheckboxGroup } from "@navikt/ds-react";
 import type React from "react";
 import type { FilterAggregation } from "@/app/stillinger/_common/types/FilterAggregations";
-import getRemoteWorkValue from "@/app/stillinger/_common/utils/getRemoteWorkValue";
 import useQuery from "@/app/stillinger/(sok)/_components/QueryProvider";
 import mergeCount from "@/app/stillinger/(sok)/_components/utils/mergeCount";
 import moveFilterToBottom from "@/app/stillinger/(sok)/_components/utils/moveFilterToBottom";
@@ -39,7 +38,7 @@ export default function Remote({ initialValues, updatedValues }: RemoteProps) {
         >
             {values.map((item) => (
                 <Checkbox name="remote[]" key={item.key} value={item.key} onChange={handleChange}>
-                    {`${getRemoteWorkValue(item.key)} (${item.count})`}
+                    {`${item.key} (${item.count})`}
                 </Checkbox>
             ))}
         </CheckboxGroup>

--- a/src/app/stillinger/(sok)/_components/searchBox/buildSelectedOptions.ts
+++ b/src/app/stillinger/(sok)/_components/searchBox/buildSelectedOptions.ts
@@ -1,6 +1,5 @@
 import type { ComboboxOption } from "@navikt/ds-react/cjs/form/combobox/types";
 import fixLocationName from "@/app/stillinger/_common/utils/fixLocationName";
-import getRemoteWorkValue from "@/app/stillinger/_common/utils/getRemoteWorkValue";
 import {
     labelForEducation,
     labelForExperience,
@@ -81,7 +80,7 @@ function buildOption(key: string, value: string): ComboboxOption | undefined {
         case QueryNames.REMOTE:
             return value === "Ikke oppgitt"
                 ? { label: "Hjemmekontor ikke oppgitt", value: `${QueryNames.REMOTE}-${value}` }
-                : { label: getRemoteWorkValue(value), value: `${QueryNames.REMOTE}-${value}` };
+                : { label: value, value: `${QueryNames.REMOTE}-${value}` };
         case QueryNames.OCCUPATION:
             return {
                 label: value,

--- a/src/app/stillinger/(sok)/_components/searchBox/searchComboboxOptions.ts
+++ b/src/app/stillinger/(sok)/_components/searchBox/searchComboboxOptions.ts
@@ -1,7 +1,6 @@
 import type { SearchLocation } from "@/app/_common/geografi/locationsMapping";
 import type FilterAggregations from "@/app/stillinger/_common/types/FilterAggregations";
 import fixLocationName from "@/app/stillinger/_common/utils/fixLocationName";
-import getRemoteWorkValue from "@/app/stillinger/_common/utils/getRemoteWorkValue";
 import {
     labelForEducation,
     labelForExperience,
@@ -269,7 +268,7 @@ function getRemoteOptions(aggregations: FilterAggregations): SearchComboboxOptio
         }
 
         return {
-            label: getRemoteWorkValue(item.key),
+            label: item.key,
             value: `${QueryNames.REMOTE}-${item.key}`,
         };
     });

--- a/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
+++ b/src/app/stillinger/(sok)/_utils/elasticSearchRequestBody.ts
@@ -225,7 +225,7 @@ function filterRemote(remote: string[] | undefined) {
         remote.forEach((item) => {
             filter.bool?.should?.push({
                 term: {
-                    "properties.remote": item,
+                    remote_facet: item,
                 },
             });
         });
@@ -236,7 +236,7 @@ function filterRemote(remote: string[] | undefined) {
                     must_not: [
                         {
                             exists: {
-                                field: "properties.remote",
+                                field: "remote_facet",
                             },
                         },
                     ],
@@ -1102,7 +1102,7 @@ const elasticSearchRequestBody = (query: ExtendedQuery) => {
                 },
                 aggs: {
                     values: {
-                        terms: { field: "properties.remote", missing: NOT_DEFINED },
+                        terms: { field: "remote_facet", missing: NOT_DEFINED },
                     },
                 },
             },

--- a/src/app/stillinger/_common/lib/ad-model/__tests__/__fixtures__/elasticHit.fixture.ts
+++ b/src/app/stillinger/_common/lib/ad-model/__tests__/__fixtures__/elasticHit.fixture.ts
@@ -53,6 +53,12 @@ export const baseHit: ElasticDocHit<LegacyAd> = {
             jobpercentagerange: "20-50",
             sector: "Privat",
         },
+        generatedSearchMetadata: {
+            remoteOfficeMetadata: {
+                remote: "Ingen mulighet for hjemmekontor",
+                reason: "Står eksplisitt at det ikke er mulighet for hjemmekontor.",
+            },
+        },
         status: "ACTIVE",
     },
 };

--- a/src/app/stillinger/_common/lib/ad-model/__tests__/adDTO.contract.test.ts
+++ b/src/app/stillinger/_common/lib/ad-model/__tests__/adDTO.contract.test.ts
@@ -24,6 +24,12 @@ const cases = [
                     employerhomepage: "acme.no",
                 },
                 locationList: [{ city: "Oslo", country: "Norge" }],
+                generatedSearchMetadata: {
+                    remoteOfficeMetadata: {
+                        remote: "Ingen mulighet for hjemmekontor",
+                        reason: "Står eksplisitt at det ikke er mulighet for hjemmekontor.",
+                    },
+                },
             } as const;
             return () => unwrapOk(transformAdDataLegacy(raw));
         })(),
@@ -69,6 +75,7 @@ const cases = [
 
             expect(dto.positionCount).toBe(1);
             expect(dto.remoteOptions).toBe("Hjemmekontor ikke mulig");
+            expect(dto.aiGeneratedRemoteOptions).toBe("Ingen mulighet for hjemmekontor");
             expect(dto.jobPercentage).toBe("35%");
 
             expect(dto.workDays).toStrictEqual(["Ukedager", "Lørdag", "Søndag"]);

--- a/src/app/stillinger/_common/lib/ad-model/schemas/ad.dto.ts
+++ b/src/app/stillinger/_common/lib/ad-model/schemas/ad.dto.ts
@@ -83,11 +83,15 @@ export const AdDTOSchema = z.object({
     positionCount: z.number().int().positive().nullable() /** properties.positioncount */,
     // Litt usikker på navn her oppfatter det som en boolsk verdi
     // Men er "Hybridkontor", "Hjemmekontor", "Hjemmekontor ikke mulig" som jeg kan se
+    // arbeidsplassen-search-indexer: "Kun hjemmekontor", "Delvis hjemmekontor", "Ingen mulighet for hjemmekontor" og "Ikke oppgitt"
     // C: remoteOptions?
     // O: jobLocationType?
     remoteOptions: z.string().nullable() /** properties - enum? */,
     // oppfatter dette som en date, men er eks "Etter avtale", "Snarest",
     // navngiving??
+    aiGeneratedRemoteOptions: z
+        .enum(["Kun hjemmekontor", "Delvis hjemmekontor", "Ingen mulighet for hjemmekontor", "Ikke oppgitt"])
+        .nullable(),
     startDate: IsoDateTimeStringSchema.nullable() /** properties.startTime*/,
     startDateLabel: z.string().nullable() /** properties.startTime*/,
     // Sørge for at disse alltid er arrays fra backend

--- a/src/app/stillinger/_common/lib/ad-model/schemas/legacy.schemas.ts
+++ b/src/app/stillinger/_common/lib/ad-model/schemas/legacy.schemas.ts
@@ -60,8 +60,18 @@ export const LegacyProperties = z.object({
     jobpercentagerange: z.string().optional(),
     location: z.string().optional(),
 });
+
+// https://github.com/navikt/arbeidsplassen-search-indexer/blob/ef108b2c946a76dc98689d120e6d1dce421435af/src/main/kotlin/no/nav/arbeidsplassen/search/indexer/enrichment/Enrichment.kt#L258
+const RemoteOfficeMetadataSchema = z.object({
+    remote: z
+        .enum(["Kun hjemmekontor", "Delvis hjemmekontor", "Ingen mulighet for hjemmekontor", "Ikke oppgitt"])
+        .nullable(),
+    reason: z.string().nullable(),
+});
+
 const GeneratedSearchMetadataSchema = z.object({
     shortSummary: z.string().nullish(),
+    remoteOfficeMetadata: RemoteOfficeMetadataSchema.nullish(),
 });
 
 export const LegacyAdSchema = z.object({

--- a/src/app/stillinger/_common/lib/ad-model/transform/transform.ts
+++ b/src/app/stillinger/_common/lib/ad-model/transform/transform.ts
@@ -95,6 +95,7 @@ export function transformAdDataLegacy(raw: unknown): Result<z.infer<typeof AdDTO
         startDate,
         startDateLabel,
         remoteOptions: orNull(cleanString(properties?.remote)),
+        aiGeneratedRemoteOptions: orNull(src.generatedSearchMetadata?.remoteOfficeMetadata?.remote),
 
         extent: arrayOrNull(toStringArray(properties?.extent)),
         workDays: arrayOrNull(toStringArray(properties?.workday)),

--- a/src/app/stillinger/stilling/[id]/_components/Ad.test.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/Ad.test.tsx
@@ -32,6 +32,7 @@ const activeAd: AdDTO = {
     jobTitle: "Utvikler (Frontend- og backend)",
     positionCount: 1,
     remoteOptions: "Hybridkontor",
+    aiGeneratedRemoteOptions: "Delvis hjemmekontor",
     startDate: null,
     startDateLabel: "Etter avtale",
     workDays: ["Ukedager", "Lørdag", "Søndag"],

--- a/src/app/stillinger/stilling/[id]/_components/EmploymentDetailsPanel.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/EmploymentDetailsPanel.tsx
@@ -146,6 +146,19 @@ function getEmploymentDetailsList(adData: AdDTO): EmploymentDetailsListItem[] {
         });
     }
 
+    if (
+        !adData.remoteOptions &&
+        adData.aiGeneratedRemoteOptions &&
+        adData.aiGeneratedRemoteOptions !== "Ikke oppgitt"
+    ) {
+        employmentDetailsList.push({
+            id: "aiRemoteOptions",
+            label: "Mulighet for hjemmekontor",
+            value: adData.aiGeneratedRemoteOptions,
+            isAiGeneratedData: true,
+        });
+    }
+
     return employmentDetailsList;
 }
 

--- a/src/app/stillinger/stilling/_data/adDataActions.tsx
+++ b/src/app/stillinger/stilling/_data/adDataActions.tsx
@@ -64,6 +64,7 @@ const sourceIncludes = [
     "updated",
     "compositeAdVector",
     "generatedSearchMetadata.shortSummary",
+    "generatedSearchMetadata.remoteOfficeMetadata",
 ].join(",");
 const ENABLE_BEST_EFFORT = process.env.ENABLE_ADDTO_BEST_EFFORT === "true";
 


### PR DESCRIPTION
## Hva endres?
- For filtrering: bruker nye `remote_facet` felt som tar til høyde for riktig aggregering av hjemmekontor filtrene med tanke på hjemmekontor felt satt av arbeidsgiver og AI-generert hjemmekontor filter. Feltet bruker også nye filternavn, så har fjernet `getRemoteWorkValue`-funksjonen der den ikke trengs lenger.
- I stillingen: Fra OpenSearch burde nå feltet `properties.remote` vise til hjemmekontor filter satt av arbeidsgiver og feltet `generatedSearchMetadata.remoteOfficeMetadata.remote/reason` er feltet for AI-generert data for hjemmekontor.

## Sjekkliste
- [ ] Ingen bruk av `any` (bruk `unknown` + innsnevring der nødvendig)
- [ ] `type` brukt fremfor `interface`
- [ ] Streng typing (ingen implicit any / løse typer)
- [ ] **Leselige variabelnavn brukt** (unngå 1–2 bokstaver og kryptiske navn som `a`, `b`, `x`, `obj`, `acc`)
- [ ] **Komponentstil fulgt:** funksjonsdeklarasjon som standard; `const`-pilfunksjon kun ved `memo`, `forwardRef`, generiske komponenter eller behov for `displayName`
- [ ] Next.js-konvensjoner fulgt (App Router, `next/link`, `next/navigation`, server actions der naturlig)
- [ ] Tester (Vitest) lagt til/oppdatert (`*.test.ts(x)` ved siden av kildekoden)
- [ ] Tilgjengelighet (WCAG) vurdert der det er UI-endringer
- [ ] Jeg har lest/fulgt retningslinjene i [.github/copilot-instructions.md](./copilot-instructions.md)

## Notater for reviewer
<!-- Eventuelle avklaringer, oppfølging, TODO -->

---

💡 **Tips:**  
Bruk gjerne **Copilot Actions** → *"Generate a summary of the changes in this pull request"* for å få en detaljert, AI-generert oppsummering som supplement til din egen beskrivelse.