### PR TITLE
superrask-soknad: screeningspørsmål [ARB-199]

### DIFF
--- a/src/app/_common/umami/events.ts
+++ b/src/app/_common/umami/events.ts
@@ -170,6 +170,8 @@ export type Events = {
         selectedQualifications: number;
         totalQualifications: number;
         motivationLength: number;
+        screeningQuestionsCount: number;
+        responseFormat: "MOTIVATION_QUESTION" | "MULTIPLE_QUESTIONS";
     };
     Stillingsvisning: {
         annonseId: string;

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_api/fetchApplicationForm.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_api/fetchApplicationForm.ts
@@ -24,8 +24,12 @@ export async function fetchApplicationForm(id: string): Promise<ApplicationForm>
 
     if (!parsed.success) {
         appLogger.warn(`ApplicationForm schema mismatch for ${id}`, { issues: parsed.error.issues });
-        // Fall back til rå data — unngår hard feil for jobbsøker ved minor feltendringer
-        return json as ApplicationForm;
+        return {
+            adId: typeof json?.adId === "string" ? json.adId : id,
+            responseFormat: "MOTIVATION_QUESTION",
+            qualifications: [],
+            questions: [],
+        };
     }
 
     return parsed.data;

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_api/fetchApplicationForm.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_api/fetchApplicationForm.ts
@@ -1,5 +1,7 @@
+import { appLogger } from "@/app/_common/logging/appLogger";
 import { getDefaultHeaders } from "@/app/stillinger/_common/utils/fetch";
 import type { ApplicationForm } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
+import { ApplicationFormSchema } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
 
 export async function fetchApplicationForm(id: string): Promise<ApplicationForm> {
     const headers = await getDefaultHeaders();
@@ -17,7 +19,16 @@ export async function fetchApplicationForm(id: string): Promise<ApplicationForm>
         throw new Error(`Failed to fetch application form for ${id}: ${res.status}`);
     }
 
-    return res.json();
+    const json = await res.json();
+    const parsed = ApplicationFormSchema.safeParse(json);
+
+    if (!parsed.success) {
+        appLogger.warn(`ApplicationForm schema mismatch for ${id}`, { issues: parsed.error.issues });
+        // Fall back til rå data — unngår hard feil for jobbsøker ved minor feltendringer
+        return json as ApplicationForm;
+    }
+
+    return parsed.data;
 }
 
 export class ApplicationFormNotFoundError extends Error {

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/Form.tsx
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/Form.tsx
@@ -71,21 +71,27 @@ function Form({ ad, applicationForm, onSubmit, error, validationErrors, isPendin
     function setErrorAsFixed(fixed: keyof ValidationErrors): void {
         if (!fixedErrors.includes(fixed)) {
             setFixedErrors((prevState) => [...prevState, fixed]);
-            const { [fixed]: _, ...rest } = localSummary;
-            setLocalSummary(rest);
+            setLocalSummary((prev) => {
+                const { [fixed]: _, ...rest } = prev;
+                return rest;
+            });
         }
     }
 
     function setAnswerErrorAsFixed(questionId: string): void {
         if (!fixedAnswerErrors.includes(questionId)) {
             setFixedAnswerErrors((prevState) => [...prevState, questionId]);
-            if (localSummary.answers) {
-                const { [questionId]: _, ...restAnswers } = localSummary.answers;
-                setLocalSummary({
-                    ...localSummary,
-                    answers: Object.keys(restAnswers).length > 0 ? restAnswers : undefined,
-                });
-            }
+            setLocalSummary((prev) => {
+                if (!prev.answers) {
+                    return prev;
+                }
+                const { [questionId]: _, ...restAnswers } = prev.answers;
+                if (Object.keys(restAnswers).length === 0) {
+                    const { answers: __, ...withoutAnswers } = prev;
+                    return withoutAnswers;
+                }
+                return { ...prev, answers: restAnswers };
+            });
         }
     }
 

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/Form.tsx
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/Form.tsx
@@ -62,11 +62,11 @@ function Form({ ad, applicationForm, onSubmit, error, validationErrors, isPendin
     }, [validationErrors]);
 
     useEffect(() => {
-        if (fixedErrors.length === 0 && Object.keys(localSummary).length > 0) {
+        if (fixedErrors.length === 0 && fixedAnswerErrors.length === 0 && Object.keys(localSummary).length > 0) {
             errorSummary?.current?.focus();
         }
         // TODO: errorSummary er ref og endres ikke — men brukes i effekten for fokus
-    }, [localSummary, fixedErrors, errorSummary]);
+    }, [localSummary, fixedErrors, fixedAnswerErrors, errorSummary]);
 
     function setErrorAsFixed(fixed: keyof ValidationErrors): void {
         if (!fixedErrors.includes(fixed)) {

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/Form.tsx
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/Form.tsx
@@ -27,7 +27,9 @@ import { MOTIVATION_MAX_LENGTH } from "./validateForm";
 function flattenValidationErrors(summary: ValidationErrors): [string, string][] {
     return Object.entries(summary).flatMap(([key, value]) => {
         if (key === "answers" && typeof value === "object") {
-            return Object.entries(value as Record<string, string>) as [string, string][];
+            return Object.entries(value as Record<string, string>).map(
+                ([qId, msg]) => [`screening-${qId}`, msg] as [string, string],
+            );
         }
         return typeof value === "string" ? ([[key, value]] as [string, string][]) : [];
     });

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/Form.tsx
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/Form.tsx
@@ -19,8 +19,19 @@ import type { AdDTO } from "@/app/stillinger/_common/lib/ad-model";
 import { FormButtonBar } from "@/app/stillinger/stilling/[id]/superrask-soknad/_components/FormButtonBar";
 import LoginBanner from "@/app/stillinger/stilling/[id]/superrask-soknad/_components/LoginBanner";
 import type { ApplicationForm } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
+import { isMultipleQuestionsFormat } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
 import type { ValidationErrors } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/ValidationErrors";
+import ScreeningQuestions from "./ScreeningQuestions";
 import { MOTIVATION_MAX_LENGTH } from "./validateForm";
+
+function flattenValidationErrors(summary: ValidationErrors): [string, string][] {
+    return Object.entries(summary).flatMap(([key, value]) => {
+        if (key === "answers" && typeof value === "object") {
+            return Object.entries(value as Record<string, string>) as [string, string][];
+        }
+        return typeof value === "string" ? ([[key, value]] as [string, string][]) : [];
+    });
+}
 
 interface FormProps {
     ad: AdDTO;
@@ -36,11 +47,15 @@ function Form({ ad, applicationForm, onSubmit, error, validationErrors, isPendin
     const errorSummary = useRef<HTMLDivElement | null>(null);
     const [motivation, setMotivation] = useState("");
     const [fixedErrors, setFixedErrors] = useState<(keyof ValidationErrors)[]>([]);
+    const [fixedAnswerErrors, setFixedAnswerErrors] = useState<string[]>([]);
     const [localSummary, setLocalSummary] = useState<ValidationErrors>(validationErrors);
     const isNotLoggedIn = authenticationStatus === AuthenticationStatus.NOT_AUTHENTICATED;
 
+    const isMultipleQuestions = isMultipleQuestionsFormat(applicationForm);
+
     useEffect(() => {
         setFixedErrors([]);
+        setFixedAnswerErrors([]);
         setLocalSummary(validationErrors);
     }, [validationErrors]);
 
@@ -54,14 +69,25 @@ function Form({ ad, applicationForm, onSubmit, error, validationErrors, isPendin
     function setErrorAsFixed(fixed: keyof ValidationErrors): void {
         if (!fixedErrors.includes(fixed)) {
             setFixedErrors((prevState) => [...prevState, fixed]);
-
-            const localSummaryWithoutFixes: ValidationErrors = {
-                ...localSummary,
-            };
-            delete localSummaryWithoutFixes[fixed];
-            setLocalSummary(localSummaryWithoutFixes);
+            const { [fixed]: _, ...rest } = localSummary;
+            setLocalSummary(rest);
         }
     }
+
+    function setAnswerErrorAsFixed(questionId: string): void {
+        if (!fixedAnswerErrors.includes(questionId)) {
+            setFixedAnswerErrors((prevState) => [...prevState, questionId]);
+            if (localSummary.answers) {
+                const { [questionId]: _, ...restAnswers } = localSummary.answers;
+                setLocalSummary({
+                    ...localSummary,
+                    answers: Object.keys(restAnswers).length > 0 ? restAnswers : undefined,
+                });
+            }
+        }
+    }
+
+    const flatErrorEntries = flattenValidationErrors(localSummary);
 
     return (
         <form onSubmit={onSubmit} className="mb-16">
@@ -73,9 +99,9 @@ function Form({ ad, applicationForm, onSubmit, error, validationErrors, isPendin
                     Ingen CV eller langt søknadsbrev, kun tre raske steg. Du får beskjed på e-post med en gang bedriften
                     har vurdert søknaden din.
                 </BodyLong>
-                {Object.entries(localSummary).length > 0 && (
+                {flatErrorEntries.length > 0 && (
                     <ErrorSummary ref={errorSummary} heading="Skjemaet inneholder feil">
-                        {Object.entries(localSummary).map(([key, value]) => (
+                        {flatErrorEntries.map(([key, value]) => (
                             <ErrorSummary.Item key={key} href={`#new-application-${key}`}>
                                 {value}
                             </ErrorSummary.Item>
@@ -106,32 +132,42 @@ function Form({ ad, applicationForm, onSubmit, error, validationErrors, isPendin
                     )}
                 </section>
             )}
-            <section className="mb-10">
-                <Heading level="2" size="medium" spacing>
-                    Hvorfor du er den rette for jobben
-                </Heading>
-                <ReadMore header="Hvordan skrive en god begrunnelse?" className="mb-4">
-                    <BodyLong className="mb-4">
-                        Vis hvorfor du er et trygt valg for denne jobben. Fortell om arbeidserfaring, praksisplasser,
-                        utdanning, frivillig arbeid, verv eller annen relevant erfaring.
-                    </BodyLong>
-                    <BodyLong>
-                        Tenk gjerne litt utradisjonelt og husk at personlige egenskaper kan være avgjørende.
-                    </BodyLong>
-                </ReadMore>
-                <Textarea
-                    id="new-application-motivation"
-                    label="Skriv en begrunnelse"
-                    name="motivation"
-                    value={motivation}
-                    onChange={(e) => {
-                        setMotivation(e.target.value);
-                        setErrorAsFixed("motivation");
-                    }}
-                    maxLength={MOTIVATION_MAX_LENGTH}
-                    error={!fixedErrors.includes("motivation") && validationErrors.motivation}
+
+            {isMultipleQuestions ? (
+                <ScreeningQuestions
+                    questions={applicationForm.questions}
+                    questionAnswerErrors={localSummary.answers}
+                    onAnswerChange={(qId) => setAnswerErrorAsFixed(qId)}
                 />
-            </section>
+            ) : (
+                <section className="mb-10">
+                    <Heading level="2" size="medium" spacing>
+                        Hvorfor du er den rette for jobben
+                    </Heading>
+                    <ReadMore header="Hvordan skrive en god begrunnelse?" className="mb-4">
+                        <BodyLong className="mb-4">
+                            Vis hvorfor du er et trygt valg for denne jobben. Fortell om arbeidserfaring,
+                            praksisplasser, utdanning, frivillig arbeid, verv eller annen relevant erfaring.
+                        </BodyLong>
+                        <BodyLong>
+                            Tenk gjerne litt utradisjonelt og husk at personlige egenskaper kan være avgjørende.
+                        </BodyLong>
+                    </ReadMore>
+                    <Textarea
+                        id="new-application-motivation"
+                        label="Skriv en begrunnelse"
+                        name="motivation"
+                        value={motivation}
+                        onChange={(e) => {
+                            setMotivation(e.target.value);
+                            setErrorAsFixed("motivation");
+                        }}
+                        maxLength={MOTIVATION_MAX_LENGTH}
+                        error={!fixedErrors.includes("motivation") && validationErrors.motivation}
+                    />
+                </section>
+            )}
+
             <section className="mb-10">
                 <Heading level="2" size="medium" spacing>
                     Din kontaktinformasjon

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/NewApplication.tsx
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/NewApplication.tsx
@@ -6,6 +6,7 @@ import { track } from "@/app/_common/umami";
 import type { AdDTO } from "@/app/stillinger/_common/lib/ad-model";
 import SuccessEmailAlreadyVerified from "@/app/stillinger/stilling/[id]/superrask-soknad/_components/SuccessEmailAlreadyVerified";
 import type { ApplicationForm } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
+import { isMultipleQuestionsFormat } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
 import type { ValidationErrors } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/ValidationErrors";
 import AdDetailsHeader from "./AdDetailsHeader";
 import Form from "./Form";
@@ -32,6 +33,8 @@ export default function NewApplication({ ad, applicationForm, submitApplication 
     const [state, setState] = useState<State>({ validationErrors: {}, success: false, error: undefined });
     const [isPending, setIsPending] = useState(false);
 
+    const isMultipleQuestions = isMultipleQuestionsFormat(applicationForm);
+
     const onSubmit = async (e: FormEvent): Promise<void> => {
         e.preventDefault();
 
@@ -54,7 +57,11 @@ export default function NewApplication({ ad, applicationForm, submitApplication 
                     annonseId: ad.id,
                     selectedQualifications: formData.getAll("qualification").length,
                     totalQualifications: applicationForm.qualifications.length,
-                    motivationLength: (formData.get("motivation") as string | null)?.length ?? 0,
+                    motivationLength: isMultipleQuestions
+                        ? 0
+                        : ((formData.get("motivation") as string | null)?.length ?? 0),
+                    screeningQuestionsCount: isMultipleQuestions ? applicationForm.questions.length : 0,
+                    responseFormat: applicationForm.responseFormat,
                 });
             }
             setState(result);

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/ScreeningQuestions.tsx
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/ScreeningQuestions.tsx
@@ -1,0 +1,36 @@
+import { BodyLong, Heading, Textarea } from "@navikt/ds-react";
+import type { PublishedQuestion } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
+import { QUESTION_ANSWER_MAX_LENGTH } from "./validateForm";
+
+interface ScreeningQuestionsProps {
+    questions: PublishedQuestion[];
+    questionAnswerErrors?: Record<string, string>;
+    onAnswerChange: (questionId: string) => void;
+}
+
+function ScreeningQuestions({ questions, questionAnswerErrors, onAnswerChange }: ScreeningQuestionsProps) {
+    const sorted = [...questions].sort((a, b) => a.sortOrder - b.sortOrder);
+
+    return (
+        <section className="mb-10">
+            <Heading level="2" size="medium" spacing>
+                Spørsmål fra arbeidsgiver
+            </Heading>
+            <BodyLong className="mb-8">Svar på spørsmålene under for å søke på stillingen.</BodyLong>
+            {sorted.map((question) => (
+                <Textarea
+                    key={question.id}
+                    id={`new-application-screening-${question.id}`}
+                    name={`screening-${question.id}`}
+                    label={question.label}
+                    maxLength={QUESTION_ANSWER_MAX_LENGTH}
+                    error={questionAnswerErrors?.[question.id]}
+                    onChange={() => onAnswerChange(question.id)}
+                    className="mb-6"
+                />
+            ))}
+        </section>
+    );
+}
+
+export default ScreeningQuestions;

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/validateForm.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/validateForm.ts
@@ -10,6 +10,13 @@ import type { ValidationErrors } from "@/app/stillinger/stilling/[id]/superrask-
 export const MOTIVATION_MAX_LENGTH = 800;
 export const QUESTION_ANSWER_MAX_LENGTH = 800;
 
+function getFormString(value: FormDataEntryValue | null): string {
+    if (value === null || value instanceof File) {
+        return "";
+    }
+    return value;
+}
+
 export function parseFormData(
     formData: FormData,
     qualifications: Qualification[],
@@ -17,10 +24,10 @@ export function parseFormData(
 ): Application {
     const isMultipleQuestions = questions && questions.length > 0;
     return {
-        name: formData.get("fullName") as string,
-        telephone: formData.get("telephone") as string,
-        email: formData.get("email") as string,
-        motivation: isMultipleQuestions ? "" : ((formData.get("motivation") as string) ?? "").replace(/\r\n/g, "\n"),
+        name: getFormString(formData.get("fullName")),
+        telephone: getFormString(formData.get("telephone")),
+        email: getFormString(formData.get("email")),
+        motivation: isMultipleQuestions ? "" : getFormString(formData.get("motivation")).replace(/\r\n/g, "\n"),
         qualifications: qualifications.map((it: Qualification) => ({
             ...it,
             checked: formData.getAll("qualification").includes(it.label),
@@ -28,7 +35,7 @@ export function parseFormData(
         ...(isMultipleQuestions && {
             answers: questions.map((q) => ({
                 id: q.id,
-                text: ((formData.get(`screening-${q.id}`) as string) ?? "").replace(/\r\n/g, "\n"),
+                text: getFormString(formData.get(`screening-${q.id}`)).replace(/\r\n/g, "\n"),
             })),
         }),
     };

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/validateForm.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/validateForm.ts
@@ -20,7 +20,7 @@ export function parseFormData(
         name: formData.get("fullName") as string,
         telephone: formData.get("telephone") as string,
         email: formData.get("email") as string,
-        motivation: isMultipleQuestions ? "" : (formData.get("motivation") as string).replace(/\r\n/g, "\n"),
+        motivation: isMultipleQuestions ? "" : ((formData.get("motivation") as string) ?? "").replace(/\r\n/g, "\n"),
         qualifications: qualifications.map((it: Qualification) => ({
             ...it,
             checked: formData.getAll("qualification").includes(it.label),

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_components/validateForm.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_components/validateForm.ts
@@ -1,19 +1,36 @@
 import { isValidEmail, isValidTelephone } from "@/app/stillinger/_common/utils/utils";
-import type { Application, Qualification } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
+import type {
+    Application,
+    PublishedQuestion,
+    Qualification,
+    QuestionAnswer,
+} from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
 import type { ValidationErrors } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/ValidationErrors";
 
 export const MOTIVATION_MAX_LENGTH = 800;
+export const QUESTION_ANSWER_MAX_LENGTH = 800;
 
-export function parseFormData(formData: FormData, qualifications: Qualification[]): Application {
+export function parseFormData(
+    formData: FormData,
+    qualifications: Qualification[],
+    questions?: PublishedQuestion[],
+): Application {
+    const isMultipleQuestions = questions && questions.length > 0;
     return {
         name: formData.get("fullName") as string,
         telephone: formData.get("telephone") as string,
         email: formData.get("email") as string,
-        motivation: (formData.get("motivation") as string).replace(/\r\n/g, "\n") as string,
+        motivation: isMultipleQuestions ? "" : (formData.get("motivation") as string).replace(/\r\n/g, "\n"),
         qualifications: qualifications.map((it: Qualification) => ({
             ...it,
             checked: formData.getAll("qualification").includes(it.label),
         })),
+        ...(isMultipleQuestions && {
+            answers: questions.map((q) => ({
+                id: q.id,
+                text: ((formData.get(`screening-${q.id}`) as string) ?? "").replace(/\r\n/g, "\n"),
+            })),
+        }),
     };
 }
 
@@ -24,6 +41,18 @@ export function validateMotivationText(motivationText: string): string | undefin
         } tegn for mye i din begrunnelse. Begrunnelsen kan ikke være lengre enn ${MOTIVATION_MAX_LENGTH} tegn`;
     }
     return undefined;
+}
+
+export function validateQuestionAnswers(questionAnswers: QuestionAnswer[]): Record<string, string> | undefined {
+    const errors: Record<string, string> = {};
+    for (const qa of questionAnswers) {
+        if (!qa.text || qa.text.trim().length === 0) {
+            errors[qa.id] = "Du må svare på dette spørsmålet";
+        } else if (qa.text.length > QUESTION_ANSWER_MAX_LENGTH) {
+            errors[qa.id] = `Svaret kan ikke være lengre enn ${QUESTION_ANSWER_MAX_LENGTH} tegn`;
+        }
+    }
+    return Object.keys(errors).length > 0 ? errors : undefined;
 }
 
 export function validateEmail(email: string): string | undefined {
@@ -47,30 +76,29 @@ export function validateTelephone(telephone: string): string | undefined {
 }
 
 export default function validateForm(application: Application): ValidationErrors {
-    let errors = {};
+    let errors: ValidationErrors = {};
 
     const emailError = validateEmail(application.email);
     if (emailError) {
-        errors = {
-            ...errors,
-            email: emailError,
-        };
+        errors = { ...errors, email: emailError };
     }
 
     const telephoneError = validateTelephone(application.telephone);
     if (telephoneError) {
-        errors = {
-            ...errors,
-            telephone: telephoneError,
-        };
+        errors = { ...errors, telephone: telephoneError };
     }
 
-    const motivationError = validateMotivationText(application.motivation);
-    if (motivationError) {
-        errors = {
-            ...errors,
-            motivation: motivationError,
-        };
+    if (application.answers) {
+        const questionErrors = validateQuestionAnswers(application.answers);
+        if (questionErrors) {
+            errors = { ...errors, answers: questionErrors };
+        }
+    } else {
+        const motivationError = validateMotivationText(application.motivation);
+        if (motivationError) {
+            errors = { ...errors, motivation: motivationError };
+        }
     }
+
     return errors;
 }

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_types/Application.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_types/Application.ts
@@ -1,14 +1,20 @@
+export const RESPONSE_FORMATS = ["MOTIVATION_QUESTION", "MULTIPLE_QUESTIONS"] as const;
+export type ResponseFormat = (typeof RESPONSE_FORMATS)[number];
+
 export interface Application {
     name: string;
     telephone: string;
     email: string;
     qualifications: Qualification[];
     motivation: string;
+    answers?: QuestionAnswer[];
 }
 
 export interface ApplicationForm {
     adId: string;
+    responseFormat: ResponseFormat;
     qualifications: Qualification[];
+    questions: PublishedQuestion[];
 }
 
 export interface Qualification {
@@ -16,6 +22,21 @@ export interface Qualification {
     label: string;
 }
 
+export interface PublishedQuestion {
+    id: string;
+    label: string;
+    sortOrder: number;
+}
+
+export interface QuestionAnswer {
+    id: string;
+    text: string;
+}
+
 export interface ConfirmApplicationEmailRequest {
     token: string;
+}
+
+export function isMultipleQuestionsFormat(applicationForm: ApplicationForm): boolean {
+    return applicationForm.responseFormat === "MULTIPLE_QUESTIONS" && applicationForm.questions.length > 0;
 }

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_types/Application.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_types/Application.ts
@@ -3,18 +3,13 @@ import { z } from "zod";
 export const RESPONSE_FORMATS = ["MOTIVATION_QUESTION", "MULTIPLE_QUESTIONS"] as const;
 export type ResponseFormat = (typeof RESPONSE_FORMATS)[number];
 
-export interface Application {
-    name: string;
-    telephone: string;
-    email: string;
-    qualifications: Qualification[];
-    motivation: string;
-    answers?: QuestionAnswer[];
-}
-
 export const QualificationSchema = z.object({
     id: z.string(),
     label: z.string(),
+});
+
+export const ApplicationQualificationSchema = QualificationSchema.extend({
+    checked: z.boolean(),
 });
 
 export const PublishedQuestionSchema = z.object({
@@ -30,11 +25,22 @@ export const ApplicationFormSchema = z.object({
     questions: z.array(PublishedQuestionSchema).default([]),
 });
 
-export interface ApplicationForm extends z.infer<typeof ApplicationFormSchema> {}
-
 export interface Qualification extends z.infer<typeof QualificationSchema> {}
 
+export interface ApplicationQualification extends z.infer<typeof ApplicationQualificationSchema> {}
+
 export interface PublishedQuestion extends z.infer<typeof PublishedQuestionSchema> {}
+
+export interface ApplicationForm extends z.infer<typeof ApplicationFormSchema> {}
+
+export interface Application {
+    name: string;
+    telephone: string;
+    email: string;
+    qualifications: ApplicationQualification[];
+    motivation: string;
+    answers?: QuestionAnswer[];
+}
 
 export interface QuestionAnswer {
     id: string;
@@ -46,5 +52,9 @@ export interface ConfirmApplicationEmailRequest {
 }
 
 export function isMultipleQuestionsFormat(applicationForm: ApplicationForm): boolean {
-    return applicationForm.responseFormat === "MULTIPLE_QUESTIONS" && applicationForm.questions.length > 0;
+    return (
+        applicationForm.responseFormat === "MULTIPLE_QUESTIONS" &&
+        Array.isArray(applicationForm.questions) &&
+        applicationForm.questions.length > 0
+    );
 }

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_types/Application.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_types/Application.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export const RESPONSE_FORMATS = ["MOTIVATION_QUESTION", "MULTIPLE_QUESTIONS"] as const;
 export type ResponseFormat = (typeof RESPONSE_FORMATS)[number];
 
@@ -10,23 +12,29 @@ export interface Application {
     answers?: QuestionAnswer[];
 }
 
-export interface ApplicationForm {
-    adId: string;
-    responseFormat: ResponseFormat;
-    qualifications: Qualification[];
-    questions: PublishedQuestion[];
-}
+export const QualificationSchema = z.object({
+    id: z.string(),
+    label: z.string(),
+});
 
-export interface Qualification {
-    id: string;
-    label: string;
-}
+export const PublishedQuestionSchema = z.object({
+    id: z.string(),
+    label: z.string(),
+    sortOrder: z.number(),
+});
 
-export interface PublishedQuestion {
-    id: string;
-    label: string;
-    sortOrder: number;
-}
+export const ApplicationFormSchema = z.object({
+    adId: z.string(),
+    responseFormat: z.enum(RESPONSE_FORMATS).default("MOTIVATION_QUESTION"),
+    qualifications: z.array(QualificationSchema).default([]),
+    questions: z.array(PublishedQuestionSchema).default([]),
+});
+
+export interface ApplicationForm extends z.infer<typeof ApplicationFormSchema> {}
+
+export interface Qualification extends z.infer<typeof QualificationSchema> {}
+
+export interface PublishedQuestion extends z.infer<typeof PublishedQuestionSchema> {}
 
 export interface QuestionAnswer {
     id: string;
@@ -38,5 +46,5 @@ export interface ConfirmApplicationEmailRequest {
 }
 
 export function isMultipleQuestionsFormat(applicationForm: ApplicationForm): boolean {
-    return applicationForm.responseFormat === "MULTIPLE_QUESTIONS" && (applicationForm.questions?.length ?? 0) > 0;
+    return applicationForm.responseFormat === "MULTIPLE_QUESTIONS" && applicationForm.questions.length > 0;
 }

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_types/Application.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_types/Application.ts
@@ -38,5 +38,5 @@ export interface ConfirmApplicationEmailRequest {
 }
 
 export function isMultipleQuestionsFormat(applicationForm: ApplicationForm): boolean {
-    return applicationForm.responseFormat === "MULTIPLE_QUESTIONS" && applicationForm.questions.length > 0;
+    return applicationForm.responseFormat === "MULTIPLE_QUESTIONS" && (applicationForm.questions?.length ?? 0) > 0;
 }

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/_types/ValidationErrors.ts
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/_types/ValidationErrors.ts
@@ -2,4 +2,5 @@ export interface ValidationErrors {
     email?: string;
     telephone?: string;
     motivation?: string;
+    answers?: Record<string, string>;
 }

--- a/src/app/stillinger/stilling/[id]/superrask-soknad/page.tsx
+++ b/src/app/stillinger/stilling/[id]/superrask-soknad/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getDefaultHeaders } from "@/app/stillinger/_common/utils/fetch";
 import { getAdData } from "@/app/stillinger/stilling/_data/adDataActions";
+import { isMultipleQuestionsFormat } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/Application";
 import type { CreateApplicationResponse } from "@/app/stillinger/stilling/[id]/superrask-soknad/_types/CreateApplicationResponse";
 import { getStillingDescription, getSuperraskTitle } from "../_components/getMetaData";
 import { ApplicationFormNotFoundError, fetchApplicationForm } from ".";
@@ -24,6 +25,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
     const params = await props.params;
     const stilling = await getAdData(params.id);
     let applicationForm: Awaited<ReturnType<typeof fetchApplicationForm>>;
+
     try {
         applicationForm = await fetchApplicationForm(params.id);
     } catch (error) {
@@ -33,10 +35,16 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         throw error;
     }
 
+    const isMultipleQuestions = isMultipleQuestionsFormat(applicationForm);
+
     async function submitApplication(formData: FormData): Promise<State> {
         "use server";
         // TODO: Flytt action ut av page i en stabil serverAction fil
-        const application = parseFormData(formData, applicationForm.qualifications);
+        const application = parseFormData(
+            formData,
+            applicationForm.qualifications,
+            isMultipleQuestions ? applicationForm.questions : undefined,
+        );
         const errors = validateForm(application);
         const isValid = Object.keys(errors).length === 0;
         const defaultState = {
@@ -59,6 +67,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
             if (oboToken) {
                 headers.set("Authorization", `Bearer ${oboToken}`);
             }
+
             const response = await fetch(`${process.env.INTEREST_API_URL}/application-form/${params.id}/application`, {
                 body: JSON.stringify(application),
                 method: "POST",


### PR DESCRIPTION
 Legg til støtte for at jobbsøker kan svare på screeningspørsmål
 i superrask søknad når arbeidsgiver har valgt formatet
 MULTIPLE_QUESTIONS i stillingsregistrering.

 - Legg til ScreeningQuestions som viser sorterte Textarea-felt per spørsmål med korrekt id/name for ErrorSummary
 - Utvid ApplicationForm med responseFormat og questions fra interest-api (PublishedQuestion: id, label, sortOrder)
 - Legg til type ResponseFormat og helper isMultipleQuestionsFormat()
 - validateForm håndterer både motivation (MOTIVATION_QUESTION) og answers per spørsmål (MULTIPLE_QUESTIONS)
 - QuestionAnswer sender { id, text }
 - ValidationErrors utvidet med answers: Record<string, string>
   for spørsmål feilmeldinger
 - Umami-tracking utvidet med screeningQuestionsCount og responseFormat
