### PR TITLE
ARBPLASS-42 Ny AIButton-komponent for Sommerjobber-siden

### DIFF
--- a/src/app/sommerjobb/_components/AIButton.module.css
+++ b/src/app/sommerjobb/_components/AIButton.module.css
@@ -1,0 +1,54 @@
+.ai-tag {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.75rem;
+    white-space: nowrap;
+    color: var(--ax-text-default);
+    font-size: var(--ax-font-size-medium);
+    font-weight: var(--ax-font-weight-bold);
+    background: var(--ax-bg-accent-moderate-pressed);
+    border-radius: var(--ax-radius-full) var(--ax-radius-full) 0 var(--ax-radius-full);
+    border-style: none;
+    padding: 0 var(--ax-space-12);
+    cursor: pointer;
+
+    &:hover {
+        background: #90a1ee; /* Hentet fra Designsystemet: Blue 200 */
+    }
+}
+
+.ai-tag:focus-visible {
+    outline: 3px solid var(--ax-border-focus);
+    outline-offset: 2px;
+}
+
+.compact-label {
+    flex-shrink: 0;
+}
+
+.reveal-wrapper {
+    overflow: hidden;
+    max-width: 0;
+    transition: max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.label-extension {
+    opacity: 0;
+    padding-left: 1px;
+    transition: opacity 0.25s ease 0.1s;
+}
+
+.ai-tag-expanded .reveal-wrapper {
+    max-width: 250px;
+}
+
+.ai-tag-expanded .label-extension {
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .reveal-wrapper,
+    .label-extension {
+        transition: none;
+    }
+}

--- a/src/app/sommerjobb/_components/AIButton.tsx
+++ b/src/app/sommerjobb/_components/AIButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+import styles from "./AIButton.module.css";
+
+export default function AIButton() {
+    const [expanded, setExpanded] = useState<boolean>(false);
+
+    return (
+        <button
+            type="button"
+            className={`${styles["ai-tag"]} ${expanded ? styles["ai-tag-expanded"] : ""}`}
+            aria-pressed={expanded}
+            aria-label="AI-genererte resultater"
+            onClick={() => setExpanded((prev) => !prev)}
+        >
+            <span className={styles["compact-label"]} aria-hidden="true">
+                AI
+            </span>
+            <span className={styles["reveal-wrapper"]} aria-hidden="true">
+                <span className={styles["label-extension"]}>-genererte resultater</span>
+            </span>
+        </button>
+    );
+}

--- a/src/app/sommerjobb/_components/SommerjobbResults.tsx
+++ b/src/app/sommerjobb/_components/SommerjobbResults.tsx
@@ -6,6 +6,7 @@ import React, { useRef } from "react";
 import FigureConfused from "@/app/_common/components/FigureConfused";
 import { track } from "@/app/_common/umami";
 import { SOMMERJOBB_KLIKK_KARRIEREVEILEDNING } from "@/app/_common/umami/constants";
+import AIButton from "@/app/sommerjobb/_components/AIButton";
 import SommerjobbItem from "@/app/sommerjobb/_components/SommerjobbItem";
 import SommerjobbPagination from "@/app/sommerjobb/_components/SommerjobbPagination";
 import { PAGE_PARAM_NAME } from "@/app/sommerjobb/_utils/constants";
@@ -35,7 +36,10 @@ function SommerjobbResults({ ads, totalAds, totalStillinger }: SommerjobbResults
                     </Heading>
                 </Stack>
                 {totalAds > 0 && (
-                    <>
+                    <VStack gap="space-16">
+                        <HStack justify="end">
+                            <AIButton />
+                        </HStack>
                         <HGrid gap="space-16" columns={{ xs: 1, md: 2 }}>
                             {ads.map((item, index) => (
                                 <React.Fragment key={item.uuid}>
@@ -89,7 +93,7 @@ function SommerjobbResults({ ads, totalAds, totalStillinger }: SommerjobbResults
                                 totalAds={totalAds}
                             />
                         </VStack>
-                    </>
+                    </VStack>
                 )}
             </Stack>
         </PageBlock>


### PR DESCRIPTION
Lenker til [Jira-sak](https://nav.atlassian.net/browse/ARBPLASS-42) og [Trello-oppgave](https://trello.com/c/UelqjAMS).

Oppgaven går ut på å legge til en tydelig KI-tag i [Sommerjobber-siden](https://arbeidsplassen.intern.dev.nav.no/sommerjobb) som kommuniserer at annonsenesammendragene er KI-generert.

Jeg har laget en enkel komponent med hardkodede tekstverdier til bruk kun i Sommerjobber. Dersom denne ønskes andre steder, kan vi gjøre nødvendige refaktoreringer da og gjøre den mer fleksibel. 

AI-tagen er ment å være helt høyrestilt med "AI" som fast tekst. Den ekspanderer mot venstre når den blir klikket og viser den komplette, mer beskrivende teksten (_se diskusjonen i Jira-saken som ledet til denne utgaven_).

<img width="1006" height="504" alt="image" src="https://github.com/user-attachments/assets/01d03b71-28d5-4337-ac1d-44e6359b633f" />


**Når tag'en er klikket, og hele label-teksten vises:**
<img width="1024" height="503" alt="image" src="https://github.com/user-attachments/assets/724d1580-eea1-4489-9d0a-52918458417f" />

⚠️ **OBS! Mulig label-teksten er feil og må justeres.
Trenger også tilbakemeldinger fra designere siden komponenten ble utviklet uten skisser som utgangspunkt.**