### PR TITLE
Fikser spacing og border-radius i infoboksene

### DIFF
--- a/src/app/stillinger/(sok)/_components/howToPanels/DoYouWantToSaveSearch.tsx
+++ b/src/app/stillinger/(sok)/_components/howToPanels/DoYouWantToSaveSearch.tsx
@@ -16,7 +16,7 @@ function DoYouWantToSaveSearch({ resultsPerPage, totalAds }: DoYouWantToSaveSear
 
     if (from + resultsPerPage >= totalAds) {
         return (
-            <Box padding={{ xs: "space-16", md: "space-24" }} borderRadius="2" className="bg-brand-blue-soft">
+            <Box padding={{ xs: "space-16", md: "space-24" }} borderRadius="8" className="bg-brand-blue-subtle">
                 <VStack align="center">
                     <Heading level="3" size="small" className="text-center" spacing>
                         Varsel ved nye treff?

--- a/src/app/stillinger/(sok)/_components/searchResult/KarriereveiledningBanner.tsx
+++ b/src/app/stillinger/(sok)/_components/searchResult/KarriereveiledningBanner.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Box, Heading, HGrid, HStack } from "@navikt/ds-react";
+import { BodyLong, Box, Heading, HGrid, HStack } from "@navikt/ds-react";
 import { AkselNextLink } from "@/app/_common/components/AkselNextLink";
 import FigureConfused from "@/app/_common/components/FigureConfused";
 import { track } from "@/app/_common/umami";
@@ -8,7 +8,7 @@ export default function KarriereveiledningBanner() {
     return (
         <Box
             padding={{ xs: "space-16", md: "space-32" }}
-            borderRadius="2"
+            borderRadius="8"
             className="bg-brand-peach-subtle"
             data-nosnippet="true"
         >
@@ -18,7 +18,7 @@ export default function KarriereveiledningBanner() {
                         Trenger du forslag til jobb?
                     </Heading>
 
-                    <BodyShort spacing>
+                    <BodyLong>
                         På{" "}
                         <AkselNextLink
                             className="default-text-color-link"
@@ -31,7 +31,7 @@ export default function KarriereveiledningBanner() {
                             Karriereveiledning.no
                         </AkselNextLink>{" "}
                         kan du finne jobber basert på din utdanning og erfaring.
-                    </BodyShort>
+                    </BodyLong>
                 </div>
 
                 <HStack justify="center">

--- a/src/app/stillinger/(sok)/_components/utdanningno/UtdanningNoPanel.tsx
+++ b/src/app/stillinger/(sok)/_components/utdanningno/UtdanningNoPanel.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Box, Heading, HGrid, HStack } from "@navikt/ds-react";
+import { BodyLong, Box, Heading, HGrid, HStack } from "@navikt/ds-react";
 import { AkselNextLink } from "@/app/_common/components/AkselNextLink";
 import FigureConfused from "@/app/_common/components/FigureConfused";
 import { track } from "@/app/_common/umami";
@@ -8,19 +8,20 @@ function UtdanningNoPanel() {
     return (
         <Box
             padding={{ xs: "space-16", md: "space-24" }}
-            borderRadius="2"
+            borderRadius="8"
             className="bg-brand-peach-subtle"
             data-nosnippet="true"
         >
-            <HGrid gap="space-16" columns={{ xs: 1, sm: "repeat(2, minmax(0, auto))" }} align="center">
+            <HGrid gap="space-24" columns={{ xs: 1, sm: "repeat(2, minmax(0, auto))" }} align="center">
                 <div>
                     <Heading level="3" size="small" spacing>
                         Fant du ikke noe som fristet?
                     </Heading>
 
-                    <BodyShort spacing>
+                    <BodyLong>
                         Utforsk hvilke{" "}
                         <AkselNextLink
+                            inlineText
                             className="default-text-color-link"
                             onClick={() => {
                                 track(SOKERESULTAT_KLIKK_UTDANNING_NO);
@@ -30,7 +31,7 @@ function UtdanningNoPanel() {
                         >
                             jobber som passer dine interesser på utdanning.no
                         </AkselNextLink>
-                    </BodyShort>
+                    </BodyLong>
                 </div>
 
                 <HStack justify="center">


### PR DESCRIPTION
- Rundere kanter, slik som ellers på sidene
- Bytter fra BodyShort til BodyLong for litt mer luftig tekst
- Sørger for at lenke brytes inline og ikke går over en linje på mindre skjermer

<img width="785" height="374" alt="Skjermbilde 2026-05-24 kl  00 59 49" src="https://github.com/user-attachments/assets/a7b5d2c2-ddf2-4e8e-8f99-0df0e0b5930d" />
