### PR TITLE
legg til søkeopplevelse-rating for AB-test 

### DIFF
--- a/src/app/_common/umami/events.ts
+++ b/src/app/_common/umami/events.ts
@@ -145,6 +145,7 @@ export type Events = {
         variant: VariantKey;
         konvertering: ExperimentConversion;
         location?: string;
+        rating?: number;
     };
 
     "Klikk - video": {

--- a/src/app/_experiments/experiments.ts
+++ b/src/app/_experiments/experiments.ts
@@ -5,7 +5,7 @@ export const experiments = [
         key: "qualifications_soek_superrask_cta",
         status: "on", // skru av eller på eksperimentet
         trafficPercent: 100, // hvor stor andel av nye brukere som skal inn i eksperimentet (0–100)
-        pathPrefixes: ["/stillinger/stilling/"], // Hvor gjøres eksperimentet
+        pathPrefixes: ["/stillinger/stilling"], // Hvor gjøres eksperimentet
         variants: [
             { key: "standard", weightPercent: 50 }, // fordeling mellom variantene innenfor eksperimentet (må summe til 100)
             { key: "test", weightPercent: 50 },
@@ -14,7 +14,7 @@ export const experiments = [
     {
         key: "searchbox-simple-variant",
         status: "on", // skru av eller på eksperimentet
-        trafficPercent: 2, // hvor stor andel av nye brukere som skal inn i eksperimentet (0–100)
+        trafficPercent: 100, // hvor stor andel av nye brukere som skal inn i eksperimentet (0–100)
         pathPrefixes: ["/stillinger"], // Hvor gjøres eksperimentet
         variants: [
             { key: "standard", weightPercent: 50 }, // fordeling mellom variantene innenfor eksperimentet (må summe til 100)

--- a/src/app/_experiments/experiments.ts
+++ b/src/app/_experiments/experiments.ts
@@ -11,6 +11,16 @@ export const experiments = [
             { key: "test", weightPercent: 50 },
         ],
     },
+    {
+        key: "searchbox-simple-variant",
+        status: "on", // skru av eller på eksperimentet
+        trafficPercent: 2, // hvor stor andel av nye brukere som skal inn i eksperimentet (0–100)
+        pathPrefixes: ["/stillinger"], // Hvor gjøres eksperimentet
+        variants: [
+            { key: "standard", weightPercent: 50 }, // fordeling mellom variantene innenfor eksperimentet (må summe til 100)
+            { key: "test", weightPercent: 50 },
+        ],
+    },
 ] as const satisfies ReadonlyArray<ExperimentDefinition>;
 
 // TypeScript-typen for alle gyldige experiment keys, basert på "key" i hvert element i experiments-arrayen.

--- a/src/app/_experiments/types.ts
+++ b/src/app/_experiments/types.ts
@@ -11,6 +11,7 @@ export type ExperimentDefinition<K extends string = string> = Readonly<{
 
 export type ExperimentConversion =
     | "cta_click"
+    | "rating"
     | "form_submit"
     | "form_submit_success"
     | "favorite_add"

--- a/src/app/stillinger/(sok)/_components/Search.tsx
+++ b/src/app/stillinger/(sok)/_components/Search.tsx
@@ -3,8 +3,10 @@ import { BodyLong, HGrid, Hide, LocalAlert, Show, VStack } from "@navikt/ds-reac
 import { PageBlock } from "@navikt/ds-react/Page";
 import { useState } from "react";
 import type { SearchLocation } from "@/app/_common/geografi/locationsMapping";
+import { useExperimentVariant } from "@/app/_experiments/client/ExperimentProvider";
 import type FilterAggregations from "@/app/stillinger/_common/types/FilterAggregations";
 import type { SearchResult as SearchResultType } from "@/app/stillinger/_common/types/SearchResult";
+import TmpSearchButtons from "@/app/stillinger/(sok)/_components/searchBox/TmpSearchButtons";
 import type { Postcode } from "@/app/stillinger/(sok)/_utils/fetchPostcodes";
 import { FETCH_SEARCH_WITHIN_DISTANCE_ERROR, type FetchError } from "@/app/stillinger/(sok)/_utils/fetchTypes";
 import Feedback from "./feedback/Feedback";
@@ -24,16 +26,35 @@ type SearchProps = {
     readonly postcodes: readonly Postcode[];
     readonly resultsPerPage: number;
     readonly errors: readonly FetchError[];
+    readonly tmpShowSaveAndResetButton: boolean;
 };
 
-const Search = ({ searchResult, aggregations, locations, postcodes, resultsPerPage, errors }: SearchProps) => {
+const Search = ({
+    searchResult,
+    aggregations,
+    locations,
+    postcodes,
+    resultsPerPage,
+    errors,
+    tmpShowSaveAndResetButton,
+}: SearchProps) => {
     const [isFiltersVisible, setIsFiltersVisible] = useState(false);
 
     const failedToSearchForPostcodes =
         errors.length > 0 && errors.some((error) => error.type === FETCH_SEARCH_WITHIN_DISTANCE_ERROR);
 
+    const tmpTestVariant = useExperimentVariant("qualifications_soek_superrask_cta");
+
     return (
         <div className="mb-24" id="search-wrapper">
+            {tmpTestVariant === "test" && (
+                <TmpSearchButtons
+                    tmpShowSaveAndResetButton={tmpShowSaveAndResetButton}
+                    isFiltersVisible={isFiltersVisible}
+                    setIsFiltersVisible={setIsFiltersVisible}
+                />
+            )}
+
             <SearchResultHeader
                 setIsFiltersVisible={setIsFiltersVisible}
                 isFiltersVisible={isFiltersVisible}

--- a/src/app/stillinger/(sok)/_components/Search.tsx
+++ b/src/app/stillinger/(sok)/_components/Search.tsx
@@ -43,7 +43,7 @@ const Search = ({
     const failedToSearchForPostcodes =
         errors.length > 0 && errors.some((error) => error.type === FETCH_SEARCH_WITHIN_DISTANCE_ERROR);
 
-    const tmpTestVariant = useExperimentVariant("qualifications_soek_superrask_cta");
+    const tmpTestVariant = useExperimentVariant("searchbox-simple-variant");
 
     return (
         <div className="mb-24" id="search-wrapper">

--- a/src/app/stillinger/(sok)/_components/SearchContentSection.tsx
+++ b/src/app/stillinger/(sok)/_components/SearchContentSection.tsx
@@ -10,6 +10,7 @@ type SearchContentSectionProps = {
     readonly locationsResult: FetchResult<SearchLocation[]>;
     readonly postcodesResult: FetchResult<Postcode[]>;
     readonly resultsPerPage: number;
+    readonly tmpShowSaveAndResetButton: boolean;
 };
 
 export default async function SearchContentSection({
@@ -18,6 +19,7 @@ export default async function SearchContentSection({
     locationsResult,
     postcodesResult,
     resultsPerPage,
+    tmpShowSaveAndResetButton,
 }: SearchContentSectionProps) {
     const searchResult = await Promise.resolve(searchResultPromise);
     const aggregations = globalAggregationsResult.data?.aggregations;
@@ -48,6 +50,7 @@ export default async function SearchContentSection({
             postcodes={postcodes}
             resultsPerPage={resultsPerPage}
             errors={errors}
+            tmpShowSaveAndResetButton={tmpShowSaveAndResetButton}
         />
     );
 }

--- a/src/app/stillinger/(sok)/_components/searchBox/SearchCombobox.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/SearchCombobox.tsx
@@ -8,6 +8,7 @@ import { containsEmail, containsValidFnrOrDnr } from "@/app/stillinger/_common/u
 import useQuery from "@/app/stillinger/(sok)/_components/QueryProvider";
 import { buildSelectedOptions } from "@/app/stillinger/(sok)/_components/searchBox/buildSelectedOptions";
 import type { SearchComboboxOption } from "@/app/stillinger/(sok)/_components/searchBox/searchComboboxOptions";
+import { markSearchBoxUsed } from "@/app/stillinger/(sok)/_components/searchExperienceRating/searchBoxUsed";
 import { QueryNames } from "@/app/stillinger/(sok)/_utils/QueryNames";
 import ScreenReaderText from "./ScreenReaderText";
 
@@ -332,6 +333,7 @@ function SearchCombobox({ options }: SearchComboboxProps) {
 
     const onToggleSelected = (option: string, isSelected: boolean, isCustomOption: boolean) => {
         setErrorMessage(null);
+        markSearchBoxUsed();
 
         if (isCustomOption) {
             if (isValidFreeText(option)) {

--- a/src/app/stillinger/(sok)/_components/searchBox/TmpSearchBox.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/TmpSearchBox.tsx
@@ -1,0 +1,26 @@
+import { Box, Heading, HStack } from "@navikt/ds-react";
+import LoggedInButtons from "@/app/stillinger/(sok)/_components/loggedInButtons/LoggedInButtons";
+import TmpSearchField from "@/app/stillinger/(sok)/_components/searchBox/TmpSearchField";
+
+export default function TmpSearchBox() {
+    return (
+        <Box paddingBlock={{ xs: "space-0", lg: "space-40 space-0" }}>
+            <Box
+                paddingInline={{ xs: "space-16", md: "space-32" }}
+                paddingBlock={{ xs: "space-16 space-0", md: "space-24 space-0" }}
+                borderRadius={{ lg: "8" }}
+                maxWidth={{ lg: "800px" }}
+                className="search-container bg-brand-green-subtle"
+            >
+                <HStack justify="space-between" align="center" className="mb-4">
+                    <Heading level="1" size="large">
+                        Søk etter jobber
+                    </Heading>
+                    <LoggedInButtons />
+                </HStack>
+
+                <TmpSearchField />
+            </Box>
+        </Box>
+    );
+}

--- a/src/app/stillinger/(sok)/_components/searchBox/TmpSearchButtons.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/TmpSearchButtons.tsx
@@ -2,7 +2,6 @@
 import { MultiplyIcon } from "@navikt/aksel-icons";
 import { Box, Button, HStack, Show, Stack } from "@navikt/ds-react";
 import { useMemo } from "react";
-import { useExperimentVariant } from "@/app/_experiments/client/ExperimentProvider";
 import useQuery from "@/app/stillinger/(sok)/_components/QueryProvider";
 import { buildSelectedOptions } from "@/app/stillinger/(sok)/_components/searchBox/buildSelectedOptions";
 import SaveSearchButton from "@/app/stillinger/lagrede-sok/_components/SaveSearchButton";
@@ -14,7 +13,6 @@ type SearchProps = {
 };
 
 const TmpSearchButtons = ({ tmpShowSaveAndResetButton, isFiltersVisible, setIsFiltersVisible }: SearchProps) => {
-    const tmpTestVariant = useExperimentVariant("qualifications_soek_superrask_cta");
     const tmpQuery = useQuery();
     const tmpUrlSearchParamsString = tmpQuery.urlSearchParams.toString();
 
@@ -32,40 +30,38 @@ const TmpSearchButtons = ({ tmpShowSaveAndResetButton, isFiltersVisible, setIsFi
             maxWidth={{ lg: "800px" }}
             className="search-container bg-brand-green-subtle mb-8"
         >
-            {tmpTestVariant === "test" && (
-                <Stack align="center" justify={{ xs: "space-between", lg: "end" }}>
-                    <Show below="lg">
+            <Stack align="center" justify={{ xs: "space-between", lg: "end" }}>
+                <Show below="lg">
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        onClick={() => {
+                            setIsFiltersVisible(!isFiltersVisible);
+                        }}
+                        aria-expanded={isFiltersVisible}
+                        aria-label="Velg sted, yrke og andre filtre"
+                        size="small"
+                    >
+                        {tmpSelectedFiltersCount > 0 ? `${tmpSelectedFiltersCount} filter` : "Velg filtre"}
+                    </Button>
+                </Show>
+                {tmpShowSaveAndResetButton && (
+                    <HStack gap="space-2" align="center" justify="end">
                         <Button
                             type="button"
-                            variant="secondary"
+                            variant="tertiary"
                             onClick={() => {
-                                setIsFiltersVisible(!isFiltersVisible);
+                                tmpQuery.reset();
                             }}
-                            aria-expanded={isFiltersVisible}
-                            aria-label="Velg sted, yrke og andre filtre"
+                            icon={<MultiplyIcon aria-hidden="true" />}
                             size="small"
                         >
-                            {tmpSelectedFiltersCount > 0 ? `${tmpSelectedFiltersCount} filter` : "Velg filtre"}
+                            Tøm søk
                         </Button>
-                    </Show>
-                    {tmpShowSaveAndResetButton && (
-                        <HStack gap="space-2" align="center" justify="end">
-                            <Button
-                                type="button"
-                                variant="tertiary"
-                                onClick={() => {
-                                    tmpQuery.reset();
-                                }}
-                                icon={<MultiplyIcon aria-hidden="true" />}
-                                size="small"
-                            >
-                                Tøm søk
-                            </Button>
-                            <SaveSearchButton size="small" />
-                        </HStack>
-                    )}
-                </Stack>
-            )}
+                        <SaveSearchButton size="small" />
+                    </HStack>
+                )}
+            </Stack>
         </Box>
     );
 };

--- a/src/app/stillinger/(sok)/_components/searchBox/TmpSearchButtons.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/TmpSearchButtons.tsx
@@ -1,9 +1,8 @@
 "use client";
 import { MultiplyIcon } from "@navikt/aksel-icons";
 import { Box, Button, HStack, Show, Stack } from "@navikt/ds-react";
-import { useMemo } from "react";
+import FilterIcon from "@/app/_common/components/FilterIcon";
 import useQuery from "@/app/stillinger/(sok)/_components/QueryProvider";
-import { buildSelectedOptions } from "@/app/stillinger/(sok)/_components/searchBox/buildSelectedOptions";
 import SaveSearchButton from "@/app/stillinger/lagrede-sok/_components/SaveSearchButton";
 
 type SearchProps = {
@@ -14,13 +13,6 @@ type SearchProps = {
 
 const TmpSearchButtons = ({ tmpShowSaveAndResetButton, isFiltersVisible, setIsFiltersVisible }: SearchProps) => {
     const tmpQuery = useQuery();
-    const tmpUrlSearchParamsString = tmpQuery.urlSearchParams.toString();
-
-    const tmpSelectedFiltersCount = useMemo(() => {
-        const clone = new URLSearchParams(tmpUrlSearchParamsString);
-        clone.delete("q");
-        return buildSelectedOptions(clone).length;
-    }, [tmpUrlSearchParamsString]);
 
     return (
         <Box
@@ -34,15 +26,16 @@ const TmpSearchButtons = ({ tmpShowSaveAndResetButton, isFiltersVisible, setIsFi
                 <Show below="lg">
                     <Button
                         type="button"
-                        variant="secondary"
+                        variant="primary"
                         onClick={() => {
                             setIsFiltersVisible(!isFiltersVisible);
                         }}
                         aria-expanded={isFiltersVisible}
                         aria-label="Velg sted, yrke og andre filtre"
                         size="small"
+                        icon={<FilterIcon />}
                     >
-                        {tmpSelectedFiltersCount > 0 ? `${tmpSelectedFiltersCount} filter` : "Velg filtre"}
+                        Filter
                     </Button>
                 </Show>
                 {tmpShowSaveAndResetButton && (

--- a/src/app/stillinger/(sok)/_components/searchBox/TmpSearchButtons.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/TmpSearchButtons.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { MultiplyIcon } from "@navikt/aksel-icons";
+import { Box, Button, HStack, Show, Stack } from "@navikt/ds-react";
+import { useMemo } from "react";
+import { useExperimentVariant } from "@/app/_experiments/client/ExperimentProvider";
+import useQuery from "@/app/stillinger/(sok)/_components/QueryProvider";
+import { buildSelectedOptions } from "@/app/stillinger/(sok)/_components/searchBox/buildSelectedOptions";
+import SaveSearchButton from "@/app/stillinger/lagrede-sok/_components/SaveSearchButton";
+
+type SearchProps = {
+    readonly tmpShowSaveAndResetButton: boolean;
+    isFiltersVisible: boolean;
+    setIsFiltersVisible: (isFiltersVisible: boolean) => void;
+};
+
+const TmpSearchButtons = ({ tmpShowSaveAndResetButton, isFiltersVisible, setIsFiltersVisible }: SearchProps) => {
+    const tmpTestVariant = useExperimentVariant("qualifications_soek_superrask_cta");
+    const tmpQuery = useQuery();
+    const tmpUrlSearchParamsString = tmpQuery.urlSearchParams.toString();
+
+    const tmpSelectedFiltersCount = useMemo(() => {
+        const clone = new URLSearchParams(tmpUrlSearchParamsString);
+        clone.delete("q");
+        return buildSelectedOptions(clone).length;
+    }, [tmpUrlSearchParamsString]);
+
+    return (
+        <Box
+            paddingInline={{ xs: "space-16", md: "space-32" }}
+            paddingBlock={{ xs: "space-16 space-16", md: "space-24 space-24" }}
+            borderRadius={{ lg: "8" }}
+            maxWidth={{ lg: "800px" }}
+            className="search-container bg-brand-green-subtle mb-8"
+        >
+            {tmpTestVariant === "test" && (
+                <Stack align="center" justify={{ xs: "space-between", lg: "end" }}>
+                    <Show below="lg">
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            onClick={() => {
+                                setIsFiltersVisible(!isFiltersVisible);
+                            }}
+                            aria-expanded={isFiltersVisible}
+                            aria-label="Velg sted, yrke og andre filtre"
+                            size="small"
+                        >
+                            {tmpSelectedFiltersCount > 0 ? `${tmpSelectedFiltersCount} filter` : "Velg filtre"}
+                        </Button>
+                    </Show>
+                    {tmpShowSaveAndResetButton && (
+                        <HStack gap="space-2" align="center" justify="end">
+                            <Button
+                                type="button"
+                                variant="tertiary"
+                                onClick={() => {
+                                    tmpQuery.reset();
+                                }}
+                                icon={<MultiplyIcon aria-hidden="true" />}
+                                size="small"
+                            >
+                                Tøm søk
+                            </Button>
+                            <SaveSearchButton size="small" />
+                        </HStack>
+                    )}
+                </Stack>
+            )}
+        </Box>
+    );
+};
+
+export default TmpSearchButtons;

--- a/src/app/stillinger/(sok)/_components/searchBox/TmpSearchField.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/TmpSearchField.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Search } from "@navikt/ds-react";
 import { useSearchParams } from "next/navigation";
-import { type SubmitEventHandler, useState } from "react";
+import { type SubmitEventHandler, useEffect, useState } from "react";
 import useQuery from "@/app/stillinger/(sok)/_components/QueryProvider";
 import { QueryNames } from "@/app/stillinger/(sok)/_utils/QueryNames";
 
@@ -9,6 +9,10 @@ export default function TmpSearchField() {
     const query = useQuery();
     const params = useSearchParams();
     const [value, setValue] = useState(params.getAll("q").join(" "));
+
+    useEffect(() => {
+        setValue(params.getAll("q").join(" "));
+    }, [params]);
 
     const onSubmit: SubmitEventHandler<HTMLFormElement> = (event) => {
         event.preventDefault();
@@ -35,6 +39,7 @@ export default function TmpSearchField() {
     };
 
     function onClear() {
+        setValue("");
         query.update(
             (draft) => {
                 draft.delete(QueryNames.SEARCH_STRING);

--- a/src/app/stillinger/(sok)/_components/searchBox/TmpSearchField.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/TmpSearchField.tsx
@@ -3,6 +3,7 @@ import { Search } from "@navikt/ds-react";
 import { useSearchParams } from "next/navigation";
 import { type SubmitEventHandler, useEffect, useState } from "react";
 import useQuery from "@/app/stillinger/(sok)/_components/QueryProvider";
+import { markSearchBoxUsed } from "@/app/stillinger/(sok)/_components/searchExperienceRating/searchBoxUsed";
 import { QueryNames } from "@/app/stillinger/(sok)/_utils/QueryNames";
 
 export default function TmpSearchField() {
@@ -16,6 +17,7 @@ export default function TmpSearchField() {
 
     const onSubmit: SubmitEventHandler<HTMLFormElement> = (event) => {
         event.preventDefault();
+        markSearchBoxUsed();
 
         if (value) {
             query.update(

--- a/src/app/stillinger/(sok)/_components/searchBox/TmpSearchField.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/TmpSearchField.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { Search } from "@navikt/ds-react";
+import { useSearchParams } from "next/navigation";
+import { type SubmitEventHandler, useState } from "react";
+import useQuery from "@/app/stillinger/(sok)/_components/QueryProvider";
+import { QueryNames } from "@/app/stillinger/(sok)/_utils/QueryNames";
+
+export default function TmpSearchField() {
+    const query = useQuery();
+    const params = useSearchParams();
+    const [value, setValue] = useState(params.getAll("q").join(" "));
+
+    const onSubmit: SubmitEventHandler<HTMLFormElement> = (event) => {
+        event.preventDefault();
+
+        if (value) {
+            query.update(
+                (draft) => {
+                    draft.set(QueryNames.SEARCH_STRING, value);
+                },
+                {
+                    changedKey: QueryNames.SEARCH_STRING,
+                },
+            );
+        } else {
+            query.update(
+                (draft) => {
+                    draft.delete(QueryNames.SEARCH_STRING);
+                },
+                {
+                    changedKey: QueryNames.SEARCH_STRING,
+                },
+            );
+        }
+    };
+
+    function onClear() {
+        query.update(
+            (draft) => {
+                draft.delete(QueryNames.SEARCH_STRING);
+            },
+            {
+                changedKey: QueryNames.SEARCH_STRING,
+            },
+        );
+    }
+
+    return (
+        <form onSubmit={onSubmit}>
+            <Search onClear={onClear} name="q" value={value} onChange={setValue} label="Søk etter jobber" />
+        </form>
+    );
+}

--- a/src/app/stillinger/(sok)/_components/searchBox/TmpSearchField.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/TmpSearchField.tsx
@@ -47,7 +47,14 @@ export default function TmpSearchField() {
 
     return (
         <form onSubmit={onSubmit}>
-            <Search onClear={onClear} name="q" value={value} onChange={setValue} label="Søk etter jobber" />
+            <Search
+                variant="secondary"
+                onClear={onClear}
+                name="q"
+                value={value}
+                onChange={setValue}
+                label="Søk etter jobber"
+            />
         </form>
     );
 }

--- a/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRating.test.tsx
+++ b/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRating.test.tsx
@@ -1,0 +1,167 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchExperienceRating } from "./SearchExperienceRating";
+
+vi.mock("@/app/_experiments/client/ExperimentProvider", () => ({
+    useExperimentVariant: () => "test",
+}));
+
+const trackMock = vi.fn();
+vi.mock("@/app/_common/umami", () => ({
+    track: (eventName: string, props?: Record<string, unknown>) => {
+        trackMock(eventName, props);
+    },
+}));
+
+vi.mock("./searchExperienceCookie", () => ({
+    hasSearchExperienceRatingCookie: () => false,
+    setSearchExperienceRatingCookie: vi.fn(),
+}));
+
+vi.mock("./searchBoxUsed", () => ({
+    hasSearchBoxBeenUsed: () => true,
+}));
+
+import { setSearchExperienceRatingCookie } from "./searchExperienceCookie";
+
+type ObserverCallback = (entries: readonly IntersectionObserverEntry[]) => void;
+
+class MockIntersectionObserver {
+    public static instances: MockIntersectionObserver[] = [];
+
+    private readonly callback: ObserverCallback;
+
+    public constructor(callback: ObserverCallback) {
+        this.callback = callback;
+        MockIntersectionObserver.instances.push(this);
+    }
+
+    public observe() {}
+    public unobserve() {}
+    public disconnect() {}
+
+    public trigger(isIntersecting: boolean) {
+        this.callback([{ isIntersecting } as IntersectionObserverEntry]);
+    }
+}
+
+describe("SearchExperienceRating", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        MockIntersectionObserver.instances = [];
+        vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    function renderWithRef() {
+        const ref = { current: document.createElement("div") };
+        const result = render(<SearchExperienceRating searchBoxRef={ref} />);
+        return { ...result, ref };
+    }
+
+    function openDialog() {
+        const observer = MockIntersectionObserver.instances[0];
+        act(() => {
+            observer.trigger(false);
+        });
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+    }
+
+    it("should not show dialog initially", () => {
+        renderWithRef();
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("should show dialog 2s after search box leaves viewport", () => {
+        renderWithRef();
+        openDialog();
+
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        expect(screen.getByText("Bare et kjapt spørsmål?")).toBeInTheDocument();
+    });
+
+    it("should not show dialog if search box returns to viewport before timeout", () => {
+        renderWithRef();
+
+        const observer = MockIntersectionObserver.instances[0];
+        act(() => {
+            observer.trigger(false);
+        });
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        act(() => {
+            observer.trigger(true);
+        });
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("should track rating and show thank you state when user rates", () => {
+        renderWithRef();
+        openDialog();
+
+        const ratingButton = screen.getByRole("button", { name: /Fantastisk \(5 av 5\)/ });
+        fireEvent.click(ratingButton);
+
+        expect(trackMock).toHaveBeenCalledWith("AB - konvertering", {
+            experiment: "searchbox-simple-variant",
+            variant: "test",
+            konvertering: "rating",
+            rating: 5,
+        });
+
+        expect(setSearchExperienceRatingCookie).toHaveBeenCalledWith("rated");
+
+        // Dialog should still be open with thank you content
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        expect(screen.getByText("🎉 Tusen takk!")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Gi tilbakemelding" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Ferdig" })).toBeInTheDocument();
+    });
+
+    it("should close dialog when clicking Ferdig in thank you state", () => {
+        renderWithRef();
+        openDialog();
+
+        const ratingButton = screen.getByRole("button", { name: /Bra \(4 av 5\)/ });
+        fireEvent.click(ratingButton);
+
+        expect(screen.getByText("🎉 Tusen takk!")).toBeInTheDocument();
+
+        const closeButton = screen.getByRole("button", { name: "Ferdig" });
+        fireEvent.click(closeButton);
+
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("should set cookie when user dismisses", () => {
+        renderWithRef();
+        openDialog();
+
+        const dismissButton = screen.getByRole("button", { name: "Nei takk, vil ikke stemme" });
+        fireEvent.click(dismissButton);
+
+        expect(setSearchExperienceRatingCookie).toHaveBeenCalledWith("dismissed");
+    });
+
+    it("should render all 5 emoji options", () => {
+        renderWithRef();
+        openDialog();
+
+        expect(screen.getByRole("button", { name: /Veldig dårlig \(1 av 5\)/ })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Dårlig \(2 av 5\)/ })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Helt greit \(3 av 5\)/ })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Bra \(4 av 5\)/ })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Fantastisk \(5 av 5\)/ })).toBeInTheDocument();
+    });
+});

--- a/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRating.test.tsx
+++ b/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRating.test.tsx
@@ -83,7 +83,7 @@ describe("SearchExperienceRating", () => {
         openDialog();
 
         expect(screen.getByRole("dialog")).toBeInTheDocument();
-        expect(screen.getByText("Bare et kjapt spørsmål?")).toBeInTheDocument();
+        expect(screen.getByText("Hvordan synes du søkefelt og filter virker?")).toBeInTheDocument();
     });
 
     it("should not show dialog if search box returns to viewport before timeout", () => {
@@ -126,10 +126,11 @@ describe("SearchExperienceRating", () => {
         expect(screen.getByRole("dialog")).toBeInTheDocument();
         expect(screen.getByText("🎉 Tusen takk!")).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "Gi tilbakemelding" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Ferdig" })).toBeInTheDocument();
+        const closeButtons = screen.getAllByRole("button", { name: "Lukk" });
+        expect(closeButtons.length).toBeGreaterThanOrEqual(1);
     });
 
-    it("should close dialog when clicking Ferdig in thank you state", () => {
+    it("should close dialog when clicking Lukk in thank you state", () => {
         renderWithRef();
         openDialog();
 
@@ -138,8 +139,10 @@ describe("SearchExperienceRating", () => {
 
         expect(screen.getByText("🎉 Tusen takk!")).toBeInTheDocument();
 
-        const closeButton = screen.getByRole("button", { name: "Ferdig" });
-        fireEvent.click(closeButton);
+        // Select the explicit "Lukk" button (not the Dialog's built-in X close button)
+        const closeButtons = screen.getAllByRole("button", { name: "Lukk" });
+        const primaryCloseButton = closeButtons.find((btn) => btn.textContent === "Lukk");
+        fireEvent.click(primaryCloseButton!);
 
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });

--- a/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRating.tsx
+++ b/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRating.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { BodyLong, BodyShort, Button, Dialog, HStack, Link, VStack } from "@navikt/ds-react";
+import { useRef, useState } from "react";
+import { track } from "@/app/_common/umami";
+import { useExperimentVariant } from "@/app/_experiments/client/ExperimentProvider";
+import { setSearchExperienceRatingCookie } from "./searchExperienceCookie";
+import { useSearchRatingSurvey } from "./useSearchRatingSurvey";
+
+type SearchExperienceRatingProps = {
+    readonly searchBoxRef: React.RefObject<HTMLElement | null>;
+};
+
+const EMOJI_OPTIONS = [
+    { emoji: "🤮", label: "Veldig dårlig", value: 1 },
+    { emoji: "😟", label: "Dårlig", value: 2 },
+    { emoji: "😐", label: "Helt greit", value: 3 },
+    { emoji: "🙂", label: "Bra", value: 4 },
+    { emoji: "😍", label: "Fantastisk", value: 5 },
+] as const;
+
+// TODO: Bytt ut med riktig Skyra-lenke når den er klar
+const SKYRA_SURVEY_URL = "https://example.com/skyra-survey";
+
+export function SearchExperienceRating({ searchBoxRef }: SearchExperienceRatingProps) {
+    const variant = useExperimentVariant("searchbox-simple-variant");
+    const { state, dismiss, complete } = useSearchRatingSurvey({ searchBoxRef });
+    const hasRated = useRef(false);
+    const [showThankYou, setShowThankYou] = useState(false);
+
+    function handleRate(rating: 1 | 2 | 3 | 4 | 5) {
+        if (hasRated.current) {
+            return;
+        }
+        hasRated.current = true;
+
+        track("AB - konvertering", {
+            experiment: "searchbox-simple-variant",
+            konvertering: "rating",
+            variant,
+            rating,
+        });
+
+        setSearchExperienceRatingCookie("rated");
+        setShowThankYou(true);
+    }
+
+    function handleDismiss() {
+        setSearchExperienceRatingCookie("dismissed");
+        dismiss();
+    }
+
+    function handleClose() {
+        complete();
+    }
+
+    const isOpen = state === "open";
+
+    return (
+        <Dialog
+            open={isOpen}
+            onOpenChange={(open) => !open && (showThankYou ? handleClose() : handleDismiss())}
+            size="small"
+        >
+            <Dialog.Popup>
+                {showThankYou ? (
+                    <>
+                        <Dialog.Header>
+                            <Dialog.Title>🎉 Tusen takk!</Dialog.Title>
+                        </Dialog.Header>
+                        <Dialog.Body>
+                            <VStack gap="space-16">
+                                <BodyLong>
+                                    Fortell gjerne hva som fungerte, eller hva du savnet. Det kan gjøre det enklere å
+                                    finne jobber som passer for deg.
+                                </BodyLong>
+                                <Link href={SKYRA_SURVEY_URL} target="_blank">
+                                    Gi tilbakemelding
+                                </Link>
+                            </VStack>
+                        </Dialog.Body>
+                        <Dialog.Footer>
+                            <Button variant="primary" size="small" onClick={handleClose}>
+                                Ferdig
+                            </Button>
+                        </Dialog.Footer>
+                    </>
+                ) : (
+                    <>
+                        <Dialog.Header>
+                            <Dialog.Title>Bare et kjapt spørsmål?</Dialog.Title>
+                        </Dialog.Header>
+                        <Dialog.Body>
+                            <VStack gap="space-16" align="center">
+                                <HStack
+                                    gap="space-12"
+                                    justify="center"
+                                    role="group"
+                                    aria-label="Gi en vurdering fra 1 til 5"
+                                >
+                                    {EMOJI_OPTIONS.map((option) => (
+                                        <Button
+                                            key={option.value}
+                                            variant="tertiary-neutral"
+                                            size="medium"
+                                            onClick={() => handleRate(option.value)}
+                                            aria-label={`${option.label} (${option.value} av 5)`}
+                                            icon={option.emoji}
+                                        />
+                                    ))}
+                                </HStack>
+                                <HStack justify="space-between" className="w-full">
+                                    <BodyShort size="small" textColor="subtle">
+                                        Hvordan synes du søkefelt og filter virker?
+                                    </BodyShort>
+                                </HStack>
+                            </VStack>
+                        </Dialog.Body>
+                        <Dialog.Footer>
+                            <Dialog.CloseTrigger>
+                                <Button variant="tertiary" size="small">
+                                    Nei takk, vil ikke stemme
+                                </Button>
+                            </Dialog.CloseTrigger>
+                        </Dialog.Footer>
+                    </>
+                )}
+            </Dialog.Popup>
+        </Dialog>
+    );
+}

--- a/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRating.tsx
+++ b/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRating.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BodyLong, BodyShort, Button, Dialog, HStack, Link, VStack } from "@navikt/ds-react";
+import { BodyLong, Button, Dialog, HStack, Link, VStack } from "@navikt/ds-react";
 import { useRef, useState } from "react";
 import { track } from "@/app/_common/umami";
 import { useExperimentVariant } from "@/app/_experiments/client/ExperimentProvider";
@@ -70,10 +70,7 @@ export function SearchExperienceRating({ searchBoxRef }: SearchExperienceRatingP
                         </Dialog.Header>
                         <Dialog.Body>
                             <VStack gap="space-16">
-                                <BodyLong>
-                                    Fortell gjerne hva som fungerte, eller hva du savnet. Det kan gjøre det enklere å
-                                    finne jobber som passer for deg.
-                                </BodyLong>
+                                <BodyLong>Fortell gjerne hva som fungerte, eller hva du savnet.</BodyLong>
                                 <Link href={SKYRA_SURVEY_URL} target="_blank">
                                     Gi tilbakemelding
                                 </Link>
@@ -81,14 +78,14 @@ export function SearchExperienceRating({ searchBoxRef }: SearchExperienceRatingP
                         </Dialog.Body>
                         <Dialog.Footer>
                             <Button variant="primary" size="small" onClick={handleClose}>
-                                Ferdig
+                                Lukk
                             </Button>
                         </Dialog.Footer>
                     </>
                 ) : (
                     <>
                         <Dialog.Header>
-                            <Dialog.Title>Bare et kjapt spørsmål?</Dialog.Title>
+                            <Dialog.Title>Hvordan synes du søkefelt og filter virker?</Dialog.Title>
                         </Dialog.Header>
                         <Dialog.Body>
                             <VStack gap="space-16" align="center">
@@ -108,11 +105,6 @@ export function SearchExperienceRating({ searchBoxRef }: SearchExperienceRatingP
                                             icon={option.emoji}
                                         />
                                     ))}
-                                </HStack>
-                                <HStack justify="space-between" className="w-full">
-                                    <BodyShort size="small" textColor="subtle">
-                                        Hvordan synes du søkefelt og filter virker?
-                                    </BodyShort>
                                 </HStack>
                             </VStack>
                         </Dialog.Body>

--- a/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRatingWrapper.tsx
+++ b/src/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRatingWrapper.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import type React from "react";
+import { useRef } from "react";
+import { SearchExperienceRating } from "./SearchExperienceRating";
+
+type SearchExperienceRatingWrapperProps = {
+    readonly children: React.ReactNode;
+};
+
+export function SearchExperienceRatingWrapper({ children }: SearchExperienceRatingWrapperProps) {
+    const searchBoxRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <>
+            <div ref={searchBoxRef}>{children}</div>
+            <SearchExperienceRating searchBoxRef={searchBoxRef} />
+        </>
+    );
+}

--- a/src/app/stillinger/(sok)/_components/searchExperienceRating/searchBoxUsed.ts
+++ b/src/app/stillinger/(sok)/_components/searchExperienceRating/searchBoxUsed.ts
@@ -1,0 +1,21 @@
+const STORAGE_KEY = "ab_search_box_used";
+
+/**
+ * Markerer at brukeren har interagert med søkefeltet (combobox eller forenklet input).
+ * Kalles fra SearchCombobox og det forenklede søkefeltet.
+ */
+export function markSearchBoxUsed(): void {
+    if (typeof sessionStorage === "undefined") {
+        return;
+    }
+
+    sessionStorage.setItem(STORAGE_KEY, "1");
+}
+
+export function hasSearchBoxBeenUsed(): boolean {
+    if (typeof sessionStorage === "undefined") {
+        return false;
+    }
+
+    return sessionStorage.getItem(STORAGE_KEY) === "1";
+}

--- a/src/app/stillinger/(sok)/_components/searchExperienceRating/searchExperienceCookie.ts
+++ b/src/app/stillinger/(sok)/_components/searchExperienceRating/searchExperienceCookie.ts
@@ -1,0 +1,23 @@
+const COOKIE_NAME = "ab_searchbox_simple_variant_rated";
+const MAX_AGE_DAYS = 120;
+
+export function getSearchExperienceRatingCookieName(): string {
+    return COOKIE_NAME;
+}
+
+export function hasSearchExperienceRatingCookie(): boolean {
+    if (typeof document === "undefined") {
+        return false;
+    }
+
+    return document.cookie.split("; ").some((c) => c.startsWith(`${COOKIE_NAME}=`));
+}
+
+export function setSearchExperienceRatingCookie(value: "rated" | "dismissed"): void {
+    if (typeof document === "undefined") {
+        return;
+    }
+
+    const maxAge = MAX_AGE_DAYS * 24 * 60 * 60;
+    document.cookie = `${COOKIE_NAME}=${value}; path=/; max-age=${maxAge}; SameSite=Lax`;
+}

--- a/src/app/stillinger/(sok)/_components/searchExperienceRating/useSearchRatingSurvey.ts
+++ b/src/app/stillinger/(sok)/_components/searchExperienceRating/useSearchRatingSurvey.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { hasSearchBoxBeenUsed } from "./searchBoxUsed";
+import { hasSearchExperienceRatingCookie } from "./searchExperienceCookie";
+
+type SurveyState = "idle" | "waiting" | "open" | "dismissed" | "completed";
+
+const DELAY_MS = 2_000;
+
+type UseSearchRatingSurveyOptions = {
+    readonly searchBoxRef: React.RefObject<HTMLElement | null>;
+    readonly enabled?: boolean;
+};
+
+type UseSearchRatingSurveyResult = {
+    readonly state: SurveyState;
+    readonly open: () => void;
+    readonly dismiss: () => void;
+    readonly complete: () => void;
+};
+
+export function useSearchRatingSurvey({
+    searchBoxRef,
+    enabled = true,
+}: UseSearchRatingSurveyOptions): UseSearchRatingSurveyResult {
+    const [state, setState] = useState<SurveyState>("idle");
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        if (hasSearchExperienceRatingCookie()) {
+            return;
+        }
+
+        const target = searchBoxRef.current;
+        if (!target) {
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const entry = entries[0];
+                if (!entry) {
+                    return;
+                }
+
+                if (!entry.isIntersecting) {
+                    // Sjekk om brukeren faktisk har brukt søkefeltet
+                    if (!hasSearchBoxBeenUsed()) {
+                        return;
+                    }
+
+                    if (timerRef.current === null) {
+                        timerRef.current = setTimeout(() => {
+                            timerRef.current = null;
+                            setState((current) => {
+                                if (current === "idle") {
+                                    return "open";
+                                }
+                                return current;
+                            });
+                        }, DELAY_MS);
+                    }
+                } else {
+                    if (timerRef.current !== null) {
+                        clearTimeout(timerRef.current);
+                        timerRef.current = null;
+                    }
+                }
+            },
+            { threshold: 0 },
+        );
+
+        observer.observe(target);
+
+        return () => {
+            observer.disconnect();
+            if (timerRef.current !== null) {
+                clearTimeout(timerRef.current);
+                timerRef.current = null;
+            }
+        };
+    }, [enabled, searchBoxRef]);
+
+    const open = useCallback(() => {
+        setState("open");
+    }, []);
+
+    const dismiss = useCallback(() => {
+        setState("dismissed");
+    }, []);
+
+    const complete = useCallback(() => {
+        setState("completed");
+    }, []);
+
+    return { state, open, dismiss, complete };
+}

--- a/src/app/stillinger/(sok)/_components/searchResultHeader/SearchResultHeader.tsx
+++ b/src/app/stillinger/(sok)/_components/searchResultHeader/SearchResultHeader.tsx
@@ -19,7 +19,7 @@ export default function SearchResultHeader({
 }: SearchResultHeaderProps) {
     const stillingerWord: string = searchResult.totalPositions === 1 ? "stilling" : "stillinger";
 
-    const tmpTestVariant = useExperimentVariant("qualifications_soek_superrask_cta");
+    const tmpTestVariant = useExperimentVariant("searchbox-simple-variant");
 
     return (
         <Box className="bg-alt-1-subtle-on-lg" paddingBlock={{ lg: "space-16" }}>

--- a/src/app/stillinger/(sok)/_components/searchResultHeader/SearchResultHeader.tsx
+++ b/src/app/stillinger/(sok)/_components/searchResultHeader/SearchResultHeader.tsx
@@ -1,6 +1,7 @@
 import { BodyShort, Box, Button, Heading, HGrid, HStack, Show, Stack } from "@navikt/ds-react";
 import { PageBlock } from "@navikt/ds-react/Page";
 import FilterIcon from "@/app/_common/components/FilterIcon";
+import { useExperimentVariant } from "@/app/_experiments/client/ExperimentProvider";
 import type { SearchResult } from "@/app/stillinger/_common/types/SearchResult";
 import { formatNumber } from "@/app/stillinger/_common/utils/utils";
 import Sorting from "@/app/stillinger/(sok)/_components/searchResult/Sorting";
@@ -17,6 +18,8 @@ export default function SearchResultHeader({
     setIsFiltersVisible,
 }: SearchResultHeaderProps) {
     const stillingerWord: string = searchResult.totalPositions === 1 ? "stilling" : "stillinger";
+
+    const tmpTestVariant = useExperimentVariant("qualifications_soek_superrask_cta");
 
     return (
         <Box className="bg-alt-1-subtle-on-lg" paddingBlock={{ lg: "space-16" }}>
@@ -57,19 +60,20 @@ export default function SearchResultHeader({
 
                             <HStack gap="space-8" align="center" wrap={false}>
                                 <Sorting />
-
-                                <Show below="lg">
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        onClick={() => {
-                                            setIsFiltersVisible(!isFiltersVisible);
-                                        }}
-                                        icon={<FilterIcon />}
-                                        aria-expanded={isFiltersVisible}
-                                        aria-label="Velg sted, yrke og andre filtre"
-                                    />
-                                </Show>
+                                {tmpTestVariant === "standard" && (
+                                    <Show below="lg">
+                                        <Button
+                                            type="button"
+                                            variant="secondary"
+                                            onClick={() => {
+                                                setIsFiltersVisible(!isFiltersVisible);
+                                            }}
+                                            icon={<FilterIcon />}
+                                            aria-expanded={isFiltersVisible}
+                                            aria-label="Velg sted, yrke og andre filtre"
+                                        />
+                                    </Show>
+                                )}
                             </HStack>
                         </HStack>
                     </Stack>

--- a/src/app/stillinger/(sok)/page.tsx
+++ b/src/app/stillinger/(sok)/page.tsx
@@ -5,15 +5,21 @@ import { Suspense } from "react";
 import { z } from "zod";
 import type { SearchLocation } from "@/app/_common/geografi/locationsMapping";
 import { appLogger } from "@/app/_common/logging/appLogger";
+import { ExperimentProvider } from "@/app/_experiments/client/ExperimentProvider";
+import { Experiment } from "@/app/_experiments/server/Experiment";
+import { getVariantMap } from "@/app/_experiments/server/getVariantMap";
 import { logTextSearch } from "@/app/stillinger/_common/monitoring/search-logging";
 import { getDefaultHeaders } from "@/app/stillinger/_common/utils/fetch";
 import MaxQuerySizeExceeded from "@/app/stillinger/(sok)/_components/maxQuerySizeExceeded/MaxQuerySizeExceeded";
 import SearchContentSection from "@/app/stillinger/(sok)/_components/SearchContentSection";
 import SearchBox from "@/app/stillinger/(sok)/_components/searchBox/SearchBox";
 import {
+    createSavedSearchParamsWithoutVersion,
+    searchParamsSize,
     toSavedSearchUrlSearchParams,
     toUrlSearchParams,
 } from "@/app/stillinger/(sok)/_components/searchBox/searchParamsUtils";
+import TmpSearchBox from "@/app/stillinger/(sok)/_components/searchBox/TmpSearchBox";
 import SearchContentSkeleton from "@/app/stillinger/(sok)/_components/skeletons/SearchContentSkeleton";
 import {
     fetchCachedGlobalAggregations,
@@ -231,24 +237,43 @@ export default async function Page(props: PageProps) {
     const urlSearchParams = toUrlSearchParams(searchParams);
     const savedSearchUrlSearchParams = toSavedSearchUrlSearchParams(searchParams);
 
+    // Temporarily AB-test
+    const tmpABTestVariants = await getVariantMap(["qualifications_soek_superrask_cta"]);
+    const tmpSavedSearchParamsWithoutVersion = createSavedSearchParamsWithoutVersion(savedSearchUrlSearchParams);
+    const tmpOnlyDrivingDistanceFiltersActive =
+        searchParamsSize(tmpSavedSearchParamsWithoutVersion) === 2 &&
+        tmpSavedSearchParamsWithoutVersion.has(QueryNames.POSTCODE) &&
+        tmpSavedSearchParamsWithoutVersion.has(QueryNames.DISTANCE);
+    const tmpShowSaveAndResetButton =
+        searchParamsSize(tmpSavedSearchParamsWithoutVersion) > 0 && !tmpOnlyDrivingDistanceFiltersActive;
+
     return (
         <>
-            <SearchBox
-                globalAggregationsResult={globalAggregationsResult}
-                locationsResult={locationsResult}
-                postcodesResult={postcodesResult}
-                searchParams={urlSearchParams}
-                savedSearchParams={savedSearchUrlSearchParams}
+            <Experiment
+                experiment="qualifications_soek_superrask_cta"
+                test={<TmpSearchBox />}
+                standard={
+                    <SearchBox
+                        globalAggregationsResult={globalAggregationsResult}
+                        locationsResult={locationsResult}
+                        postcodesResult={postcodesResult}
+                        searchParams={urlSearchParams}
+                        savedSearchParams={savedSearchUrlSearchParams}
+                    />
+                }
             />
 
             <Suspense fallback={<SearchContentSkeleton />}>
-                <SearchContentSection
-                    searchResultPromise={searchResultPromise}
-                    globalAggregationsResult={globalAggregationsResult}
-                    locationsResult={locationsResult}
-                    postcodesResult={postcodesResult}
-                    resultsPerPage={resultsPerPage}
-                />
+                <ExperimentProvider variants={tmpABTestVariants}>
+                    <SearchContentSection
+                        searchResultPromise={searchResultPromise}
+                        globalAggregationsResult={globalAggregationsResult}
+                        locationsResult={locationsResult}
+                        postcodesResult={postcodesResult}
+                        resultsPerPage={resultsPerPage}
+                        tmpShowSaveAndResetButton={tmpShowSaveAndResetButton}
+                    />
+                </ExperimentProvider>
             </Suspense>
         </>
     );

--- a/src/app/stillinger/(sok)/page.tsx
+++ b/src/app/stillinger/(sok)/page.tsx
@@ -20,6 +20,7 @@ import {
     toUrlSearchParams,
 } from "@/app/stillinger/(sok)/_components/searchBox/searchParamsUtils";
 import TmpSearchBox from "@/app/stillinger/(sok)/_components/searchBox/TmpSearchBox";
+import { SearchExperienceRatingWrapper } from "@/app/stillinger/(sok)/_components/searchExperienceRating/SearchExperienceRatingWrapper";
 import SearchContentSkeleton from "@/app/stillinger/(sok)/_components/skeletons/SearchContentSkeleton";
 import {
     fetchCachedGlobalAggregations,
@@ -249,19 +250,21 @@ export default async function Page(props: PageProps) {
 
     return (
         <>
-            <Experiment
-                experiment="searchbox-simple-variant"
-                test={<TmpSearchBox />}
-                standard={
-                    <SearchBox
-                        globalAggregationsResult={globalAggregationsResult}
-                        locationsResult={locationsResult}
-                        postcodesResult={postcodesResult}
-                        searchParams={urlSearchParams}
-                        savedSearchParams={savedSearchUrlSearchParams}
-                    />
-                }
-            />
+            <SearchExperienceRatingWrapper>
+                <Experiment
+                    experiment="searchbox-simple-variant"
+                    test={<TmpSearchBox />}
+                    standard={
+                        <SearchBox
+                            globalAggregationsResult={globalAggregationsResult}
+                            locationsResult={locationsResult}
+                            postcodesResult={postcodesResult}
+                            searchParams={urlSearchParams}
+                            savedSearchParams={savedSearchUrlSearchParams}
+                        />
+                    }
+                />
+            </SearchExperienceRatingWrapper>
 
             <Suspense fallback={<SearchContentSkeleton />}>
                 <ExperimentProvider variants={tmpABTestVariants}>

--- a/src/app/stillinger/(sok)/page.tsx
+++ b/src/app/stillinger/(sok)/page.tsx
@@ -238,7 +238,7 @@ export default async function Page(props: PageProps) {
     const savedSearchUrlSearchParams = toSavedSearchUrlSearchParams(searchParams);
 
     // Temporarily AB-test
-    const tmpABTestVariants = await getVariantMap(["qualifications_soek_superrask_cta"]);
+    const tmpABTestVariants = await getVariantMap(["searchbox-simple-variant"]);
     const tmpSavedSearchParamsWithoutVersion = createSavedSearchParamsWithoutVersion(savedSearchUrlSearchParams);
     const tmpOnlyDrivingDistanceFiltersActive =
         searchParamsSize(tmpSavedSearchParamsWithoutVersion) === 2 &&
@@ -250,7 +250,7 @@ export default async function Page(props: PageProps) {
     return (
         <>
             <Experiment
-                experiment="qualifications_soek_superrask_cta"
+                experiment="searchbox-simple-variant"
                 test={<TmpSearchBox />}
                 standard={
                     <SearchBox

--- a/src/app/stillinger/lagrede-sok/_components/SaveSearchButton.tsx
+++ b/src/app/stillinger/lagrede-sok/_components/SaveSearchButton.tsx
@@ -3,6 +3,7 @@ import { FloppydiskIcon } from "@navikt/aksel-icons";
 import { Button, type ButtonProps } from "@navikt/ds-react";
 import { useSearchParams } from "next/navigation";
 import { useContext } from "react";
+import { useExperimentVariant } from "@/app/_experiments/client/ExperimentProvider";
 import LoginModal from "@/app/stillinger/_common/auth/components/LoginModal";
 import {
     AuthenticationContext,
@@ -44,6 +45,8 @@ function SaveSearchButton({ size }: SaveSearchButtonProps) {
     const searchParams = useSearchParams();
     const savedSearchUuid = searchParams?.get("saved");
 
+    const tmpTestVariant = useExperimentVariant("qualifications_soek_superrask_cta");
+
     function handleClick(): void {
         if (authenticationStatus === AuthenticationStatus.NOT_AUTHENTICATED) {
             openLoginModal();
@@ -73,7 +76,7 @@ function SaveSearchButton({ size }: SaveSearchButtonProps) {
                 type="button"
                 onClick={handleClick}
             >
-                Lagre søk
+                {tmpTestVariant === "test" ? "Lagre" : "Lagre søk"}
             </Button>
 
             {shouldShowQueryIsEmptyModal && <SearchIsEmptyModal onClose={closeQueryIsEmptyModal} />}

--- a/src/app/stillinger/lagrede-sok/_components/SaveSearchButton.tsx
+++ b/src/app/stillinger/lagrede-sok/_components/SaveSearchButton.tsx
@@ -45,7 +45,7 @@ function SaveSearchButton({ size }: SaveSearchButtonProps) {
     const searchParams = useSearchParams();
     const savedSearchUuid = searchParams?.get("saved");
 
-    const tmpTestVariant = useExperimentVariant("qualifications_soek_superrask_cta");
+    const tmpTestVariant = useExperimentVariant("searchbox-simple-variant");
 
     function handleClick(): void {
         if (authenticationStatus === AuthenticationStatus.NOT_AUTHENTICATED) {


### PR DESCRIPTION
- Emoji-rating (1-5) i modal dialog etter bruker har søkt og scrollet ned
 - Trigges 2s etter søkeboksen forsvinner fra viewport
 - Krever at bruker faktisk har brukt søkefeltet (sessionStorage-flagg)
 - Cookie hindrer at undersøkelsen vises mer enn én gang
 - Tracker rating via "AB - konvertering" umami-event med variant
 - Viser takk-melding med lenke til Skyra-undersøkelse etter rating
 - Integrert med PR https://github.com/navikt/pam-stillingsok/pull/1469 sin forenklede søkeboks (searchbox-simple-variant)
 - markSearchBoxUsed() lagt til i både SearchCombobox og TmpSearchField