### PR TITLE
Fix/arb 183 stillinger blir maskert i umami

### DIFF
--- a/src/app/_common/tracking/ViewportEventTracker.test.tsx
+++ b/src/app/_common/tracking/ViewportEventTracker.test.tsx
@@ -68,7 +68,7 @@ describe("ViewportEventTracker", () => {
                 resetKey="1234asd"
                 getPayload={({ timeOnPageMs }) => {
                     return {
-                        adId: "1234asd",
+                        annonseId: "1234asd",
                         flowId: "flow-5678",
                         tidSynligMs: timeOnPageMs,
                     };
@@ -95,7 +95,7 @@ describe("ViewportEventTracker", () => {
                 getPayload={({ timeOnPageMs }) => {
                     return {
                         flowId: "flow-5678",
-                        adId: "1234asd",
+                        annonseId: "1234asd",
                         tidSynligMs: timeOnPageMs,
                     };
                 }}

--- a/src/app/_common/umami/AnalyticsInitializer.tsx
+++ b/src/app/_common/umami/AnalyticsInitializer.tsx
@@ -4,6 +4,7 @@ import { getConsentValues } from "@navikt/arbeidsplassen-react";
 import Script from "next/script";
 import { type ReactElement, useEffect, useState } from "react";
 import { useCookieBannerContext } from "@/app/_common/cookie-banner/CookieBannerContext";
+import { BEFORE_SEND_SCRIPT } from "./beforeSend";
 import { getUmamiConfig } from "./getUmamiConfig";
 
 type AnalyticsInitializerProps = Readonly<{
@@ -15,6 +16,7 @@ type AnalyticsInitializerState = Readonly<{
     scriptSrc: string | null;
     hostUrl: string | null;
     optOutFilter: string | null;
+    beforeSendFnName: string | null;
 }>;
 
 const INITIAL_STATE: AnalyticsInitializerState = {
@@ -23,6 +25,7 @@ const INITIAL_STATE: AnalyticsInitializerState = {
     scriptSrc: null,
     hostUrl: null,
     optOutFilter: null,
+    beforeSendFnName: null,
 };
 
 function readAnalyticsState(): AnalyticsInitializerState {
@@ -35,6 +38,7 @@ function readAnalyticsState(): AnalyticsInitializerState {
         scriptSrc: umamiConfig?.scriptSrc ?? null,
         hostUrl: umamiConfig?.hostUrl ?? null,
         optOutFilter: umamiConfig?.optOutFilters.join(",") ?? null,
+        beforeSendFnName: umamiConfig?.beforeSendFnName ?? null,
     };
 }
 
@@ -65,14 +69,24 @@ export default function AnalyticsInitializer({ nonce }: AnalyticsInitializerProp
     }
 
     return (
-        <Script
-            id="nav-umami"
-            src={state.scriptSrc}
-            nonce={nonce ?? undefined}
-            strategy="afterInteractive"
-            data-website-id={state.websiteId}
-            data-opt-out-filters={state.optOutFilter}
-            data-host-url={state.hostUrl}
-        />
+        <>
+            <Script
+                id="nav-before-send"
+                strategy="afterInteractive"
+                nonce={nonce ?? undefined}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+                dangerouslySetInnerHTML={{ __html: BEFORE_SEND_SCRIPT }}
+            />
+            <Script
+                id="nav-umami"
+                src={state.scriptSrc}
+                nonce={nonce ?? undefined}
+                strategy="afterInteractive"
+                data-website-id={state.websiteId}
+                data-opt-out-filters={state.optOutFilter}
+                data-host-url={state.hostUrl}
+                data-before-send={state.beforeSendFnName ?? undefined}
+            />
+        </>
     );
 }

--- a/src/app/_common/umami/AnalyticsInitializer.tsx
+++ b/src/app/_common/umami/AnalyticsInitializer.tsx
@@ -70,13 +70,9 @@ export default function AnalyticsInitializer({ nonce }: AnalyticsInitializerProp
 
     return (
         <>
-            <Script
-                id="nav-before-send"
-                strategy="afterInteractive"
-                nonce={nonce ?? undefined}
-                // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-                dangerouslySetInnerHTML={{ __html: BEFORE_SEND_SCRIPT }}
-            />
+            <Script id="nav-before-send" strategy="afterInteractive" nonce={nonce ?? undefined}>
+                {BEFORE_SEND_SCRIPT}
+            </Script>
             <Script
                 id="nav-umami"
                 src={state.scriptSrc}

--- a/src/app/_common/umami/beforeSend.test.ts
+++ b/src/app/_common/umami/beforeSend.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { BEFORE_SEND_FN_NAME, installNavBeforeSend } from "./beforeSend";
+
+type BeforeSendFn = (type: string, payload: Record<string, unknown>) => Record<string, unknown>;
+
+function getBeforeSend(): BeforeSendFn {
+    installNavBeforeSend();
+    return (window as unknown as Record<string, BeforeSendFn>)[BEFORE_SEND_FN_NAME];
+}
+
+const UUID = "217b2553-5eea-45a6-9873-87c50df7ceee";
+const REDACTED = "[uuid]";
+
+describe("navBeforeSend", () => {
+    let beforeSend: BeforeSendFn;
+
+    beforeEach(() => {
+        beforeSend = getBeforeSend();
+    });
+
+    describe("stilling-URLer", () => {
+        it("beholder UUID i /stillinger/stilling/[uuid]", () => {
+            const url = `https://arbeidsplassen.nav.no/stillinger/stilling/${UUID}`;
+            const result = beforeSend("pageview", { url });
+            expect(result.url).toBe(url);
+        });
+
+        it("beholder UUID i relativ /stillinger/stilling/[uuid]", () => {
+            const url = `/stillinger/stilling/${UUID}`;
+            const result = beforeSend("pageview", { url });
+            expect(result.url).toBe(url);
+        });
+
+        it("beholder UUID i /stillinger/trekk-soknad/[uuid]", () => {
+            const url = `https://arbeidsplassen.nav.no/stillinger/trekk-soknad/${UUID}`;
+            const result = beforeSend("pageview", { url });
+            expect(result.url).toBe(url);
+        });
+
+        it("beholder UUID i /stillinger/rapporter-annonse/[uuid]", () => {
+            const url = `https://arbeidsplassen.nav.no/stillinger/rapporter-annonse/${UUID}`;
+            const result = beforeSend("pageview", { url });
+            expect(result.url).toBe(url);
+        });
+    });
+
+    describe("andre URLer — UUID skal redakteres", () => {
+        it("redakterer UUID i /muligheter/mulighet/[uuid]", () => {
+            const url = `https://arbeidsplassen.nav.no/muligheter/mulighet/${UUID}`;
+            const result = beforeSend("pageview", { url });
+            expect(result.url).toContain(REDACTED);
+            expect(result.url).not.toContain(UUID);
+        });
+
+        it("beholder website-feltet urørt (Umami intern UUID)", () => {
+            const result = beforeSend("event", { website: UUID, url: "/stillinger" });
+            expect(result.website).toBe(UUID);
+        });
+
+        it("beholder data-feltet urørt (developer-kontrollerte analytics-data)", () => {
+            const result = beforeSend("event", {
+                url: "/stillinger",
+                data: { adid: UUID, href: `/stillinger/stilling/${UUID}` },
+            });
+            const data = result.data as Record<string, string>;
+            expect(data.adid).toBe(UUID);
+            expect(data.href).toBe(`/stillinger/stilling/${UUID}`);
+        });
+
+        it("redakterer UUID i andre felter enn url", () => {
+            const result = beforeSend("event", {
+                url: "/stillinger",
+                referrer: `https://example.com/foo/${UUID}/bar`,
+            });
+            expect(result.referrer).not.toContain(UUID);
+            expect(result.referrer).toContain(REDACTED);
+        });
+
+        it("beholder ikke-UUID-strenger urørt", () => {
+            const result = beforeSend("event", {
+                url: "/stillinger",
+                title: "Søk etter stillinger",
+            });
+            expect(result.title).toBe("Søk etter stillinger");
+        });
+    });
+
+    describe("edge cases", () => {
+        it("krasjer ikke på ugyldig URL-streng", () => {
+            expect(() => beforeSend("pageview", { url: "ikke en url %%%" })).not.toThrow();
+        });
+
+        it("redakterer UUID i nestede objekter i andre felter enn preservedKeys", () => {
+            const result = beforeSend("event", {
+                url: "/stillinger",
+                meta: { referrer: `https://example.com/${UUID}` },
+            });
+            const meta = result.meta as Record<string, string>;
+            expect(meta.referrer).not.toContain(UUID);
+        });
+
+        it("håndterer payload med arrays", () => {
+            const result = beforeSend("event", {
+                url: "/stillinger",
+                tags: [`tag-${UUID}`, "plain-tag"],
+            });
+            const tags = result.tags as string[];
+            expect(tags[0]).not.toContain(UUID);
+            expect(tags[1]).toBe("plain-tag");
+        });
+    });
+});

--- a/src/app/_common/umami/beforeSend.test.ts
+++ b/src/app/_common/umami/beforeSend.test.ts
@@ -60,10 +60,10 @@ describe("navBeforeSend", () => {
         it("beholder data-feltet urørt (developer-kontrollerte analytics-data)", () => {
             const result = beforeSend("event", {
                 url: "/stillinger",
-                data: { adid: UUID, href: `/stillinger/stilling/${UUID}` },
+                data: { annonseId: UUID, href: `/stillinger/stilling/${UUID}` },
             });
             const data = result.data as Record<string, string>;
-            expect(data.adid).toBe(UUID);
+            expect(data.annonseId).toBe(UUID);
             expect(data.href).toBe(`/stillinger/stilling/${UUID}`);
         });
 

--- a/src/app/_common/umami/beforeSend.ts
+++ b/src/app/_common/umami/beforeSend.ts
@@ -1,0 +1,68 @@
+export const BEFORE_SEND_FN_NAME = "navBeforeSend" as const;
+
+type Payload = Record<string, unknown>;
+
+/**
+ * Installerer window.navBeforeSend slik at Umami kan kalle den før hver hendelse sendes.
+ *
+ * Logikk:
+ * - Ruter der UUID er innholds-ID (stilling): behold UUID i URL-feltet
+ * - `preservedKeys` (website, data, api_key, device_id): aldri redakter
+ * - Alle andre felter og ruter: rediger UUID til [uuid]
+ *
+ * Eksportert som funksjon så logikken er testbar direkte uten eval.
+ * Serialisert til BEFORE_SEND_SCRIPT via .toString() for bruk som inline-script.
+ *
+ * Viktig: funksjonen må være selvinneholdt — ingen referanser til variabler
+ * utenfor funksjonen, siden .toString() kun serialiserer funksjonskroppen.
+ */
+export function installNavBeforeSend(): void {
+    const ALLOWED = ["/stillinger/stilling/", "/stillinger/trekk-soknad/", "/stillinger/rapporter-annonse/"];
+    // api_key, device_id, website: standard Umami-interne felt
+    // data: developer-kontrollerte custom event-data — satt eksplisitt av appen
+    const preservedKeys = new Set(["api_key", "device_id", "website", "data"]);
+    const uuidPattern = /(^|[^0-9a-f])([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})([^0-9a-f]|$)/gi;
+
+    function redact(v: unknown, key?: string): unknown {
+        if (key !== undefined && preservedKeys.has(key)) {
+            return v;
+        }
+        if (typeof v === "string") {
+            return v.replace(uuidPattern, "$1[uuid]$3");
+        }
+        if (Array.isArray(v)) {
+            return v.map((item) => redact(item));
+        }
+        if (v !== null && typeof v === "object") {
+            const result: Payload = {};
+            for (const [k, val] of Object.entries(v as Payload)) {
+                result[k] = redact(val, k);
+            }
+            return result;
+        }
+        return v;
+    }
+
+    function isAllowedUrl(url: string): boolean {
+        try {
+            const { pathname } = new URL(url, location.href);
+            return ALLOWED.some((p) => pathname.startsWith(p));
+        } catch {
+            return false;
+        }
+    }
+
+    (window as unknown as Record<string, unknown>).navBeforeSend = (_type: string, payload: Payload): Payload => {
+        const result: Payload = {};
+        for (const [k, v] of Object.entries(payload)) {
+            result[k] = preservedKeys.has(k) ? v : typeof v === "string" && isAllowedUrl(v) ? v : redact(v, k);
+        }
+        return result;
+    };
+}
+
+/**
+ * Serialisert versjon av installNavBeforeSend for bruk som inline <Script>-tag.
+ * Generert automatisk fra funksjonen over — rediger aldri denne strengen direkte.
+ */
+export const BEFORE_SEND_SCRIPT = `(${installNavBeforeSend.toString()})()`;

--- a/src/app/_common/umami/beforeSend.ts
+++ b/src/app/_common/umami/beforeSend.ts
@@ -3,21 +3,17 @@ export const BEFORE_SEND_FN_NAME = "navBeforeSend" as const;
 type Payload = Record<string, unknown>;
 
 /**
- * Installerer window.navBeforeSend slik at Umami kan kalle den før hver hendelse sendes.
+ * Setter opp window.navBeforeSend som Umami kaller før hver event sendes.
  *
- * Logikk:
- * - Ruter der UUID er innholds-ID (stilling): behold UUID i URL-feltet
- * - `preservedKeys` (website, data, api_key, device_id): aldri redakter
- * - Alle andre felter og ruter: rediger UUID til [uuid]
+ * UUIDs redigeres til [uuid] i alle felt — unntatt:
+ * - URL-feltet på stilling/trekk-soknad/rapporter-annonse (UUID er stilling-ID der)
+ * - preservedKeys: Umamiinterne felt + "data" (custom event-data vi selv setter)
  *
- * Eksportert som funksjon så logikken er testbar direkte uten eval.
- * Serialisert til BEFORE_SEND_SCRIPT via .toString() for bruk som inline-script.
- *
- * Viktig: funksjonen må være selvinneholdt — ingen referanser til variabler
- * utenfor funksjonen, siden .toString() kun serialiserer funksjonskroppen.
+ * NB: Funksjonen serialiseres med .toString() til et inline-script, så den må
+ * være selvinneholdt — ingen closures over variabler utenfor.
  */
 export function installNavBeforeSend(): void {
-    const ALLOWED = ["/stillinger/stilling/", "/stillinger/trekk-soknad/", "/stillinger/rapporter-annonse/"];
+    const ALLOWED_ROUTES = ["/stillinger/stilling/", "/stillinger/trekk-soknad/", "/stillinger/rapporter-annonse/"];
     // api_key, device_id, website: standard Umami-interne felt
     // data: developer-kontrollerte custom event-data — satt eksplisitt av appen
     const preservedKeys = new Set(["api_key", "device_id", "website", "data"]);
@@ -46,7 +42,7 @@ export function installNavBeforeSend(): void {
     function isAllowedUrl(url: string): boolean {
         try {
             const { pathname } = new URL(url, location.href);
-            return ALLOWED.some((p) => pathname.startsWith(p));
+            return ALLOWED_ROUTES.some((p) => pathname.startsWith(p));
         } catch {
             return false;
         }
@@ -62,7 +58,7 @@ export function installNavBeforeSend(): void {
 }
 
 /**
- * Serialisert versjon av installNavBeforeSend for bruk som inline <Script>-tag.
- * Generert automatisk fra funksjonen over — rediger aldri denne strengen direkte.
+ * Serialisert versjon av installNavBeforeSend — brukes som inline <Script>.
+ * Ikke rediger denne strengen direkte, endre funksjonen over.
  */
 export const BEFORE_SEND_SCRIPT = `(${installNavBeforeSend.toString()})()`;

--- a/src/app/_common/umami/events.ts
+++ b/src/app/_common/umami/events.ts
@@ -76,7 +76,7 @@ export type Events = {
     };
 
     "Klikk - Lignende annonser": {
-        adId: string;
+        annonseId: string;
         position: number;
         score: number;
         title: string;
@@ -88,7 +88,7 @@ export type Events = {
 
     "lagre favoritt": {
         title: string;
-        adId: string;
+        annonseId: string;
         harSamtykket?: boolean;
         erInnlogget?: boolean;
         plassering: FavorittPlassering;
@@ -97,7 +97,7 @@ export type Events = {
     };
     "fjern favoritt": {
         title: string;
-        adId: string;
+        annonseId: string;
         plassering: FavorittPlassering;
         index?: number;
         page?: number;
@@ -105,12 +105,12 @@ export type Events = {
 
     "logg inn for å lagre favoritt": {
         title: string;
-        adId: string;
+        annonseId: string;
         plassering: FavorittPlassering;
     };
     "avbryt lagre favoritt": {
         title: string;
-        adId: string;
+        annonseId: string;
         plassering: FavorittPlassering;
     };
     "Scrolled 80%": {
@@ -119,12 +119,12 @@ export type Events = {
     };
     "sett bunnen av annonseteksten": {
         flowId: string;
-        adId: string;
+        annonseId: string;
         tidSynligMs: number;
     };
     "tid på stilling": {
         flowId: string;
-        adId: string;
+        annonseId: string;
         tidTotalMs: number;
         tidAktivMs: number;
     };

--- a/src/app/_common/umami/getUmamiConfig.ts
+++ b/src/app/_common/umami/getUmamiConfig.ts
@@ -1,4 +1,7 @@
 "use client";
+
+import { BEFORE_SEND_FN_NAME } from "./beforeSend";
+
 /**
  * Svakhet med denne typen er at duplikater som ["uuid", "uuid"] er tillatt
  */
@@ -10,6 +13,7 @@ type UmamiConfig = Readonly<{
     scriptSrc: string;
     hostUrl: string;
     optOutFilters: OptOutFilters;
+    beforeSendFnName: string;
 }>;
 
 const DEV_INTERN_DOMAIN = "arbeidsplassen.intern.dev.nav.no";
@@ -21,6 +25,7 @@ const DEV_CONFIG: UmamiConfig = {
     scriptSrc: "https://cdn.nav.no/team-researchops/sporing/sporing-dev.js",
     hostUrl: "https://reops-event-proxy.ekstern.dev.nav.no",
     optOutFilters: ["uuid"],
+    beforeSendFnName: BEFORE_SEND_FN_NAME,
 };
 
 const PROD_CONFIG: UmamiConfig = {
@@ -28,6 +33,7 @@ const PROD_CONFIG: UmamiConfig = {
     scriptSrc: "https://cdn.nav.no/team-researchops/sporing/sporing.js",
     hostUrl: "https://reops-event-proxy.nav.no",
     optOutFilters: ["uuid"],
+    beforeSendFnName: BEFORE_SEND_FN_NAME,
 };
 
 export function getUmamiConfig(): UmamiConfig | null {

--- a/src/app/muligheter/mulighet/[id]/_components/HowToApplyMuligheter.tsx
+++ b/src/app/muligheter/mulighet/[id]/_components/HowToApplyMuligheter.tsx
@@ -32,7 +32,7 @@ export default function HowToApplyMuligheter({ adData }: PageProps) {
             const result = await meldInteresseAction(adData.id || "");
             if (result.success) {
                 track(MELD_INTERESSE_TIL_VEILEDER, {
-                    adid: adData.id || "",
+                    annonseId: adData.id || "",
                     title: adData.title || "",
                     href: `/muligheter/mulighet/${adData.id}/meld-interesse`,
                     source: "Meld interesse til veileder",

--- a/src/app/stillinger/(sok)/_components/searchResult/SearchResultItem.tsx
+++ b/src/app/stillinger/(sok)/_components/searchResult/SearchResultItem.tsx
@@ -140,7 +140,7 @@ function LinkToAd({ children, stilling, position, fromSimilaritySearch }: LinkTo
             onClick={() => {
                 if (fromSimilaritySearch) {
                     track("Klikk - Lignende annonser", {
-                        adId: stilling.uuid || "",
+                        annonseId: stilling.uuid || "",
                         position: position || -1,
                         title: stilling.title || "",
                         jobTitle: stilling.jobTitle || "",
@@ -151,7 +151,7 @@ function LinkToAd({ children, stilling, position, fromSimilaritySearch }: LinkTo
                     });
                 } else {
                     track(KLIKK_ANNONSE, {
-                        adid: stilling.uuid || "",
+                        annonseId: stilling.uuid || "",
                         title: stilling.title || "",
                         href: `/stillinger/stilling/${stilling.uuid}`,
                     });

--- a/src/app/stillinger/favoritter/_components/FavouritesButton.tsx
+++ b/src/app/stillinger/favoritter/_components/FavouritesButton.tsx
@@ -92,7 +92,7 @@ function FavouritesButton({
             title: stilling.title,
             index: index,
             page: page,
-            adId: id,
+            annonseId: id,
             harSamtykket: hasAcceptedTermsStatus === HasAcceptedTermsStatus.HAS_ACCEPTED,
             erInnlogget: authenticationStatus === AuthenticationStatus.IS_AUTHENTICATED,
             plassering: plassering,
@@ -117,7 +117,7 @@ function FavouritesButton({
     function handleDeleteFavouriteClick(): void {
         track("fjern favoritt", {
             title: stilling.title,
-            adId: id,
+            annonseId: id,
             page: page,
             index: index,
             plassering: plassering,
@@ -149,7 +149,7 @@ function FavouritesButton({
 
                         track("logg inn for å lagre favoritt", {
                             title: stilling.title,
-                            adId: id,
+                            annonseId: id,
                             plassering: plassering,
                         });
                     }}
@@ -158,7 +158,7 @@ function FavouritesButton({
 
                         track("avbryt lagre favoritt", {
                             title: stilling.title,
-                            adId: id,
+                            annonseId: id,
                             plassering: plassering,
                         });
                     }}

--- a/src/app/stillinger/stilling/[id]/_components/Ad.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/Ad.tsx
@@ -36,7 +36,7 @@ function Ad({ adData, organizationNumber, qualifications }: PageProps): ReactNod
         getPayload: ({ tidTotalMs, tidAktivMs }) => {
             return {
                 flowId,
-                adId: adData.id,
+                annonseId: adData.id,
                 tidTotalMs,
                 tidAktivMs,
             };
@@ -91,7 +91,7 @@ function Ad({ adData, organizationNumber, qualifications }: PageProps): ReactNod
                     getPayload={({ timeOnPageMs }) => {
                         return {
                             flowId,
-                            adId: adData.id,
+                            annonseId: adData.id,
                             tidSynligMs: Math.round(timeOnPageMs),
                         };
                     }}

--- a/src/app/stillinger/stilling/[id]/_components/HowToApply.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/HowToApply.tsx
@@ -49,7 +49,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                                 prefetch={false}
                                 onClick={() => {
                                     track(KONTAKTER_ARBEIDSGIVER, {
-                                        adid: adData.id || "",
+                                        annonseId: adData.id || "",
                                         title: adData.title || "",
                                         href: `/stillinger/${path}/${adData.id}/superrask-soknad`,
                                         source: "Superrask søknad",
@@ -76,7 +76,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                                     href={`mailto:${adData.application.applicationEmail}`}
                                     onClick={() => {
                                         track(KONTAKTER_ARBEIDSGIVER, {
-                                            adid: adData.id || "",
+                                            annonseId: adData.id || "",
                                             title: adData.title || "",
                                             source: "Søker via e-post",
                                         });
@@ -93,7 +93,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                                     size="xsmall"
                                     onClick={() => {
                                         track(KONTAKTER_ARBEIDSGIVER, {
-                                            adid: adData.id || "",
+                                            annonseId: adData.id || "",
                                             title: adData.title || "",
                                             source: "Kopierer e-post",
                                         });
@@ -110,7 +110,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                             href={applicationUrl}
                             onClick={() => {
                                 track(KONTAKTER_ARBEIDSGIVER, {
-                                    adid: adData.id || "",
+                                    annonseId: adData.id || "",
                                     title: adData.title || "",
                                     href: applicationUrl,
                                     source: "Ekstern søknadslenke",
@@ -151,7 +151,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                                 icon={<ExternalLinkIcon aria-hidden="true" />}
                                 onClick={() => {
                                     track(KONTAKTER_ARBEIDSGIVER, {
-                                        adid: adData.id || "",
+                                        annonseId: adData.id || "",
                                         title: adData.title || "",
                                         href: applicationUrl,
                                         source: "Ekstern søknadslenke",
@@ -173,7 +173,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                                     href={`mailto:${adData.application.applicationEmail}`}
                                     onClick={() => {
                                         track(KONTAKTER_ARBEIDSGIVER, {
-                                            adid: adData.id || "",
+                                            annonseId: adData.id || "",
                                             title: adData.title || "",
                                             source: "Søker via e-post",
                                         });
@@ -189,7 +189,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                                     size="xsmall"
                                     onClick={() => {
                                         track(KONTAKTER_ARBEIDSGIVER, {
-                                            adid: adData.id || "",
+                                            annonseId: adData.id || "",
                                             title: adData.title || "",
                                             source: "Kopierer e-post",
                                         });
@@ -208,7 +208,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                                 className="min-width text-overflow display-inline"
                                 onClick={() => {
                                     track(KONTAKTER_ARBEIDSGIVER, {
-                                        adid: adData.id || "",
+                                        annonseId: adData.id || "",
                                         title: adData.title || "",
                                         source: "Søker via e-post",
                                     });
@@ -224,7 +224,7 @@ export default function HowToApply({ adData }: PageProps): ReactNode {
                                 size="xsmall"
                                 onClick={() => {
                                     track(KONTAKTER_ARBEIDSGIVER, {
-                                        adid: adData.id || "",
+                                        annonseId: adData.id || "",
                                         title: adData.title || "",
                                         source: "Kopierer e-post",
                                     });

--- a/src/app/stillinger/stilling/[id]/_components/ShareAd.tsx
+++ b/src/app/stillinger/stilling/[id]/_components/ShareAd.tsx
@@ -28,7 +28,7 @@ export default function ShareAd({ adData }: PageProps): ReactNode {
                     icon={<FacebookIcon />}
                     onClick={() => {
                         track(DEL_ANNONSE_FACEBOOK, {
-                            adid: adData.id || "",
+                            annonseId: adData.id || "",
                             ad: shareAdRedirectUrl,
                             title: adData.title || "",
                         });
@@ -43,7 +43,7 @@ export default function ShareAd({ adData }: PageProps): ReactNode {
                     icon={<LinkedinIcon />}
                     onClick={() => {
                         track(DEL_ANNONSE_LINKEDIN, {
-                            adid: adData.id || "",
+                            annonseId: adData.id || "",
                             ad: shareAdRedirectUrl,
                             title: adData.title || "",
                         });
@@ -58,7 +58,7 @@ export default function ShareAd({ adData }: PageProps): ReactNode {
                     icon={<TwitterIcon />}
                     onClick={() => {
                         track(DEL_ANNONSE_X, {
-                            adid: adData.id || "",
+                            annonseId: adData.id || "",
                             ad: shareAdRedirectUrl,
                             title: adData.title || "",
                         });


### PR DESCRIPTION
## Hva endres?
adid maskeres i umami
det er en reservert key i systemet og vil alltid maskeres.

i vårt tilfelle inneholder ikke sider med adid sensitive data. dette er stillingsannonser.

endrer derfor alle steder vi har custom track eventer med feltet adid til annonseId.

legger også til en metode beforeSend etter andbefaling fra ResearchOps-teamet

"Global JavaScript-funksjon som kjøres før hver hendelse sendes. Bruk dette til å modifisere, berike eller filtrere hendelser."

"redakere UUID-er i hele payloaden, men la dem stå urørt for kjente trygge stier. Nyttig i kombinasjon med data-opt-out-filters="uuid" når visse sider bruker UUID-er som strukturerte nøkler (ikke som PII) og andre sider ikke gjør det."

[dokumentasjon](https://reops-docs.ansatt.dev.nav.no/innsamling/sporingsskript/#data-before-send)