### PR TITLE
Fix: use job percentage range if available else default normal percentage

### DIFF
--- a/src/app/stillinger/_common/lib/ad-model/__tests__/adDTO.contract.test.ts
+++ b/src/app/stillinger/_common/lib/ad-model/__tests__/adDTO.contract.test.ts
@@ -76,7 +76,7 @@ const cases = [
             expect(dto.positionCount).toBe(1);
             expect(dto.remoteOptions).toBe("Hjemmekontor ikke mulig");
             expect(dto.aiRemoteOptions).toBe("Ingen mulighet for hjemmekontor");
-            expect(dto.jobPercentage).toBe("35%");
+            expect(dto.jobPercentage).toBe("20% - 50%");
 
             expect(dto.workDays).toStrictEqual(["Ukedager", "Lørdag", "Søndag"]);
             expect(dto.workHours).toStrictEqual(["Dagtid", "Kveld"]);

--- a/src/app/stillinger/_common/lib/ad-model/transform/transform.ts
+++ b/src/app/stillinger/_common/lib/ad-model/transform/transform.ts
@@ -104,7 +104,7 @@ export function transformAdDataLegacy(raw: unknown): Result<z.infer<typeof AdDTO
         extent: arrayOrNull(toStringArray(properties?.extent)),
         workDays: arrayOrNull(toStringArray(properties?.workday)),
         workHours: arrayOrNull(toStringArray(properties?.workhours)),
-        jobPercentage: orNull(jobPercentage ?? jobPercentageRange),
+        jobPercentage: orNull(jobPercentageRange ?? jobPercentage),
         workLanguages: arrayOrNull(toStringArray(properties?.workLanguage)),
 
         adTextHtml: orNull(sanitizeAdText(properties?.adtext)),


### PR DESCRIPTION
## Hva endres?
Bugfiks: I en stilling vises det ikke jobb prosent intervall hvis dette er lagt til fra stillingsregistrering. Så for eksempel deltid 60% - 99%  ble vist som 80%.

## Sjekkliste
- [ ] Ingen bruk av `any` (bruk `unknown` + innsnevring der nødvendig)
- [ ] `type` brukt fremfor `interface`
- [ ] Streng typing (ingen implicit any / løse typer)
- [ ] **Leselige variabelnavn brukt** (unngå 1–2 bokstaver og kryptiske navn som `a`, `b`, `x`, `obj`, `acc`)
- [ ] **Komponentstil fulgt:** funksjonsdeklarasjon som standard; `const`-pilfunksjon kun ved `memo`, `forwardRef`, generiske komponenter eller behov for `displayName`
- [ ] Next.js-konvensjoner fulgt (App Router, `next/link`, `next/navigation`, server actions der naturlig)
- [ ] Tester (Vitest) lagt til/oppdatert (`*.test.ts(x)` ved siden av kildekoden)
- [ ] Tilgjengelighet (WCAG) vurdert der det er UI-endringer
- [ ] Jeg har lest/fulgt retningslinjene i [.github/copilot-instructions.md](./copilot-instructions.md)

## Notater for reviewer
<!-- Eventuelle avklaringer, oppfølging, TODO -->

---

💡 **Tips:**  
Bruk gjerne **Copilot Actions** → *"Generate a summary of the changes in this pull request"* for å få en detaljert, AI-generert oppsummering som supplement til din egen beskrivelse.