### PR TITLE
fix(abtest): fordelingen er ikke jevn [ARB-167]

### DIFF
--- a/src/app/_experiments/middlewareAb.ts
+++ b/src/app/_experiments/middlewareAb.ts
@@ -10,59 +10,70 @@ export type AbMiddlewareOptions = Readonly<{
     readonly pathname: string;
 }>;
 
-export function applyAbCookies(request: NextRequest, response: NextResponse, options: AbMiddlewareOptions): void {
-    const isProd = process.env.NODE_ENV === "production";
+function isEligibleForAb(options: AbMiddlewareOptions): boolean {
+    return options.hasAnalyticsConsent && !options.isRsc && options.isDocumentRequest;
+}
 
-    // Ikke sett noe uten samtykke
-    if (!options.hasAnalyticsConsent) {
-        return;
-    }
-
-    // Ikke på RSC/fetch
-    if (options.isRsc) {
-        return;
-    }
-
-    // Kun på document-like requests
-    if (!options.isDocumentRequest) {
-        return;
+/**
+ * Evaluerer hvilke AB-varianter som skal tildeles nye besøkende (uten eksisterende cookie).
+ * Må kalles FØR NextResponse.next() slik at resultatet kan injiseres i request-headers
+ * og dermed leses av server-komponenter via cookies() i samme request.
+ */
+export function buildAbAssignments(request: NextRequest, options: AbMiddlewareOptions): Map<string, string> {
+    const assignments = new Map<string, string>();
+    if (!isEligibleForAb(options)) {
+        return assignments;
     }
 
     for (const def of experimentsRuntime) {
-        // Skru av betyr: ikke sett cookie
         if (def.status !== "on") {
             continue;
         }
 
-        const isInScope =
-            !def.pathPrefixes ||
-            def.pathPrefixes.some((prefix) => {
-                return options.pathname.startsWith(prefix);
-            });
-
+        const isInScope = !def.pathPrefixes || def.pathPrefixes.some((prefix) => options.pathname.startsWith(prefix));
         if (!isInScope) {
             continue;
         }
 
-        const experimentCookieName = getExperimentCookieName(def.key);
-
-        // Sticky: hvis cookie allerede finnes, ikke rør
-        const alreadyAssigned = request.cookies.get(experimentCookieName)?.value;
-        if (alreadyAssigned) {
-            continue;
+        const cookieName = getExperimentCookieName(def.key);
+        if (request.cookies.get(cookieName)?.value) {
+            continue; // sticky: allerede tildelt
         }
 
-        // random + set cookie for alle (standard/test)
         const evaluation = evaluateExperimentRandom(def);
-        const cookieValue = evaluation.variant;
+        assignments.set(cookieName, evaluation.variant);
+    }
 
-        /**
-         * Cookie kan slettes på egen route: await fetch("/api/consent/ab", { method: "POST" });
-         * Dette gjøres ved umami onConsentChanged gjør dette for å fjerne alle AB-cookies når samtykke endres,
-         * slik at nye cookies settes på nytt ved neste request basert på oppdatert samtykke og random-evaluering.
-         * Det er ryddig og fint
-         */
-        response.cookies.set(experimentCookieName, cookieValue, {
+    return assignments;
+}
+
+/**
+ * Injiserer nye AB-tildelinger i cookie-headeren på requestHeaders slik at server-komponenter
+ * kan lese riktig variant via cookies() allerede på første request — ikke bare fra andre besøk.
+ * Kall denne FØR NextResponse.next({ request: { headers: requestHeaders } }).
+ */
+export function injectAbRequestHeaders(requestHeaders: Headers, assignments: Map<string, string>): void {
+    if (assignments.size === 0) {
+        return;
+    }
+
+    const existing = requestHeaders.get("cookie") ?? "";
+    const newParts = [...assignments.entries()].map(([name, value]) => `${name}=${value}`).join("; ");
+    requestHeaders.set("cookie", existing ? `${existing}; ${newParts}` : newParts);
+}
+
+/**
+ * Setter AB-variant-cookies i HTTP-responsen slik at nettleseren lagrer dem til neste request.
+ * Cookie kan slettes via /api/consent/ab ved samtykkeendring.
+ */
+export function applyAbResponseCookies(response: NextResponse, assignments: Map<string, string>): void {
+    if (assignments.size === 0) {
+        return;
+    }
+
+    const isProd = process.env.NODE_ENV === "production";
+    for (const [name, value] of assignments) {
+        response.cookies.set(name, value, {
             httpOnly: true,
             sameSite: "lax",
             secure: isProd,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import { getConsentValues } from "@navikt/arbeidsplassen-react";
 import { type NextRequest, NextResponse } from "next/server";
-import { applyAbCookies } from "@/app/_experiments/middlewareAb";
+import { applyAbResponseCookies, buildAbAssignments, injectAbRequestHeaders } from "@/app/_experiments/middlewareAb";
 import { QueryNames } from "@/app/stillinger/(sok)/_utils/QueryNames";
 import { CURRENT_VERSION, migrateSearchParams } from "@/app/stillinger/(sok)/_utils/versioning/searchParamsVersioning";
 
@@ -173,19 +173,24 @@ export async function proxy(request: NextRequest) {
         responseHeaders.set("X-Robots-Tag", "noindex, nofollow, noarchive");
     }
 
+    // A/B: evaluer tildelinger FØR NextResponse.next() slik at server-komponenter
+    // kan lese riktig variant via cookies() allerede på første request.
+    const abOptions = {
+        hasAnalyticsConsent: hasAnalyticsConsent(request),
+        isRsc,
+        pathname,
+        isDocumentRequest,
+    };
+    const abAssignments = buildAbAssignments(request, abOptions);
+    injectAbRequestHeaders(requestHeaders, abAssignments);
+
     const response = NextResponse.next({
         request: {
             headers: requestHeaders,
         },
     });
 
-    // A/B-cookies (kun når samtykke + ikke RSC + document-like)
-    applyAbCookies(request, response, {
-        hasAnalyticsConsent: hasAnalyticsConsent(request),
-        isRsc,
-        pathname,
-        isDocumentRequest,
-    });
+    applyAbResponseCookies(response, abAssignments);
 
     applyResponseHeaders(response, responseHeaders);
 


### PR DESCRIPTION
I AB-eksperimentet (qualifications_soek_superrask_cta) ble 1461 registrert som "test" og 1909 som "standard" over 3370 besøk, selv om fordelingen er satt til 50/50.

Prøver å sjekke variant tidligere og sette request header
- buildAbAssignments() → evaluer variant for nye besøkende (ingen cookie)
- injectAbRequestHeaders() → skriv tildelingen inn i cookie-headeren på requestHeaders FØR NextResponse.next() kalles, slik at cookies() i server-komponenter ser riktig variant allerede på første request
- applyAbResponseCookies() → sett Set-Cookie i responsen slik at

[deploy:dev]
