### PR TITLE
Gjør tips panel dynamiske

### DIFF
--- a/src/app/stillinger/(sok)/_components/Search.tsx
+++ b/src/app/stillinger/(sok)/_components/Search.tsx
@@ -31,12 +31,12 @@ type SearchProps = {
 };
 
 function getTipsPanel(query: QueryActions) {
-    if (query.getAll(QueryNames.SEARCH_STRING).some((q) => q.toLowerCase() === "sommerjobb")) {
+    if (query.getAll(QueryNames.SEARCH_STRING).some((q) => q.trim().toLowerCase() === "sommerjobb")) {
         return <SummerJobPanel />;
     } else if (
-        query.getAll(QueryNames.EXPERIENCE).includes("Ingen") ||
-        query.getAll(QueryNames.EDUCATION).includes("Ingen krav") ||
-        query.getAll(QueryNames.UNDER18).includes("true")
+        query.has(QueryNames.EXPERIENCE, "Ingen") ||
+        query.has(QueryNames.EDUCATION, "Ingen krav") ||
+        query.has(QueryNames.UNDER18, "true")
     ) {
         return <UngJobPanel />;
     }

--- a/src/app/stillinger/(sok)/_components/Search.tsx
+++ b/src/app/stillinger/(sok)/_components/Search.tsx
@@ -5,8 +5,12 @@ import { useState } from "react";
 import type { SearchLocation } from "@/app/_common/geografi/locationsMapping";
 import type FilterAggregations from "@/app/stillinger/_common/types/FilterAggregations";
 import type { SearchResult as SearchResultType } from "@/app/stillinger/_common/types/SearchResult";
+import SummerJobPanel from "@/app/stillinger/(sok)/_components/howToPanels/SummerJobPanel";
+import UngJobPanel from "@/app/stillinger/(sok)/_components/howToPanels/UngJobPanel";
+import useQuery, { type QueryActions } from "@/app/stillinger/(sok)/_components/QueryProvider";
 import type { Postcode } from "@/app/stillinger/(sok)/_utils/fetchPostcodes";
 import { FETCH_SEARCH_WITHIN_DISTANCE_ERROR, type FetchError } from "@/app/stillinger/(sok)/_utils/fetchTypes";
+import { QueryNames } from "@/app/stillinger/(sok)/_utils/QueryNames";
 import Feedback from "./feedback/Feedback";
 import FiltersDesktop from "./filters/FiltersDesktop";
 import FiltersMobile from "./filters/FiltersMobile";
@@ -26,8 +30,23 @@ type SearchProps = {
     readonly errors: readonly FetchError[];
 };
 
+function getTipsPanel(query: QueryActions) {
+    if (query.getAll(QueryNames.SEARCH_STRING).some((q) => q.toLowerCase() === "sommerjobb")) {
+        return <SummerJobPanel />;
+    } else if (
+        query.getAll(QueryNames.EXPERIENCE).includes("Ingen") ||
+        query.getAll(QueryNames.EDUCATION).includes("Ingen krav") ||
+        query.getAll(QueryNames.UNDER18).includes("true")
+    ) {
+        return <UngJobPanel />;
+    }
+    return <UtdanningNoPanel />;
+}
+
 const Search = ({ searchResult, aggregations, locations, postcodes, resultsPerPage, errors }: SearchProps) => {
     const [isFiltersVisible, setIsFiltersVisible] = useState(false);
+    const query = useQuery();
+    const tipsPanel = getTipsPanel(query);
 
     const failedToSearchForPostcodes =
         errors.length > 0 && errors.some((error) => error.type === FETCH_SEARCH_WITHIN_DISTANCE_ERROR);
@@ -88,7 +107,7 @@ const Search = ({ searchResult, aggregations, locations, postcodes, resultsPerPa
                         <MaxResultsBox resultsPerPage={resultsPerPage} />
                         <SearchPagination searchResult={searchResult} resultsPerPage={resultsPerPage} />
                         <DoYouWantToSaveSearch totalAds={searchResult.totalAds} resultsPerPage={resultsPerPage} />
-                        <UtdanningNoPanel />
+                        {tipsPanel}
                         {searchResult.ads?.length > 0 && <Feedback />}
                     </VStack>
                 </HGrid>

--- a/src/app/stillinger/(sok)/_components/howToPanels/SummerJobPanel.tsx
+++ b/src/app/stillinger/(sok)/_components/howToPanels/SummerJobPanel.tsx
@@ -1,0 +1,31 @@
+import { BodyLong, Box, Heading, HStack } from "@navikt/ds-react";
+import { AkselNextLink } from "@/app/_common/components/AkselNextLink";
+import FigureHoldingFlowerAlt from "@/features/ung/ui/FigureHoldingFlowerAlt";
+
+function SummerJobPanel() {
+    return (
+        <Box padding={{ xs: "space-16", md: "space-24" }} borderRadius="8" className="bg-brand-peach-subtle">
+            <HStack gap="space-24" align="center" wrap={false}>
+                <FigureHoldingFlowerAlt />
+                <div>
+                    <Heading level="3" size="small" className="mb-1">
+                        Skal du søke sommerjobb?
+                    </Heading>
+
+                    <BodyLong>
+                        Se våre{" "}
+                        <AkselNextLink
+                            inlineText
+                            data-color="neutral"
+                            href="/ung/artikler/5-tips-til-deg-som-skal-soke-sommerjobb"
+                        >
+                            5 tips til deg som skal søke sommerjobb
+                        </AkselNextLink>
+                    </BodyLong>
+                </div>
+            </HStack>
+        </Box>
+    );
+}
+
+export default SummerJobPanel;

--- a/src/app/stillinger/(sok)/_components/howToPanels/UngJobPanel.tsx
+++ b/src/app/stillinger/(sok)/_components/howToPanels/UngJobPanel.tsx
@@ -1,0 +1,29 @@
+import { BodyLong, Box, Heading, HStack } from "@navikt/ds-react";
+import { AkselNextLink } from "@/app/_common/components/AkselNextLink";
+import FigureEnteringDoorAlt from "@/features/ung/ui/FigureEnteringDoorAlt";
+
+function UngJobPanel() {
+    return (
+        <Box padding={{ xs: "space-16", md: "space-24" }} borderRadius="8" className="bg-brand-peach-subtle">
+            <HStack gap="space-24" align="center" wrap={false}>
+                <div>
+                    <FigureEnteringDoorAlt />
+                </div>
+                <div>
+                    <Heading level="3" size="small" className="mb-1">
+                        Er du ung og vil jobbe?
+                    </Heading>
+
+                    <BodyLong>
+                        Leter du etter din første jobb?{" "}
+                        <AkselNextLink inlineText data-color="neutral" href="/ung">
+                            Her finner du tips som gjør det enklere å søke.
+                        </AkselNextLink>
+                    </BodyLong>
+                </div>
+            </HStack>
+        </Box>
+    );
+}
+
+export default UngJobPanel;


### PR DESCRIPTION
I stedet for alltid å vise det samme tips-panelet på bunn, så varierer vi hvilke tips vi gir utifra hvilke søkekriterier som er aktive

