### PR TITLE
Fikser layout-issues i mine søknader

### DIFF
--- a/src/app/superrask-soknad/mine-soknader/_components/ApplicationCard.module.css
+++ b/src/app/superrask-soknad/mine-soknader/_components/ApplicationCard.module.css
@@ -1,7 +1,0 @@
-.asLink {
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    font-weight: 600;
-}

--- a/src/app/superrask-soknad/mine-soknader/_components/ApplicationCard.tsx
+++ b/src/app/superrask-soknad/mine-soknader/_components/ApplicationCard.tsx
@@ -1,11 +1,11 @@
-import { ExternalLinkIcon, TrashIcon } from "@navikt/aksel-icons";
-import { BodyShort, Box, Button, Heading, HStack, Link, Tag } from "@navikt/ds-react";
+import { TrashIcon } from "@navikt/aksel-icons";
+import { BodyShort, Box, Button, Heading, HStack, Tag } from "@navikt/ds-react";
 import { format as formatDateFns } from "date-fns/format";
 import { nb } from "date-fns/locale";
 import NextLink from "next/link";
 import type React from "react";
+import { AkselNextLink } from "@/app/_common/components/AkselNextLink";
 import { type Application, ApplicationStatusEnum } from "@/app/superrask-soknad/mine-soknader/types";
-import styles from "./ApplicationCard.module.css";
 import { getStatusTag } from "./ApplicationStatusTag";
 
 type ApplicationCardProps = {
@@ -46,13 +46,9 @@ export default function ApplicationCard({
             </HStack>
 
             <Heading level="2" size="small" className="overflow-wrap-anywhere mb-1">
-                {canOpenDetails ? (
-                    <Link as="button" className={styles.asLink} onClick={() => onOpenDetails(application)}>
-                        {adTitle}
-                    </Link>
-                ) : (
-                    adTitle
-                )}
+                <AkselNextLink href={`/stillinger/stilling/${adId}`} target="_blank">
+                    {adTitle}
+                </AkselNextLink>
             </Heading>
             <BodyShort weight="semibold" className="mb-4">
                 {organizationName}
@@ -62,19 +58,12 @@ export default function ApplicationCard({
                 Du søkte {formatDateFns(createdAt, "EEEE d. MMMM", { locale: nb })}
             </BodyShort>
 
-            <HStack justify="space-between" gap="space-8" align="center" wrap className="mt-4">
-                <Button
-                    variant="tertiary"
-                    size="small"
-                    icon={<ExternalLinkIcon aria-hidden />}
-                    iconPosition="right"
-                    as={NextLink}
-                    prefetch={false}
-                    href={`/stillinger/stilling/${adId}`}
-                    target="_blank"
-                >
-                    Vis annonsen
-                </Button>
+            <HStack gap="space-8" align="center" wrap className="mt-4">
+                {canOpenDetails && (
+                    <Button variant="secondary" size="small" onClick={() => onOpenDetails(application)}>
+                        Vis søknad
+                    </Button>
+                )}
 
                 {canWithdraw && (
                     <Button

--- a/src/app/superrask-soknad/mine-soknader/_components/ApplicationCard.tsx
+++ b/src/app/superrask-soknad/mine-soknader/_components/ApplicationCard.tsx
@@ -46,8 +46,9 @@ export default function ApplicationCard({
             </HStack>
 
             <Heading level="2" size="small" className="overflow-wrap-anywhere mb-1">
-                <AkselNextLink href={`/stillinger/stilling/${adId}`} target="_blank">
+                <AkselNextLink href={`/stillinger/stilling/${adId}`} target="_blank" rel="noopener noreferrer">
                     {adTitle}
+                    <span className="visually-hidden"> (Åpner i ny fane)</span>
                 </AkselNextLink>
             </Heading>
             <BodyShort weight="semibold" className="mb-4">

--- a/src/app/superrask-soknad/mine-soknader/_components/ApplicationCard.tsx
+++ b/src/app/superrask-soknad/mine-soknader/_components/ApplicationCard.tsx
@@ -34,7 +34,7 @@ export default function ApplicationCard({
             aria-label={`${adTitle}, ${organizationName}`}
         >
             <HStack gap="space-4" wrap className="mb-8">
-                <Tag size="small" variant="moderate" data-color="info">
+                <Tag size="small" variant="moderate" data-color="accent">
                     Superrask søknad
                 </Tag>
                 {getStatusTag(status)}


### PR DESCRIPTION
Fikser følgende uu-issues:

- Flytter knappen "Trekk søknad" fra høyre ytterkant til venstre side sammen med de andre knappene. Slik at knappene er samlet langs venstre akse.

Bytter om på logikken bak på annonsetittel og knappen "Vis annonsen":
- Gjør om annonsetittelen (som er programmert som knapp, men ser ut som lenke) til en reel lenke. I dag åpner denne en modal med søknaden, men her bytter vi om så den blir en lenke som tar deg til annonsen i stedet.
- Gjør om knappen "Vis annonsen" (som er programmert som en lenke, men ser ut som en knapp) til en reel knapp. I stedet for at den tar deg til annonsen, så kalles den Vis søknaden og åpner modalen med søknaden