### PR TITLE
Rydder i filter

### DIFF
--- a/src/app/stillinger/(sok)/_components/filters/DriversLicense.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/DriversLicense.tsx
@@ -29,12 +29,9 @@ export default function DriversLicense({ initialValues, updatedValues }: Drivers
         <CheckboxGroup
             value={query.getAll(QueryNames.NEED_DRIVERS_LICENSE)}
             legend={
-                <>
-                    <BodyShort as="span" visuallyHidden>
-                        Filtrer etter{" "}
-                    </BodyShort>
-                    <span className="capitalize">førerkort</span>
-                </>
+                <BodyShort as="span" visuallyHidden>
+                    Filtrer etter førerkort
+                </BodyShort>
             }
         >
             {values.map((item) => (

--- a/src/app/stillinger/(sok)/_components/filters/Engagement.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/Engagement.tsx
@@ -30,15 +30,11 @@ export default function Engagement({ initialValues, updatedValues }: EngagementP
 
     return (
         <CheckboxGroup
-            className="mt-4"
             value={query.getAll(QueryNames.ENGAGEMENT_TYPE)}
             legend={
-                <>
-                    <BodyShort as="span" visuallyHidden>
-                        Filtrer etter{" "}
-                    </BodyShort>
-                    <span className="capitalize">ansettelsesform</span>
-                </>
+                <BodyShort as="span" visuallyHidden>
+                    Filtrer etter ansettelsesform
+                </BodyShort>
             }
         >
             {values.map((item) => (

--- a/src/app/stillinger/(sok)/_components/filters/Extent.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/Extent.tsx
@@ -27,12 +27,9 @@ export default function Extent({ initialValues, updatedValues }: ExtentProps) {
         <CheckboxGroup
             value={query.getAll(QueryNames.EXTENT)}
             legend={
-                <>
-                    <BodyShort as="span" visuallyHidden>
-                        Filtrer etter{" "}
-                    </BodyShort>
-                    <span className="capitalize">omfang</span>
-                </>
+                <BodyShort as="span" visuallyHidden>
+                    Filtrer etter heltid/deltid
+                </BodyShort>
             }
         >
             {values.map((item) => (

--- a/src/app/stillinger/(sok)/_components/filters/FilterAccordionItem.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/FilterAccordionItem.tsx
@@ -17,6 +17,7 @@ export const PANEL_KEYS = [
     "needDriversLicense",
     "experience",
     "remote",
+    "sector",
 ] as const;
 
 export type PanelKey = (typeof PANEL_KEYS)[number];

--- a/src/app/stillinger/(sok)/_components/filters/FiltersDesktop.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/FiltersDesktop.tsx
@@ -51,22 +51,17 @@ export default function FiltersDesktop({
                         errors={errors}
                     />
                 </FilterAccordionItem>
-                <FilterAccordionItem title="Yrkeskategori og sektor" watchKeys={["occupationLevel1"]}>
+                <FilterAccordionItem title="Yrkeskategori" watchKeys={["occupationLevel1"]}>
                     <Occupations
                         initialValues={aggregations.occupationFirstLevels}
                         updatedValues={searchResult.aggregations.occupationFirstLevels}
                     />
-                    <Sector initialValues={aggregations.sector} updatedValues={searchResult.aggregations.sector} />
                 </FilterAccordionItem>
                 <FilterAccordionItem
-                    title="Utdanning, erfaring og førerkort"
-                    watchKeys={["education", "under18", "experience", "needDriversLicense"]}
+                    title="Utdanning og erfaring"
+                    watchKeys={["education", "under18", "experience"]}
                     openWhen="any"
                 >
-                    {/* TODO: Add Skyra survey
-                    <Alert variant="info" className="mb-6">
-                        <NewFiltersMessage />
-                    </Alert> */}
                     <Under18 initialValues={aggregations.under18} updatedValues={searchResult.aggregations.under18} />
                     <Education
                         initialValues={aggregations.education}
@@ -76,6 +71,8 @@ export default function FiltersDesktop({
                         initialValues={aggregations.experience}
                         updatedValues={searchResult.aggregations.experience}
                     />
+                </FilterAccordionItem>
+                <FilterAccordionItem title="Førerkort" watchKeys={["needDriversLicense"]}>
                     <DriversLicense
                         initialValues={aggregations.needDriversLicense}
                         updatedValues={searchResult.aggregations.needDriversLicense}
@@ -87,18 +84,19 @@ export default function FiltersDesktop({
                         updatedValues={searchResult.aggregations.workLanguage}
                     />
                 </FilterAccordionItem>
-                <FilterAccordionItem
-                    title="Omfang og ansettelsesform"
-                    watchKeys={["extent", "engagementType"]}
-                    openWhen="any"
-                >
+                <FilterAccordionItem title="Heltid/deltid" watchKeys={["extent"]}>
                     <Extent initialValues={aggregations.extent} updatedValues={searchResult.aggregations.extent} />
+                </FilterAccordionItem>
+                <FilterAccordionItem title="Ansettelsesform" watchKeys={["engagementType"]}>
                     <EngagementType
                         initialValues={aggregations.engagementTypes}
                         updatedValues={searchResult.aggregations.engagementTypes}
                     />
                 </FilterAccordionItem>
-                <FilterAccordionItem title="Mulighet for hjemmekontor" watchKeys={["remote"]}>
+                <FilterAccordionItem title="Sektor" watchKeys={["sector"]}>
+                    <Sector initialValues={aggregations.sector} updatedValues={searchResult.aggregations.sector} />
+                </FilterAccordionItem>
+                <FilterAccordionItem title="Hjemmekontor" watchKeys={["remote"]}>
                     <Remote initialValues={aggregations.remote} updatedValues={searchResult.aggregations.remote} />
                 </FilterAccordionItem>
             </Accordion>

--- a/src/app/stillinger/(sok)/_components/filters/FiltersMobile.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/FiltersMobile.tsx
@@ -87,11 +87,14 @@ const FiltersMobile = ({
                         {[
                             "Publisert",
                             "Sted",
-                            "Yrkeskategori og sektor",
-                            "Utdanning, erfaring og førerkort",
+                            "Yrkeskategori",
+                            "Utdanning og erfaring",
+                            "Førerkort",
                             "Arbeidsspråk",
-                            "Omfang og ansettelsesform",
-                            "Mulighet for hjemmekontor",
+                            "Heltid/deltid",
+                            "Ansettelsesform",
+                            "Sektor",
+                            "Hjemmekontor",
                         ].map((filter) => (
                             <button
                                 key={filter}
@@ -106,7 +109,7 @@ const FiltersMobile = ({
                         ))}
                     </nav>
                 )}
-                <div className="mt-4">
+                <div>
                     {selectedFilter === "Publisert" && (
                         <Published
                             initialValues={aggregations.published}
@@ -124,26 +127,14 @@ const FiltersMobile = ({
                         />
                     )}
 
-                    {selectedFilter === "Yrkeskategori og sektor" && (
-                        <>
-                            <div className="mb-6">
-                                <Occupations
-                                    initialValues={aggregations.occupationFirstLevels}
-                                    updatedValues={searchResult?.aggregations.occupationFirstLevels}
-                                />
-                            </div>
-                            <Sector
-                                initialValues={aggregations.sector}
-                                updatedValues={searchResult.aggregations.sector}
-                            />
-                        </>
+                    {selectedFilter === "Yrkeskategori" && (
+                        <Occupations
+                            initialValues={aggregations.occupationFirstLevels}
+                            updatedValues={searchResult?.aggregations.occupationFirstLevels}
+                        />
                     )}
-                    {selectedFilter === "Utdanning, erfaring og førerkort" && (
+                    {selectedFilter === "Utdanning og erfaring" && (
                         <>
-                            {/* TODO: Add Skyra survey
-                            <Alert variant="info" className="mb-4">
-                                <NewFiltersMessage />
-                            </Alert> */}
                             <Under18
                                 initialValues={aggregations.under18}
                                 updatedValues={searchResult.aggregations.under18}
@@ -156,11 +147,14 @@ const FiltersMobile = ({
                                 initialValues={aggregations.experience}
                                 updatedValues={searchResult.aggregations.experience}
                             />
-                            <DriversLicense
-                                initialValues={aggregations.needDriversLicense}
-                                updatedValues={searchResult.aggregations.needDriversLicense}
-                            />
                         </>
+                    )}
+
+                    {selectedFilter === "Førerkort" && (
+                        <DriversLicense
+                            initialValues={aggregations.needDriversLicense}
+                            updatedValues={searchResult.aggregations.needDriversLicense}
+                        />
                     )}
 
                     {selectedFilter === "Arbeidsspråk" && (
@@ -171,22 +165,22 @@ const FiltersMobile = ({
                         />
                     )}
 
-                    {selectedFilter === "Omfang og ansettelsesform" && (
-                        <>
-                            <div className="mb-6">
-                                <Extent
-                                    initialValues={aggregations.extent}
-                                    updatedValues={searchResult?.aggregations.extent}
-                                />
-                            </div>
-                            <EngagementType
-                                initialValues={aggregations.engagementTypes}
-                                updatedValues={searchResult?.aggregations.engagementTypes}
-                            />
-                        </>
+                    {selectedFilter === "Heltid/deltid" && (
+                        <Extent initialValues={aggregations.extent} updatedValues={searchResult?.aggregations.extent} />
                     )}
 
-                    {selectedFilter === "Mulighet for hjemmekontor" && (
+                    {selectedFilter === "Ansettelsesform" && (
+                        <EngagementType
+                            initialValues={aggregations.engagementTypes}
+                            updatedValues={searchResult?.aggregations.engagementTypes}
+                        />
+                    )}
+
+                    {selectedFilter === "Sektor" && (
+                        <Sector initialValues={aggregations.sector} updatedValues={searchResult.aggregations.sector} />
+                    )}
+
+                    {selectedFilter === "Hjemmekontor" && (
                         <Remote initialValues={aggregations.remote} updatedValues={searchResult.aggregations.remote} />
                     )}
                 </div>

--- a/src/app/stillinger/(sok)/_components/filters/Remote.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/Remote.tsx
@@ -32,7 +32,7 @@ export default function Remote({ initialValues, updatedValues }: RemoteProps) {
             value={query.getAll(QueryNames.REMOTE)}
             legend={
                 <BodyShort as="span" visuallyHidden>
-                    Filtrer etter mulighet for hjemmekontor
+                    Filtrer etter hjemmekontor
                 </BodyShort>
             }
         >

--- a/src/app/stillinger/(sok)/_components/filters/Sector.tsx
+++ b/src/app/stillinger/(sok)/_components/filters/Sector.tsx
@@ -29,15 +29,11 @@ export default function Sector({ initialValues, updatedValues }: SectorProps) {
 
     return (
         <CheckboxGroup
-            className="mt-4"
             value={query.getAll(QueryNames.SECTOR)}
             legend={
-                <>
-                    <BodyShort as="span" visuallyHidden>
-                        Filtrer etter{" "}
-                    </BodyShort>
-                    <span className="capitalize">sektor</span>
-                </>
+                <BodyShort as="span" visuallyHidden>
+                    Filtrer etter sektor
+                </BodyShort>
             }
         >
             {values.map((item) => (


### PR DESCRIPTION
Gjør filtermenyen mer lettlest og enklere å scanne:

- Deler opp `Yrkeskategori og sektor` i separate kategorier `Yrkeskategori` og `Sektor`
- Deler opp `Omfang og ansettelesform`
- Gir mer konkrete navn: `Omfang` --> `Heltid/deltid` og `Mulighet for hjemmekontor` --> `Hjemmekontor`
- Trekker `Førerkort` ut av `Utdanning og erfaing`

<img width="399" height="517" alt="Skjermbilde 2026-05-26 kl  08 46 54" src="https://github.com/user-attachments/assets/ac755604-ebe8-4c76-82c8-3e606947fc63" />

