### PR TITLE
Fiks feil som gjorde at fritekst-søk med bindestrek ikke kunne fjernes

### DIFF
--- a/src/app/stillinger/(sok)/_components/searchBox/SearchCombobox.tsx
+++ b/src/app/stillinger/(sok)/_components/searchBox/SearchCombobox.tsx
@@ -126,7 +126,6 @@ function parseOption(option: string): Readonly<{
         };
     }
     return {
-        key: potentialKey,
         value: option,
     };
 }


### PR DESCRIPTION
Når fritekst-søk inneholdt en bindestrek (f.eks. "frontend-utvikler"), behandlet parseOption() delen før bindestreken som en nøkkel, selv om det ikke var en kjent QueryName.
Dette gjorde at fjerning av søketaggen ved oppdatering av siden ikke fungerte.

Nå returnerer parseOption() { value: option } når nøkkelen ikke gjenkjennes
