### PR TITLE
Fix: published value of valid iso string should be allowed

### DIFF
--- a/src/app/stillinger/(sok)/_utils/query.test.ts
+++ b/src/app/stillinger/(sok)/_utils/query.test.ts
@@ -98,6 +98,16 @@ describe("createQuery", () => {
         expect(query.published).toEqual("now-7d");
     });
 
+    test("Should parse published param iso string", () => {
+        const query = createQuery({ published: "2025-08-04T00:00" });
+        expect(query.published).toEqual("2025-08-04T00:00");
+    });
+
+    test("Should not parse invalid published param", () => {
+        const query = createQuery({ published: "11.11.2025" });
+        expect(query.published).toBeUndefined;
+    });
+
     test("Should ignore published param if provided value is not allowed", () => {
         const query = createQuery({ published: "0" });
         expect(query.published).toBeUndefined();

--- a/src/app/stillinger/(sok)/_utils/query.test.ts
+++ b/src/app/stillinger/(sok)/_utils/query.test.ts
@@ -105,7 +105,7 @@ describe("createQuery", () => {
 
     test("Should not parse invalid published param", () => {
         const query = createQuery({ published: "11.11.2025" });
-        expect(query.published).toBeUndefined;
+        expect(query.published).toBeUndefined();
     });
 
     test("Should ignore published param if provided value is not allowed", () => {

--- a/src/app/stillinger/(sok)/_utils/query.ts
+++ b/src/app/stillinger/(sok)/_utils/query.ts
@@ -1,3 +1,4 @@
+import { isValidISOString } from "@/app/stillinger/_common/utils/utils";
 import { PublishedLabels } from "@/app/stillinger/(sok)/_utils/publishedLabels";
 import { CURRENT_VERSION } from "@/app/stillinger/(sok)/_utils/versioning/searchParamsVersioning";
 
@@ -7,6 +8,10 @@ export const ALLOWED_NUMBER_OF_RESULTS_PER_PAGE = [SEARCH_CHUNK_SIZE, SEARCH_CHU
 export const ALLOWED_SORT_VALUES = ["relevant", "published", "expires"];
 export const ALLOWED_PUBLISHED_VALUES = Object.keys(PublishedLabels);
 export const DEFAULT_SORTING = "relevant";
+
+function isAllowedPublishedValue(publishedValue: string): boolean {
+    return ALLOWED_PUBLISHED_VALUES.includes(publishedValue) || isValidISOString(publishedValue);
+}
 
 function asArray(value: unknown) {
     if (value == null) {
@@ -86,7 +91,7 @@ export function createQuery(params: Record<string, string | string[] | undefined
         occupationSecondLevels: asArray(searchParams.occupationLevel2),
         postcode: Array.isArray(searchParams.postcode) ? searchParams.postcode[0] : searchParams.postcode,
         distance: Array.isArray(searchParams.distance) ? searchParams.distance[0] : searchParams.distance,
-        published: publishedValue && ALLOWED_PUBLISHED_VALUES.includes(publishedValue) ? publishedValue : undefined,
+        published: publishedValue && isAllowedPublishedValue(publishedValue) ? publishedValue : undefined,
         needDriversLicense: asArray(searchParams.needDriversLicense),
         under18: asArray(searchParams.under18),
         experience: asArray(searchParams.experience),

--- a/src/app/stillinger/_common/utils/utils.test.ts
+++ b/src/app/stillinger/_common/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { containsValidFnrOrDnr } from "@/app/stillinger/_common/utils/utils";
+import { containsValidFnrOrDnr, isValidISOString } from "@/app/stillinger/_common/utils/utils";
 import { isValidUrl } from "@/app/stillinger/_common/utils/utilsts";
 
 describe("isValidUrl", () => {
@@ -62,5 +62,16 @@ describe("containsValidFnrOrDnr", () => {
     it("should not contain valid id", () => {
         expect(containsValidFnrOrDnr("personal 11111111111 identification")).toBe(false);
         expect(containsValidFnrOrDnr("forgot11111111111 to use space")).toBe(false);
+    });
+});
+
+describe("isValidISOString", () => {
+    it("should be true for valid format", () => {
+        expect(isValidISOString("2025-11-11")).toBe(true);
+        expect(isValidISOString("2025-11-11T14:01:02Z")).toBe(true);
+        expect(isValidISOString("2025-08-04T00:00")).toBe(true);
+    });
+    it("should be invalid for wrong format", () => {
+        expect(isValidISOString("11.11.2025")).toBe(false);
     });
 });


### PR DESCRIPTION
## Hva endres?
Lagret søk bruker pam-stillingsok til å finne stillinger til e-post notifikasjon. Siden sanitering av `published` verdien er kun satt til verdiene som ligger i filtrene, så feiler Lagret søk som søker via en dato i `published`-feltet.
[pam-aduser - SearchService.java](https://github.com/navikt/pam-aduser/blob/c4c15590358dc66ded0dec70a5d8d204f4ebbe82/src/main/java/no/nav/pam/aduser/savedsearch/scheduler/SearchService.java#L52)

- Lagt til gyldig dato som lovlig i validering


## Sjekkliste
- [ ] Ingen bruk av `any` (bruk `unknown` + innsnevring der nødvendig)
- [ ] `type` brukt fremfor `interface`
- [ ] Streng typing (ingen implicit any / løse typer)
- [ ] **Leselige variabelnavn brukt** (unngå 1–2 bokstaver og kryptiske navn som `a`, `b`, `x`, `obj`, `acc`)
- [ ] **Komponentstil fulgt:** funksjonsdeklarasjon som standard; `const`-pilfunksjon kun ved `memo`, `forwardRef`, generiske komponenter eller behov for `displayName`
- [ ] Next.js-konvensjoner fulgt (App Router, `next/link`, `next/navigation`, server actions der naturlig)
- [ ] Tester (Vitest) lagt til/oppdatert (`*.test.ts(x)` ved siden av kildekoden)
- [ ] Tilgjengelighet (WCAG) vurdert der det er UI-endringer
- [ ] Jeg har lest/fulgt retningslinjene i [.github/copilot-instructions.md](./copilot-instructions.md)

## Notater for reviewer
<!-- Eventuelle avklaringer, oppfølging, TODO -->

---

💡 **Tips:**  
Bruk gjerne **Copilot Actions** → *"Generate a summary of the changes in this pull request"* for å få en detaljert, AI-generert oppsummering som supplement til din egen beskrivelse.