### PR TITLE
Oppdater  arbeidsplassen-react til siste versjon

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@fortedigital/nextjs-cache-handler": "^3.2.0",
         "@navikt/aksel-icons": "^8.10.6",
         "@navikt/arbeidsplassen-css": "^10.0.8",
-        "@navikt/arbeidsplassen-react": "^11.0.1",
+        "@navikt/arbeidsplassen-react": "^12.0.0",
         "@navikt/arbeidsplassen-theme": "^10.0.6",
         "@navikt/ds-css": "^8.11.0",
         "@navikt/ds-react": "^8.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^10.0.8
         version: 10.0.8
       '@navikt/arbeidsplassen-react':
-        specifier: ^11.0.1
-        version: 11.0.1(zod@4.4.3)
+        specifier: ^12.0.0
+        version: 12.0.0(zod@4.4.3)
       '@navikt/arbeidsplassen-theme':
         specifier: ^10.0.6
         version: 10.0.6
@@ -1064,8 +1064,8 @@ packages:
   '@navikt/arbeidsplassen-css@10.0.8':
     resolution: {integrity: sha512-ekUEFeFJg8Z/uk4U2QrktLZLfuWF/pH7Wf4gMb90wSOZ9TBjj1pJf2ZT6mTwGE1IXn9rXj8AMZmsiCjApeB3Ew==, tarball: https://npm.pkg.github.com/download/@navikt/arbeidsplassen-css/10.0.8/dbe79bcffeb85569417e1deb0005c6efeff3ece6}
 
-  '@navikt/arbeidsplassen-react@11.0.1':
-    resolution: {integrity: sha512-5JDQkaT0qDBixORcdRgcw0CktfzKdXk6vbKyKIYJPGNSTcre7+zsELRyg8Kler4ECEycKtHk3AE7RRUgQPgwkw==, tarball: https://npm.pkg.github.com/download/@navikt/arbeidsplassen-react/11.0.1/5877dbdc82cdf214d591d1c4ad7d5ed1e45650e8}
+  '@navikt/arbeidsplassen-react@12.0.0':
+    resolution: {integrity: sha512-r20OGPxEpS0uSL5NOI2LreVkG/863gyjy5YIS9mlJyiy8VUjtdBlJaSm2NUSnq33OzrCIemPMKAAT+ZzXRjJvg==, tarball: https://npm.pkg.github.com/download/@navikt/arbeidsplassen-react/12.0.0/4a47b8404a801e2588df2240807a41f15897908f}
     peerDependencies:
       zod: ^4.4.2
 
@@ -1081,6 +1081,9 @@ packages:
       '@types/react': 19.2.14
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@navikt/ds-tokens@8.11.0':
     resolution: {integrity: sha512-4vte9eN1/6h/Gnbh1Ls9kOt+jRYjNYs/uNk3CzYW/5cSDrmjKnCMhdFKQdpkfolu4ff+GCDoHc1WaJJpeYn/dQ==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tokens/8.11.0/247cb6dd6c04352aceea2df5f3ce9588f6cd5883}
@@ -4904,7 +4907,7 @@ snapshots:
 
   '@navikt/arbeidsplassen-css@10.0.8': {}
 
-  '@navikt/arbeidsplassen-react@11.0.1(zod@4.4.3)':
+  '@navikt/arbeidsplassen-react@12.0.0(zod@4.4.3)':
     dependencies:
       '@babel/polyfill': 7.12.1
       zod: 4.4.3
@@ -4919,11 +4922,12 @@ snapshots:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@navikt/aksel-icons': 8.11.0
       '@navikt/ds-tokens': 8.11.0
-      '@types/react': 19.2.14
       date-fns: 4.3.0
       react: 19.2.5
       react-day-picker: 9.14.0(react@19.2.5)
       react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@navikt/ds-tokens@8.11.0': {}
 

--- a/src/app/_common/components/NotFoundPage.tsx
+++ b/src/app/_common/components/NotFoundPage.tsx
@@ -9,11 +9,9 @@ interface NotFoundPageProps {
 }
 
 export default function NotFoundPage({ title, text }: NotFoundPageProps) {
-    /** TODO: Vi må rydde opp i typer i arbeidsplassen-react
-     * (Konvertere til ts) slik at dette blir fikset og kan fjerne className="" */
     return (
         <PageBlock as="section" width="lg" className="mt-12 mb-24">
-            <NotFound title={title} text={text} className="" />
+            <NotFound title={title} text={text} />
         </PageBlock>
     );
 }

--- a/src/app/muligheter/mulighet/[id]/_components/EmploymentDetailsMuligheter.tsx
+++ b/src/app/muligheter/mulighet/[id]/_components/EmploymentDetailsMuligheter.tsx
@@ -136,7 +136,7 @@ export default function EmploymentDetailsMuligheter({ adData }: EmploymentDetail
             </LinkCard>
 
             {adData.adTextHtml?.includes("arb-aapningstekst") && (
-                <RichText className="">{parse(adData.adTextHtml, options)}</RichText>
+                <RichText>{parse(adData.adTextHtml, options)}</RichText>
             )}
             <dl className="ad-description-list mb-8">
                 {adData.jobTitle && (

--- a/src/app/stillinger/(sok)/_components/maxQuerySizeExceeded/MaxQuerySizeExceeded.tsx
+++ b/src/app/stillinger/(sok)/_components/maxQuerySizeExceeded/MaxQuerySizeExceeded.tsx
@@ -12,7 +12,6 @@ export default function MaxQuerySizeExceeded({ goBackToSearchUrl }: MaxQuerySize
         <PageBlock width="md" gutters className=" mt-12 mb-24">
             <VStack align="center" gap="space-32">
                 <NotFound
-                    className=""
                     title="Du har nådd maks antall annonser for ditt søk"
                     text="Utvid søket ditt ved å prøve andre filtre eller søkeord for å oppdage flere annonser."
                 />

--- a/src/app/stillinger/_common/auth/components/LoginIsRequiredPage.tsx
+++ b/src/app/stillinger/_common/auth/components/LoginIsRequiredPage.tsx
@@ -7,11 +7,9 @@ type LoginIsRequiredPageProps = {
     redirect?: string;
 };
 const LoginIsRequiredPage = ({ redirect = "/stillinger" }: LoginIsRequiredPageProps) => {
-    /** TODO: Vi må rydde opp i typer i arbeidsplassen-react
-     * (Konvertere til ts) slik at dette blir fikset og kan fjerne className="" */
     return (
         <PageBlock as="section" width="md" className="mt-12 mb-12">
-            <LoginPage className="" link={`/oauth2/login?redirect=${redirect}`} />
+            <LoginPage link={`/oauth2/login?redirect=${redirect}`} />
         </PageBlock>
     );
 };

--- a/src/app/stillinger/stilling/[id]/_components/EmploymentDetails.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/EmploymentDetails.tsx
@@ -45,8 +45,6 @@ export default function EmploymentDetails({ adData }: EmploymentDetailsProps) {
      *  Fiks type casting her få på plass riktig modell
      */
 
-    /** TODO: Vi må rydde opp i typer i arbeidsplassen-react
-     * (Konvertere til ts) slik at dette blir fikset og kan fjerne className="" */
     return (
         <section className="full-width mt-8 mb-8">
             <HStack gap="space-2" justify="space-between" align="center" className="mb-4">
@@ -79,7 +77,7 @@ export default function EmploymentDetails({ adData }: EmploymentDetailsProps) {
             </HStack>
 
             {adData.adTextHtml?.includes("arb-aapningstekst") && (
-                <RichText className="">{parse(adData.adTextHtml, options)}</RichText>
+                <RichText>{parse(adData.adTextHtml, options)}</RichText>
             )}
 
             <EmploymentDetailsPanel adData={adData} />


### PR DESCRIPTION
Oppdater til siste versjon av arbeidsplassen-react som er konvertert til TS

fjern workaround for className i tidligere versjon av arbeidsplassen-react hvor denne var påkrevd i enkelte komponenter
